### PR TITLE
Change VC type from Consent to Access

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,7 +68,7 @@ export const INRUPT_CONSENT_SERVICE_LEGACY =
 
 export const SOLID_CONSENT_SERVICE = "http://www.w3.org/ns/solid/terms#consent";
 
-export const CREDENTIAL_TYPE = "SolidConsentRequest";
+export const CREDENTIAL_TYPE = "SolidAccessRequest";
 
 export const CONSENT_STATUS = new Set([
   GC_CONSENT_STATUS_DENIED,

--- a/src/guard/isBaseAccessGrantVerifiableCredential.test.ts
+++ b/src/guard/isBaseAccessGrantVerifiableCredential.test.ts
@@ -50,7 +50,7 @@ const validAccessGrantVerifiableCredential = {
     verificationMethod:
       "https://consent.service.example.com/key/f82e5979-xxxx-xxxx-xxxx-cd9d2105d314",
   },
-  type: ["VerifiableCredential", "SolidConsentRequest"],
+  type: ["VerifiableCredential", "SolidAccessRequest"],
 };
 
 describe("isBaseAccessGrantVerifiableCredential", () => {

--- a/src/guard/isBaseAccessRequestVerifiableCredential.test.ts
+++ b/src/guard/isBaseAccessRequestVerifiableCredential.test.ts
@@ -50,7 +50,7 @@ const validAccessRequestVerifiableCredential = {
     verificationMethod:
       "https://consent.service.example.com/key/f82e5979-xxxx-xxxx-xxxx-cd9d2105d314",
   },
-  type: ["VerifiableCredential", "SolidConsentRequest"],
+  type: ["VerifiableCredential", "SolidAccessRequest"],
 };
 
 describe("isBaseAccessRequestVerifiableCredential", () => {

--- a/src/manage/approve.mock.ts
+++ b/src/manage/approve.mock.ts
@@ -65,7 +65,7 @@ export const mockAccessRequestVc = (): VerifiableCredential &
       type: "some proof type",
       verificationMethod: "some method",
     },
-    type: ["SolidConsentRequest"],
+    type: ["SolidAccessRequest"],
   };
 };
 
@@ -92,7 +92,7 @@ export const mockAccessGrantVc = (): VerifiableCredential & BaseGrantBody => {
       type: "some proof type",
       verificationMethod: "some method",
     },
-    type: ["SolidConsentRequest"],
+    type: ["SolidAccessRequest"],
   };
 };
 

--- a/src/manage/approve.test.ts
+++ b/src/manage/approve.test.ts
@@ -76,7 +76,7 @@ describe("approveAccessRequest", () => {
     await expect(
       approveAccessRequest({
         ...mockAccessRequestVc(),
-        type: ["NotASolidConsentRequest"],
+        type: ["NotASolidAccessRequest"],
       })
     ).rejects.toThrow(
       "An error occured when type checking the VC, it is not a BaseAccessVerifiableCredential."
@@ -170,7 +170,7 @@ describe("approveAccessRequest", () => {
         inbox: mockAccessRequestVc().credentialSubject.inbox,
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       }),
       expect.anything()
     );
@@ -211,7 +211,7 @@ describe("approveAccessRequest", () => {
         inbox: "https://some-custom.inbox",
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       }),
       expect.anything()
     );
@@ -249,7 +249,7 @@ describe("approveAccessRequest", () => {
         inbox: mockAccessRequestVc().credentialSubject.inbox,
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       }),
       expect.anything()
     );
@@ -287,7 +287,7 @@ describe("approveAccessRequest", () => {
         inbox: mockAccessRequestVc().credentialSubject.inbox,
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       }),
       expect.anything()
     );
@@ -326,7 +326,7 @@ describe("approveAccessRequestWithConsent", () => {
     await expect(
       approveAccessRequestWithConsent({
         ...mockConsentRequestVc(),
-        type: ["NotASolidConsentRequest"],
+        type: ["NotASolidAccessRequest"],
       })
     ).rejects.toThrow(
       "An error occured when type checking the VC, it is not a BaseAccessVerifiableCredential."
@@ -380,7 +380,7 @@ describe("approveAccessRequestWithConsent", () => {
         inbox: mockConsentGrantVc().credentialSubject.inbox,
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       }),
       expect.anything()
     );
@@ -425,7 +425,7 @@ describe("approveAccessRequestWithConsent", () => {
         inbox: "https://some-custom.inbox",
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       }),
       expect.anything()
     );
@@ -470,7 +470,7 @@ describe("approveAccessRequestWithConsent", () => {
         inbox: "https://some-custom.inbox",
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       }),
       expect.anything()
     );
@@ -512,7 +512,7 @@ describe("approveAccessRequestWithConsent", () => {
         inbox: mockConsentRequestVc().credentialSubject.inbox,
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
         expirationDate: mockConsentRequestVc().expirationDate,
         issuanceDate: new Date(2021, 8, 15).toISOString(),
       }),
@@ -555,7 +555,7 @@ describe("approveAccessRequestWithConsent", () => {
         inbox: mockConsentRequestVc().credentialSubject.inbox,
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
         issuanceDate: mockConsentRequestVc().issuanceDate,
         expirationDate: new Date(2021, 8, 16).toISOString(),
       }),
@@ -599,7 +599,7 @@ describe("approveAccessRequestWithConsent", () => {
         inbox: mockConsentRequestVc().credentialSubject.inbox,
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
         issuanceDate: mockConsentRequestVc().issuanceDate,
       }),
       expect.anything()
