### PR TITLE
Cancel an access request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+- `cancelAccessRequest`: Cancel a pending access request.
 - `isValidConsentGrant`: Verify if a consent grant is valid (correct signature, issuer key match...).
   The verification is done at a remote endpoint, and not client-side.
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -24,6 +24,7 @@ import {
   isValidConsentGrant,
   requestAccess,
   requestAccessWithConsent,
+  cancelAccessRequest,
 } from "./index";
 
 describe("Index exports", () => {
@@ -31,5 +32,6 @@ describe("Index exports", () => {
     expect(isValidConsentGrant).toBeDefined();
     expect(requestAccess).toBeDefined();
     expect(requestAccessWithConsent).toBeDefined();
+    expect(cancelAccessRequest).toBeDefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
   RequestAccessParameters,
   requestAccessWithConsent,
   RequestAccessWithConsentParameters,
+  cancelAccessRequest,
 } from "./request/request";
 
 export { default as isValidConsentGrant } from "./verify/verify";

--- a/src/request/request.mock.ts
+++ b/src/request/request.mock.ts
@@ -26,8 +26,8 @@ import {
 } from "@inrupt/solid-client";
 import { VerifiableCredential } from "@inrupt/solid-client-vc";
 
-export const mockedCredentialId = "https://some.credential";
-export const mockedIssuanceDate = "2021-09-07T09:59:00Z";
+export const MOCKED_CREDENTIAL_ID = "https://some.credential";
+export const MOCKED_ISSUANCE_DATE = "2021-09-07T09:59:00Z";
 
 export const mockAccessGrant = (
   issuer: string,
@@ -41,11 +41,11 @@ export const mockAccessGrant = (
       ...subjectClaims,
     },
     type: ["SolidCredential", "SolidConsentRequest"],
-    id: mockedCredentialId,
-    issuanceDate: mockedIssuanceDate,
+    id: MOCKED_CREDENTIAL_ID,
+    issuanceDate: MOCKED_ISSUANCE_DATE,
     issuer,
     proof: {
-      created: mockedIssuanceDate,
+      created: MOCKED_ISSUANCE_DATE,
       proofPurpose: "assertionMethod",
       verificationMethod: "https://issuer.jwks",
       proofValue: "eyJhbGciO..E1og50tS9tH8WyXMlXyo45CA",


### PR DESCRIPTION
Cancel a pending access request. Under the hood, this simply revokes the
VC representing the access request.

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).