### PR TITLE
Temporarily disable VC type checking

### DIFF
--- a/src/manage/approve.test.ts
+++ b/src/manage/approve.test.ts
@@ -74,7 +74,8 @@ describe("approveAccessRequest", () => {
     );
   });
 
-  it("throws if the provided VC isn't a solid consent request VC", async () => {
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip("throws if the provided VC isn't a solid consent request VC", async () => {
     mockConsentEndpoint();
     await expect(
       approveAccessRequest({
@@ -326,7 +327,8 @@ describe("approveAccessRequestWithConsent", () => {
     );
   });
 
-  it("throws if the provided VC isn't a VC of type Solid Consent request", async () => {
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip("throws if the provided VC isn't a VC of type Solid Consent request", async () => {
     mockConsentEndpoint();
     await expect(
       approveAccessRequestWithConsent({

--- a/src/manage/denyAccessRequest.test.ts
+++ b/src/manage/denyAccessRequest.test.ts
@@ -65,7 +65,8 @@ describe("denyAccessRequest", () => {
     );
   });
 
-  it("throws if the provided VC isn't a Solid consent request", async () => {
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip("throws if the provided VC isn't a Solid consent request", async () => {
     mockConsentEndpoint();
     await expect(
       denyAccessRequest({

--- a/src/util/getBaseAccessVerifiableCredential.ts
+++ b/src/util/getBaseAccessVerifiableCredential.ts
@@ -22,6 +22,7 @@ import type { UrlString } from "@inrupt/solid-client";
 import type { ConsentApiBaseOptions } from "../type/ConsentApiBaseOptions";
 import type { BaseAccessBody } from "../type/AccessVerifiableCredential";
 import { getSessionFetch } from "./getSessionFetch";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { isBaseAccessVerifiableCredential } from "../guard/isBaseAccessVerifiableCredential";
 
 async function getVerifiableCredential(
@@ -48,11 +49,11 @@ export async function getBaseAccessVerifiableCredential(
     typeof vc === "string" || vc instanceof URL
       ? await getVerifiableCredential(vc, options)
       : vc;
-
-  if (!isBaseAccessVerifiableCredential(fetchedVerifiableCredential)) {
-    throw new Error(
-      `An error occured when type checking the VC, it is not a BaseAccessVerifiableCredential.`
-    );
-  }
-  return fetchedVerifiableCredential;
+  // TODO: This test is failing on legitimate VCs and should be fixed.
+  // if (!isBaseAccessVerifiableCredential(fetchedVerifiableCredential)) {
+  //   throw new Error(
+  //     `An error occured when type checking the VC, it is not a BaseAccessVerifiableCredential.`
+  //   );
+  // }
+  return fetchedVerifiableCredential as BaseAccessBody & VerifiableCredential;
 }


### PR DESCRIPTION
This temporarily disables type checking on provided VCs because the current test throws on legitimate VCs. This unblocks dependants while enabling us to investigate the issue.