### PR TITLE
Prepare e2e test app

### DIFF
--- a/e2e/browser/src/package-lock.json
+++ b/e2e/browser/src/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@inrupt/prism-react-components": "^0.13.1-alpha.2",
+        "@inrupt/solid-client": "^1.18.0",
+        "@inrupt/solid-client-access-grants": "*",
         "@inrupt/solid-ui-react": "^2.7.0",
         "@material-ui/core": "^4.12.3",
         "@solid/lit-prism-patterns": "^0.13.1-alpha.2",
@@ -480,9 +482,9 @@
       }
     },
     "node_modules/@inrupt/solid-client": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.17.0.tgz",
-      "integrity": "sha512-XJMSrzlk0X+u8kMnCVIWp+k9mOtT1xqcB800WtmGQ6NJEri6ddbs8/XWNZP9n6jVN8d5PCiktpIh3+nm5jW44A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.18.0.tgz",
+      "integrity": "sha512-KHr/XesIiIWXbc973x9RI+eqjvWtKwWcX0mFHdg0nIxRpOQEvUrzhPhrZQ0s1a1t5Qq6yI6608TcZ05qA1oxqw==",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
         "@rdfjs/types": "^1.0.1",
@@ -492,6 +494,21 @@
         "http-link-header": "^1.0.2",
         "jsonld": "^5.2.0",
         "n3": "^1.10.0"
+      }
+    },
+    "node_modules/@inrupt/solid-client-access-grants": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-access-grants/-/solid-client-access-grants-0.4.1.tgz",
+      "integrity": "sha512-Vxzp7KarF/h74vVHndxOgiB1VTGj2ttie7BEQ/9UdOINMDw6+RbMFmz8f9HbOXr7w+i/NWfjuXe+/QdCf5yfsg==",
+      "dependencies": {
+        "@inrupt/solid-client": "^1.17.0",
+        "@inrupt/solid-client-authn-core": "^1.11.2",
+        "@inrupt/solid-client-vc": "^0.2.2",
+        "auth-header": "^1.0.0",
+        "cross-fetch": "^3.1.4",
+        "events": "^3.3.0",
+        "parse-link-header": "^2.0.0",
+        "rdf-namespaces": "^1.9.2"
       }
     },
     "node_modules/@inrupt/solid-client-authn-browser": {
@@ -523,6 +540,15 @@
         "events": "^3.3.0",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^8.3.1"
+      }
+    },
+    "node_modules/@inrupt/solid-client-vc": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.2.2.tgz",
+      "integrity": "sha512-1I8xQ14Mgp9QlAAPf4pWw+YEYnPH2aYaJz0YwU5SJOCOXjRfRiV6LdS9d1SMJInrzxcYchRv9wLIh9KfsEEesA==",
+      "dependencies": {
+        "@inrupt/solid-client": "^1.15.0",
+        "cross-fetch": "^3.1.4"
       }
     },
     "node_modules/@inrupt/solid-common-vocab": {
@@ -1071,6 +1097,11 @@
         "object-is": "^1.0.1",
         "util": "^0.12.0"
       }
+    },
+    "node_modules/auth-header": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/auth-header/-/auth-header-1.0.0.tgz",
+      "integrity": "sha512-CPPazq09YVDUNNVWo4oSPTQmtwIzHusZhQmahCKvIsk0/xH6U3QsMAv3sM+7+Q0B1K2KJ/Q38OND317uXs4NHA=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -3239,6 +3270,14 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "node_modules/parse-link-header": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
+      "dependencies": {
+        "xtend": "~4.0.1"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -3455,6 +3494,11 @@
       "dependencies": {
         "@rdfjs/types": "*"
       }
+    },
+    "node_modules/rdf-namespaces": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/rdf-namespaces/-/rdf-namespaces-1.9.2.tgz",
+      "integrity": "sha512-Gf/sZLUo758fDLnqZs0laG0IbOm06yq1fVrCnFhOEcGyTKt9hh7lcs+7L0DAQquacwARqfsJIOcJDsfdZRU/Wg=="
     },
     "node_modules/react": {
       "version": "16.14.0",
@@ -4429,9 +4473,9 @@
       }
     },
     "@inrupt/solid-client": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.17.0.tgz",
