### PR TITLE
Simplify package.json by specifying a dist method in the docs Makefile

### DIFF
--- a/docs/api/Makefile
+++ b/docs/api/Makefile
@@ -29,7 +29,7 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCECOPYDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 
-.PHONY: help clean Makefile migrate html
+.PHONY: help clean Makefile migrate html dist
 
 clean:
 	if [ -d $(BUILDDIR) ]; then rm -rf $(BUILDDIR) ; fi;
@@ -48,19 +48,22 @@ migrate: clean
 
 	cp -R $(SOURCEDIR)/index.rst $(SOURCECOPYDIR)
 	cp -R $(SOURCEDIR)/api/modules/ $(SOURCECOPYDIR)/modules/
-	
-html: Makefile migrate
 
+html: Makefile migrate
 # To clean up cross-reference links in markdown (foo.md#somesection) 
 # If making html (e.g. foo.html), use sed to change .md# to .html#
 # Also, on macOS, need -i '' but not for Linux
-
 ifdef IS_MAC
 	find . $(SOURCECOPYDIR) -type f -name "*.md" -exec sed -i '' -e 's?\.md#?\.html#?g' {} \;
 else
 	find . $(SOURCECOPYDIR) -type f -name "*.md" -exec sed -i  -e 's?\.md#?\.html#?g' {} \;
 endif
 	@$(SPHINXBUILD) -M $@ "$(SOURCECOPYDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -c .
+
+dist: html
+	rm -r ../dist || true
+	mkdir -p ../dist
+	cp -R $(BUILDDIR)/html/. ../dist/
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -57,7 +57,7 @@ templates_path = ['./build/docs-assets/_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = [ ]
+exclude_patterns = [ 'index.md' ]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.js",
-    "build-api-docs": "rm -rf docs/api/source/api/ && typedoc",
-    "build-docs-preview-site": "npm run build-api-docs; cd docs/api; rm source/api/index.md; make html; cd ../; rm -r dist || true; mkdir -p dist/api; cp -r api/build/html/. dist/;",
+    "build-api-docs": "typedoc",
+    "build-docs-preview-site": "npm run build-api-docs; cd docs/api; make html dist",
     "lint": "eslint --max-warnings 0 src",
     "test": "jest src",
     "e2e-test-node": "jest --config=jest.e2e.config.js e2e/node",


### PR DESCRIPTION
I was looking at the package script for building the docs site, and I realised we could simplify it if we relied instead on the Makefile for preparing the dist folder.