@@ -644,7 +644,7 @@ describe("approveAccessRequestWithConsent", () => {
         inbox: mockConsentRequestVc().credentialSubject.inbox,
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       }),
       expect.anything()
     );

--- a/src/manage/denyAccessRequest.test.ts
+++ b/src/manage/denyAccessRequest.test.ts
@@ -70,7 +70,7 @@ describe("denyAccessRequest", () => {
     await expect(
       denyAccessRequest({
         ...mockAccessRequestVc(),
-        type: ["NotASolidConsentRequest"],
+        type: ["NotASolidAccessRequest"],
       })
     ).rejects.toThrow(
       "An error occured when type checking the VC, it is not a BaseAccessVerifiableCredential."
@@ -155,7 +155,7 @@ describe("denyAccessRequest", () => {
         inbox: mockAccessRequestVc().credentialSubject.inbox,
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       }),
       expect.anything()
     );
@@ -193,7 +193,7 @@ describe("denyAccessRequest", () => {
         inbox: mockAccessRequestVc().credentialSubject.inbox,
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       }),
       expect.anything()
     );
@@ -232,7 +232,7 @@ describe("denyAccessRequest", () => {
         inbox: mockAccessRequestVc().credentialSubject.inbox,
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       }),
       expect.anything()
     );

--- a/src/request/request.mock.ts
+++ b/src/request/request.mock.ts
@@ -53,7 +53,7 @@ export const mockAccessGrant = (
       inbox: "https://some.inbox",
       ...subjectClaims,
     },
-    type: ["SolidCredential", "SolidConsentRequest"],
+    type: ["SolidCredential", "SolidAccessRequest"],
     id: MOCKED_CREDENTIAL_ID,
     issuanceDate: MOCKED_ISSUANCE_DATE,
     issuer,

--- a/src/request/request.test.ts
+++ b/src/request/request.test.ts
@@ -79,7 +79,7 @@ describe("getConsentRequestBody", () => {
         id: MOCK_REQUESTOR_IRI,
         inbox: MOCK_REQUESTOR_INBOX,
       },
-      type: ["SolidConsentRequest"],
+      type: ["SolidAccessRequest"],
     });
   });
 
@@ -121,7 +121,7 @@ describe("getConsentRequestBody", () => {
       },
       expirationDate: "1990-11-12T13:37:42.042Z",
       issuanceDate: "1955-06-08T13:37:42.042Z",
-      type: ["SolidConsentRequest"],
+      type: ["SolidAccessRequest"],
     });
   });
 });
@@ -166,7 +166,7 @@ describe("requestAccess", () => {
         },
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       }),
       expect.anything()
     );
@@ -249,7 +249,7 @@ describe("requestAccessWithConsent", () => {
         },
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
         issuanceDate: "1955-06-08T13:37:42.042Z",
         expirationDate: "1990-11-12T13:37:42.042Z",
       }),
@@ -293,7 +293,7 @@ describe("requestAccessWithConsent", () => {
         },
       }),
       expect.objectContaining({
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       }),
       expect.anything()
     );
@@ -358,7 +358,7 @@ describe("isAccessRequest", () => {
         proof: mockCredentialProof(),
         issuer: "https://some.issuer",
         issuanceDate: "some date",
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       })
     ).toBe(false);
   });
@@ -379,7 +379,7 @@ describe("isAccessRequest", () => {
         proof: mockCredentialProof(),
         issuer: "https://some.issuer",
         issuanceDate: "some date",
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       })
     ).toBe(false);
   });
@@ -400,7 +400,7 @@ describe("isAccessRequest", () => {
         proof: mockCredentialProof(),
         issuer: "https://some.issuer",
         issuanceDate: "some date",
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       })
     ).toBe(false);
   });
@@ -421,7 +421,7 @@ describe("isAccessRequest", () => {
         proof: mockCredentialProof(),
         issuer: "https://some.issuer",
         issuanceDate: "some date",
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       })
     ).toBe(false);
   });
@@ -442,12 +442,12 @@ describe("isAccessRequest", () => {
         proof: mockCredentialProof(),
         issuer: "https://some.issuer",
         issuanceDate: "some date",
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       })
     ).toBe(false);
   });
 
-  it("returns false if the credential type does not include 'SolidConsentRequest'", () => {
+  it("returns false if the credential type does not include 'SolidAccessRequest'", () => {
     expect(
       isAccessRequest({
         "@context": "https://some.context",
@@ -486,7 +486,7 @@ describe("isAccessRequest", () => {
         proof: mockCredentialProof(),
         issuer: "https://some.issuer",
         issuanceDate: "some date",
-        type: ["SolidConsentRequest"],
+        type: ["SolidAccessRequest"],
       })
     ).toBe(true);
   });

--- a/src/verify/isValidConsentGrant.test.ts
+++ b/src/verify/isValidConsentGrant.test.ts
@@ -62,7 +62,7 @@ describe("isValidConsentGrant", () => {
     ],
     id: "https://example.com/id",
     issuer: "https://example.com/issuer",
-    type: ["VerifiableCredential", "SolidCredential", "SolidConsentGrant"],
+    type: ["VerifiableCredential", "SolidCredential", "SolidAccessGrant"],
     issuanceDate: "2021-05-26T16:40:03",
     expirationDate: "2021-06-09T16:40:03",
     credentialSubject: {


### PR DESCRIPTION
This aligns the client tooling with a server-side change, moving SolidConsentRequest to SolidAccessrequest and SolidConsentGrant to SolidAccessGrant.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [ ] The changelog has been updated, if applicable. N/A
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).