-      "integrity": "sha512-XJMSrzlk0X+u8kMnCVIWp+k9mOtT1xqcB800WtmGQ6NJEri6ddbs8/XWNZP9n6jVN8d5PCiktpIh3+nm5jW44A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.18.0.tgz",
+      "integrity": "sha512-KHr/XesIiIWXbc973x9RI+eqjvWtKwWcX0mFHdg0nIxRpOQEvUrzhPhrZQ0s1a1t5Qq6yI6608TcZ05qA1oxqw==",
       "requires": {
         "@rdfjs/dataset": "^1.1.0",
         "@rdfjs/types": "^1.0.1",
@@ -4441,6 +4485,21 @@
         "http-link-header": "^1.0.2",
         "jsonld": "^5.2.0",
         "n3": "^1.10.0"
+      }
+    },
+    "@inrupt/solid-client-access-grants": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-access-grants/-/solid-client-access-grants-0.4.1.tgz",
+      "integrity": "sha512-Vxzp7KarF/h74vVHndxOgiB1VTGj2ttie7BEQ/9UdOINMDw6+RbMFmz8f9HbOXr7w+i/NWfjuXe+/QdCf5yfsg==",
+      "requires": {
+        "@inrupt/solid-client": "^1.17.0",
+        "@inrupt/solid-client-authn-core": "^1.11.2",
+        "@inrupt/solid-client-vc": "^0.2.2",
+        "auth-header": "^1.0.0",
+        "cross-fetch": "^3.1.4",
+        "events": "^3.3.0",
+        "parse-link-header": "^2.0.0",
+        "rdf-namespaces": "^1.9.2"
       }
     },
     "@inrupt/solid-client-authn-browser": {
@@ -4472,6 +4531,15 @@
         "events": "^3.3.0",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^8.3.1"
+      }
+    },
+    "@inrupt/solid-client-vc": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.2.2.tgz",
+      "integrity": "sha512-1I8xQ14Mgp9QlAAPf4pWw+YEYnPH2aYaJz0YwU5SJOCOXjRfRiV6LdS9d1SMJInrzxcYchRv9wLIh9KfsEEesA==",
+      "requires": {
+        "@inrupt/solid-client": "^1.15.0",
+        "cross-fetch": "^3.1.4"
       }
     },
     "@inrupt/solid-common-vocab": {
@@ -4825,6 +4893,11 @@
         "object-is": "^1.0.1",
         "util": "^0.12.0"
       }
+    },
+    "auth-header": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/auth-header/-/auth-header-1.0.0.tgz",
+      "integrity": "sha512-CPPazq09YVDUNNVWo4oSPTQmtwIzHusZhQmahCKvIsk0/xH6U3QsMAv3sM+7+Q0B1K2KJ/Q38OND317uXs4NHA=="
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -6470,6 +6543,14 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "parse-link-header": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
+      "requires": {
+        "xtend": "~4.0.1"
+      }
+    },
     "path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -6643,6 +6724,11 @@
       "requires": {
         "@rdfjs/types": "*"
       }
+    },
+    "rdf-namespaces": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/rdf-namespaces/-/rdf-namespaces-1.9.2.tgz",
+      "integrity": "sha512-Gf/sZLUo758fDLnqZs0laG0IbOm06yq1fVrCnFhOEcGyTKt9hh7lcs+7L0DAQquacwARqfsJIOcJDsfdZRU/Wg=="
     },
     "react": {
       "version": "16.14.0",

--- a/e2e/browser/src/package.json
+++ b/e2e/browser/src/package.json
@@ -17,6 +17,8 @@
   },
   "dependencies": {
     "@inrupt/prism-react-components": "^0.13.1-alpha.2",
+    "@inrupt/solid-client": "^1.18.0",
+    "@inrupt/solid-client-access-grants": "*",
     "@inrupt/solid-ui-react": "^2.7.0",
     "@material-ui/core": "^4.12.3",
     "@solid/lit-prism-patterns": "^0.13.1-alpha.2",

--- a/e2e/browser/src/pages/index.jsx
+++ b/e2e/browser/src/pages/index.jsx
@@ -20,14 +20,125 @@
  */
 
 import { useSession } from "@inrupt/solid-ui-react";
+import { useEffect, useState } from "react";
+import {
+  approveAccessRequest,
+  revokeAccessGrant,
+} from "@inrupt/solid-client-access-grants";
+import {
+  getPodUrlAll,
+  saveFileInContainer,
+  getSourceUrl,
+  deleteFile,
+} from "@inrupt/solid-client";
+
+// This is the content of the file uploaded manually at SHARED_FILE_IRI.
+const SHARED_FILE_CONTENT = "Some content.\n";
 
 export default function Home() {
   const { session } = useSession();
+  const [accessGrant, setAccessGrant] = useState(undefined);
+  const [sharedResourceIri, setSharedResourceIri] = useState(undefined);
+
+  const handleCreate = (e) => {
+    // This prevents the default behaviour of the button, i.e. to resubmit, which reloads the page.
+    e.preventDefault();
+    if (typeof sharedResourceIri === "string") {
+      // If a resource already exist, do nothing
+      return;
+    }
+    (async () => {
+      // Create a file in the resource owner's Pod
+      const resourceOwnerPodAll = await getPodUrlAll(session.info.webId);
+      if (resourceOwnerPodAll.length === 0) {
+        throw new Error(
+          "The Resource Owner WebID Profile is missing a link to at least one Pod root."
+        );
+      }
+      const savedFile = await saveFileInContainer(
+        resourceOwnerPodAll[0],
+        Buffer.from(SHARED_FILE_CONTENT),
+        {
+          // The session ID is a random string, used here as a unique slug.
+          slug: `${session.info.sessionId}.txt`,
+          fetch: session.fetch,
+        }
+      );
+      setSharedResourceIri(getSourceUrl(savedFile));
+    })();
+  };
+
+  const handleDelete = (e) => {
+    // This prevents the default behaviour of the button, i.e. to resubmit, which reloads the page.
+    e.preventDefault();
+    (async () => {
+      await deleteFile(sharedResourceIri, {
+        fetch: session.fetch,
+      });
+      setSharedResourceIri(undefined);
+    })();
+  };
+
+  const handleGrant = (e) => {
+    // This prevents the default behaviour of the button, i.e. to resubmit, which reloads the page.
+    e.preventDefault();
+    if (typeof sharedResourceIri !== "string") {
+      // If the resource does not exist, do nothing.
+      return;
+    }
+    (async () => {
+      const accessGrant = await approveAccessRequest(
+        session.info.webId,
+        undefined,
+        {
+          requestor: "https://johndoe.webid",
+          access: { read: true },
+          resources: [sharedResourceIri],
+        },
+        {
+          fetch: session.fetch,
+        }
+      );
+      setAccessGrant(JSON.stringify(accessGrant, null, "  "));
+    })();
+  };
+
+  const handleRevoke = (e) => {
+    // This prevents the default behaviour of the button, i.e. to resubmit, which reloads the page.
+    e.preventDefault();
+    if (typeof accessGrant !== "string") {
+      // If the resource does not exist, do nothing.
+      return;
+    }
+    (async () => {
+      await revokeAccessGrant(JSON.parse(accessGrant), {
+        fetch: session.fetch,
+      });
+      setAccessGrant(undefined);
+    })();
+  };
 
   return (
     <div>
-      <h1>Demo</h1>
+      <h1>
+        <code>@inrupt/solid-client-access-grants</code> test browser app
+      </h1>
       {session.info.isLoggedIn && <p>Logged in as: {session.info.webId}</p>}
+      <div>
+        <button onClick={(e) => handleCreate(e)}>Create resource</button>
+        <button onClick={(e) => handleDelete(e)}>Delete resource</button>
+      </div>
+      <p>
+        Created resource:{" "}
+        <span data-testid="resource-iri">{sharedResourceIri}</span>
+      </p>
+      <div>
+        <button onClick={(e) => handleGrant(e)}>Grant access</button>
+        <button onClick={(e) => handleRevoke(e)}>Revoke access</button>
+      </div>
+      <p>
+        Granted access: <pre data-testid="access-grant">{accessGrant}</pre>
+      </p>
     </div>
   );
 }

--- a/src/fetch/index.test.ts
+++ b/src/fetch/index.test.ts
@@ -91,7 +91,7 @@ describe("parseUMAAuthTicket", () => {
 
     const ticket = parseUMAAuthTicket(header);
 
-    expect(ticket).toEqual("some_value");
+    expect(ticket).toBe("some_value");
   });
 
   it("returns null if no value is found", () => {
@@ -108,7 +108,7 @@ describe("parseUMAAuthIri", () => {
       'UMA realm="test" as_uri="https://fake.url" ticket="some_value"';
 
     const ticket = parseUMAAuthIri(header);
-    expect(ticket).toEqual("https://fake.url");
+    expect(ticket).toBe("https://fake.url");
   });
 
   it("returns null if no value is found", () => {
@@ -162,7 +162,7 @@ describe("exchangeTicketForAccessToken", () => {
       mockedFetch
     );
 
-    expect(token).toEqual("some_access_token");
+    expect(token).toBe("some_access_token");
     expect(mockedFetch).toHaveBeenCalledWith(tokenEndpoint, {
       method: "POST",
       headers: {


### PR DESCRIPTION
This prepares the e2e test app for playwright tests. The app displays a couple of buttons to log in, create a resource, grant access to it, revoke the grant and delete the resource. This should make playwright tests fairly straightforward, just clicking around for setup, testing displayed values and teardown.

One thing I'm unsure about is the linking from the test app to the local code in `solid-client-access-grants`. I assume setting up the end-to-end tests would require to systematically run `npm link` in CI, does that sound correct @ThisIsMissEm ?