### PR TITLE
Deprecate passing the VC subject in the access flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The following changes have been implemented but not released yet:
 
 - The JSON-LD context URL has changed from https://vc.inrupt.com/credentials/v1 to https://vc.inrupt.com/credentials/v1.
 
+### Deprecation
+
+- `approveAccessRequest` and `denyAccessRequest` no longer requires the `resourceOwner` parameter.
+- `issueAccessRequest` options no longer include the `requestor` field.
+
 ## [0.4.1](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v0.4.1) - 2022-01-28
 
 ### Bugfixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@inrupt/solid-client": "^1.18.0",
         "@inrupt/solid-client-authn-core": "^1.11.2",
-        "@inrupt/solid-client-vc": "^0.2.2",
+        "@inrupt/solid-client-vc": "^0.3.1",
         "auth-header": "^1.0.0",
         "cross-fetch": "^3.1.4",
         "events": "^3.3.0",
@@ -2022,9 +2022,9 @@
       }
     },
     "node_modules/@inrupt/solid-client-vc": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.2.2.tgz",
-      "integrity": "sha512-1I8xQ14Mgp9QlAAPf4pWw+YEYnPH2aYaJz0YwU5SJOCOXjRfRiV6LdS9d1SMJInrzxcYchRv9wLIh9KfsEEesA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.3.1.tgz",
+      "integrity": "sha512-L2TpFFI20pIVzaTXupQarvCAEfhZHyU2Lm9Y837qqCUdz5Lr4ufT6drAjNGG/LGxPHyvmpuUW7MPiDgIERZ1QA==",
       "dependencies": {
         "@inrupt/solid-client": "^1.15.0",
         "cross-fetch": "^3.1.4"
@@ -16306,9 +16306,9 @@
       }
     },
     "@inrupt/solid-client-vc": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.2.2.tgz",
-      "integrity": "sha512-1I8xQ14Mgp9QlAAPf4pWw+YEYnPH2aYaJz0YwU5SJOCOXjRfRiV6LdS9d1SMJInrzxcYchRv9wLIh9KfsEEesA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.3.1.tgz",
+      "integrity": "sha512-L2TpFFI20pIVzaTXupQarvCAEfhZHyU2Lm9Y837qqCUdz5Lr4ufT6drAjNGG/LGxPHyvmpuUW7MPiDgIERZ1QA==",
       "requires": {
         "@inrupt/solid-client": "^1.15.0",
         "cross-fetch": "^3.1.4"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   "dependencies": {
     "@inrupt/solid-client": "^1.18.0",
     "@inrupt/solid-client-authn-core": "^1.11.2",
-    "@inrupt/solid-client-vc": "^0.2.2",
+    "@inrupt/solid-client-vc": "^0.3.1",
     "auth-header": "^1.0.0",
     "cross-fetch": "^3.1.4",
     "events": "^3.3.0",

--- a/src/guard/isBaseAccessGrantVerifiableCredential.ts
+++ b/src/guard/isBaseAccessGrantVerifiableCredential.ts
@@ -22,13 +22,19 @@
 import {
   BaseGrantBody,
   GrantCredentialSubject,
+  GrantCredentialSubjectPayload,
   RequestCredentialSubject,
+  RequestCredentialSubjectPayload,
 } from "../type/AccessVerifiableCredential";
 import { isConsentAttributes } from "./isConsentAttributes";
 import { isBaseAccessVcBody } from "./isBaseAccessVcBody";
 
 function isGrantCredentialSubject(
-  x: RequestCredentialSubject | GrantCredentialSubject
+  x:
+    | RequestCredentialSubject
+    | GrantCredentialSubject
+    | GrantCredentialSubjectPayload
+    | RequestCredentialSubjectPayload
 ): x is GrantCredentialSubject {
   return (x as GrantCredentialSubject).providedConsent !== undefined;
 }

--- a/src/guard/isBaseAccessRequestVerifiableCredential.ts
+++ b/src/guard/isBaseAccessRequestVerifiableCredential.ts
@@ -22,13 +22,19 @@
 import {
   BaseRequestBody,
   GrantCredentialSubject,
+  GrantCredentialSubjectPayload,
   RequestCredentialSubject,
+  RequestCredentialSubjectPayload,
 } from "../type/AccessVerifiableCredential";
 import { isConsentAttributes } from "./isConsentAttributes";
 import { isBaseAccessVcBody } from "./isBaseAccessVcBody";
 
 function isRequestCredentialSubject(
-  x: RequestCredentialSubject | GrantCredentialSubject
+  x:
+    | RequestCredentialSubject
+    | GrantCredentialSubject
+    | GrantCredentialSubjectPayload
+    | RequestCredentialSubjectPayload
 ): x is RequestCredentialSubject {
   return (x as RequestCredentialSubject).hasConsent !== undefined;
 }

--- a/src/manage/approveAccessRequest.test.ts
+++ b/src/manage/approveAccessRequest.test.ts
@@ -36,8 +36,6 @@ import {
   mockConsentRequestVc,
 } from "./approveAccessRequest.mock";
 
-const MOCK_RESOURCE_OWNER = "https://some.resource/owner";
-
 jest.mock("@inrupt/solid-client", () => {
   // TypeScript can't infer the type of modules imported via Jest;
   // skip type checking for those:
@@ -105,10 +103,9 @@ describe("approveAccessRequest", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const scab = jest.requireMock("@inrupt/solid-client-authn-browser") as any;
 
-    await approveAccessRequest(MOCK_RESOURCE_OWNER, mockAccessRequestVc());
+    await approveAccessRequest(mockAccessRequestVc());
 
     expect(mockedIssue).toHaveBeenCalledWith(
-      expect.anything(),
       expect.anything(),
       expect.anything(),
       expect.anything(),
@@ -138,7 +135,6 @@ describe("approveAccessRequest", () => {
     const spiedAcrSave = jest.spyOn(mockedClientModule.acp_v4, "saveAcrFor");
 
     await approveAccessRequest(
-      MOCK_RESOURCE_OWNER,
       mockAccessRequestVc({
         modes: [
           "http://www.w3.org/ns/auth/acl#Write",
@@ -174,9 +170,7 @@ describe("approveAccessRequest", () => {
   it("throws if the resource's ACR cannot be accessed by the current user", async () => {
     mockAcpClient({ hasAccessibleAcr: false });
     mockAccessApiEndpoint();
-    await expect(
-      approveAccessRequest(MOCK_RESOURCE_OWNER, mockAccessRequestVc())
-    ).rejects.toThrow(
+    await expect(approveAccessRequest(mockAccessRequestVc())).rejects.toThrow(
       "The current user does not have access to the resource's Access Control Resource"
     );
   });
@@ -184,7 +178,7 @@ describe("approveAccessRequest", () => {
   it("throws if the provided VC isn't a solid access request VC", async () => {
     mockAccessApiEndpoint();
     await expect(
-      approveAccessRequest(MOCK_RESOURCE_OWNER, {
+      approveAccessRequest({
         ...mockAccessRequestVc(),
         type: ["NotASolidAccessRequest"],
       })
@@ -197,7 +191,7 @@ describe("approveAccessRequest", () => {
     mockAccessApiEndpoint();
     const accessRequest = mockAccessRequestVc();
     await expect(
-      approveAccessRequest(MOCK_RESOURCE_OWNER, {
+      approveAccessRequest({
         ...accessRequest,
         credentialSubject: {
           ...accessRequest.credentialSubject,
@@ -219,18 +213,12 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    await approveAccessRequest(
-      MOCK_RESOURCE_OWNER,
-      mockAccessRequestVc(),
-      undefined,
-      {
-        accessEndpoint: "https://some.consent-endpoint.override/",
-        fetch: jest.fn(),
-      }
-    );
+    await approveAccessRequest(mockAccessRequestVc(), undefined, {
+      accessEndpoint: "https://some.consent-endpoint.override/",
+      fetch: jest.fn(),
+    });
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       "https://some.consent-endpoint.override/issue",
-      expect.anything(),
       expect.anything(),
       expect.anything(),
       expect.anything()
@@ -248,16 +236,10 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    await approveAccessRequest(
-      MOCK_RESOURCE_OWNER,
-      mockAccessRequestVc(),
-      undefined,
-      {
-        fetch: mockedFetch,
-      }
-    );
+    await approveAccessRequest(mockAccessRequestVc(), undefined, {
+      fetch: mockedFetch,
+    });
     expect(spiedIssueRequest).toHaveBeenCalledWith(
-      expect.anything(),
       expect.anything(),
       expect.anything(),
       expect.anything(),
@@ -275,18 +257,12 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    await approveAccessRequest(
-      MOCK_RESOURCE_OWNER,
-      mockAccessRequestVc(),
-      undefined,
-      {
-        fetch: jest.fn(global.fetch),
-      }
-    );
+    await approveAccessRequest(mockAccessRequestVc(), undefined, {
+      fetch: jest.fn(global.fetch),
+    });
 
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      MOCK_RESOURCE_OWNER,
       expect.objectContaining({
         providedConsent: {
           mode: mockAccessRequestVc().credentialSubject.hasConsent.mode,
@@ -319,18 +295,12 @@ describe("approveAccessRequest", () => {
       .mockResolvedValueOnce(
         new Response(JSON.stringify(mockConsentRequestVc()))
       );
-    await approveAccessRequest(
-      MOCK_RESOURCE_OWNER,
-      "https://some.credential",
-      undefined,
-      {
-        fetch: mockedFetch,
-      }
-    );
+    await approveAccessRequest("https://some.credential", undefined, {
+      fetch: mockedFetch,
+    });
 
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      MOCK_RESOURCE_OWNER,
       expect.objectContaining({
         providedConsent: {
           mode: mockConsentRequestVc().credentialSubject.hasConsent.mode,
@@ -360,18 +330,12 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    await approveAccessRequest(
-      MOCK_RESOURCE_OWNER,
-      mockConsentRequestVc(),
-      undefined,
-      {
-        fetch: jest.fn(global.fetch),
-      }
-    );
+    await approveAccessRequest(mockConsentRequestVc(), undefined, {
+      fetch: jest.fn(global.fetch),
+    });
 
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      MOCK_RESOURCE_OWNER,
       expect.objectContaining({
         providedConsent: {
           mode: mockConsentGrantVc().credentialSubject.providedConsent.mode,
@@ -403,7 +367,6 @@ describe("approveAccessRequest", () => {
       "issueVerifiableCredential"
     );
     await approveAccessRequest(
-      MOCK_RESOURCE_OWNER,
       mockConsentRequestVc(),
       {
         resources: ["https://some-custom.resource"],
@@ -416,7 +379,6 @@ describe("approveAccessRequest", () => {
 
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      MOCK_RESOURCE_OWNER,
       expect.objectContaining({
         providedConsent: {
           mode: mockConsentRequestVc().credentialSubject.hasConsent.mode,
@@ -445,7 +407,6 @@ describe("approveAccessRequest", () => {
       "issueVerifiableCredential"
     );
     await approveAccessRequest(
-      MOCK_RESOURCE_OWNER,
       mockConsentRequestVc(),
       {
         access: { append: true },
@@ -463,7 +424,6 @@ describe("approveAccessRequest", () => {
 
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      MOCK_RESOURCE_OWNER,
       expect.objectContaining({
         providedConsent: {
           mode: ["http://www.w3.org/ns/auth/acl#Append"],
@@ -492,7 +452,6 @@ describe("approveAccessRequest", () => {
       "issueVerifiableCredential"
     );
     await approveAccessRequest(
-      MOCK_RESOURCE_OWNER,
       undefined,
       {
         access: { append: true },
@@ -510,7 +469,6 @@ describe("approveAccessRequest", () => {
 
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      MOCK_RESOURCE_OWNER,
       expect.objectContaining({
         providedConsent: {
           mode: ["http://www.w3.org/ns/auth/acl#Append"],
@@ -539,7 +497,6 @@ describe("approveAccessRequest", () => {
       "issueVerifiableCredential"
     );
     await approveAccessRequest(
-      MOCK_RESOURCE_OWNER,
       mockConsentRequestVc(),
       {
         issuanceDate: new Date(2021, 8, 15),
@@ -551,7 +508,6 @@ describe("approveAccessRequest", () => {
 
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      MOCK_RESOURCE_OWNER,
       expect.objectContaining({
         providedConsent: {
           mode: mockConsentGrantVc().credentialSubject.providedConsent.mode,
@@ -585,7 +541,6 @@ describe("approveAccessRequest", () => {
       "issueVerifiableCredential"
     );
     await approveAccessRequest(
-      MOCK_RESOURCE_OWNER,
       mockConsentRequestVc(),
       {
         expirationDate: new Date(2021, 8, 16),
@@ -597,7 +552,6 @@ describe("approveAccessRequest", () => {
 
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      MOCK_RESOURCE_OWNER,
       expect.objectContaining({
         providedConsent: {
           mode: mockConsentRequestVc().credentialSubject.hasConsent.mode,
@@ -630,7 +584,6 @@ describe("approveAccessRequest", () => {
       "issueVerifiableCredential"
     );
     await approveAccessRequest(
-      MOCK_RESOURCE_OWNER,
       {
         ...mockConsentRequestVc(),
         expirationDate: undefined,
@@ -643,7 +596,6 @@ describe("approveAccessRequest", () => {
 
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      MOCK_RESOURCE_OWNER,
       expect.objectContaining({
         providedConsent: {
           mode: mockConsentRequestVc().credentialSubject.hasConsent.mode,

--- a/src/manage/approveAccessRequest.ts
+++ b/src/manage/approveAccessRequest.ts
@@ -161,16 +161,7 @@ export async function approveAccessRequest(
   requestOverride?: Partial<ApproveAccessRequestOverrides>,
   options?: AccessBaseOptions
 ): Promise<VerifiableCredential>;
-/**
- * @deprecated Please remove the `resourceOwner` parameter.
- */
-export async function approveAccessRequest(
-  resourceOwner: WebId,
-  // If the VC is specified, all the overrides become optional
-  requestVc: VerifiableCredential | URL | UrlString,
-  requestOverride?: Partial<ApproveAccessRequestOverrides>,
-  options?: AccessBaseOptions
-): Promise<VerifiableCredential>;
+
 /**
  * Approve an access request. The content of the approved access request is provided
  * as a set of claims, and no input Verifiable Credential is expected.
@@ -187,8 +178,22 @@ export async function approveAccessRequest(
   requestOverride: ApproveAccessRequestOverrides,
   options?: AccessBaseOptions
 ): Promise<VerifiableCredential>;
+
 /**
  * @deprecated Please remove the `resourceOwner` parameter.
+ * @hidden
+ */
+export async function approveAccessRequest(
+  resourceOwner: WebId,
+  // If the VC is specified, all the overrides become optional
+  requestVc: VerifiableCredential | URL | UrlString,
+  requestOverride?: Partial<ApproveAccessRequestOverrides>,
+  options?: AccessBaseOptions
+): Promise<VerifiableCredential>;
+
+/**
+ * @deprecated Please remove the `resourceOwner` parameter.
+ * @hidden
  */
 export async function approveAccessRequest(
   resourceOwner: WebId,

--- a/src/manage/approveAccessRequest.ts
+++ b/src/manage/approveAccessRequest.ts
@@ -85,43 +85,24 @@ async function addVcMatcher(
   );
 }
 
-/**
- * Approve an access request. The content of the approved access request is provided
- * as a Verifiable Credential which properties may be overriden if necessary.
- *
- * @param requestVc The Verifiable Credential representing the Access Request. If
- * not conform to an Access Request, the function will throw.
- * @param requestOverride Elements overriding information from the provided Verifiable Credential.
- * @param options Optional properties to customise the access grant behaviour.
- * @returns A Verifiable Credential representing the granted access.
- * @since 0.0.1.
- */
-export async function approveAccessRequest(
-  resourceOwner: WebId,
+// The following may be removed and merged back in `approveAccessRequest` once
+// the deprecated signature is removed.
+// eslint-disable-next-line camelcase
+async function internal_approveAccessRequest(
   // If the VC is specified, all the overrides become optional
   requestVc: VerifiableCredential | URL | UrlString,
   requestOverride?: Partial<ApproveAccessRequestOverrides>,
   options?: AccessBaseOptions
 ): Promise<VerifiableCredential>;
-/**
- * Approve an access request. The content of the approved access request is provided
- * as a set of claims, and no input Verifiable Credential is expected.
- *
- * @param requestVc A Verifiable Credential that would represent the Access Request if provided.
- * @param requestOverride Claims constructing the Access Grant.
- * @param options Optional properties to customise the access grant behaviour.
- * @returns A Verifiable Credential representing the granted access.
- * @since 0.0.1.
- */
-export async function approveAccessRequest(
-  resourceOwner: WebId,
+// eslint-disable-next-line camelcase
+async function internal_approveAccessRequest(
   requestVc: undefined,
   // If the VC is undefined, then some of the overrides become mandatory
   requestOverride: ApproveAccessRequestOverrides,
   options?: AccessBaseOptions
 ): Promise<VerifiableCredential>;
-export async function approveAccessRequest(
-  resourceOwner: WebId,
+// eslint-disable-next-line camelcase
+async function internal_approveAccessRequest(
   requestVc?: VerifiableCredential | URL | UrlString,
   requestOverride?: Partial<ApproveAccessRequestOverrides>,
   options: AccessBaseOptions = {}
@@ -143,7 +124,6 @@ export async function approveAccessRequest(
   );
 
   const grantBody = getGrantBody({
-    resourceOwner,
     access: internalOptions.access,
     requestor: internalOptions.requestor,
     resources: internalOptions.resources,
@@ -161,7 +141,92 @@ export async function approveAccessRequest(
     options
   );
 
-  return issueAccessVc(resourceOwner, grantBody, options);
+  return issueAccessVc(grantBody, options);
+}
+
+/**
+ * Approve an access request. The content of the approved access request is provided
+ * as a Verifiable Credential which properties may be overriden if necessary.
+ *
+ * @param requestVc The Verifiable Credential representing the Access Request. If
+ * not conform to an Access Request, the function will throw.
+ * @param requestOverride Elements overriding information from the provided Verifiable Credential.
+ * @param options Optional properties to customise the access grant behaviour.
+ * @returns A Verifiable Credential representing the granted access.
+ * @since 0.0.1.
+ */
+export async function approveAccessRequest(
+  // If the VC is specified, all the overrides become optional
+  requestVc: VerifiableCredential | URL | UrlString,
+  requestOverride?: Partial<ApproveAccessRequestOverrides>,
+  options?: AccessBaseOptions
+): Promise<VerifiableCredential>;
+/**
+ * @deprecated Please remove the `resourceOwner` parameter.
+ */
+export async function approveAccessRequest(
+  resourceOwner: WebId,
+  // If the VC is specified, all the overrides become optional
+  requestVc: VerifiableCredential | URL | UrlString,
+  requestOverride?: Partial<ApproveAccessRequestOverrides>,
+  options?: AccessBaseOptions
+): Promise<VerifiableCredential>;
+/**
+ * Approve an access request. The content of the approved access request is provided
+ * as a set of claims, and no input Verifiable Credential is expected.
+ *
+ * @param requestVc A Verifiable Credential that would represent the Access Request if provided.
+ * @param requestOverride Claims constructing the Access Grant.
+ * @param options Optional properties to customise the access grant behaviour.
+ * @returns A Verifiable Credential representing the granted access.
+ * @since 0.0.1.
+ */
+export async function approveAccessRequest(
+  requestVc: undefined,
+  // If the VC is undefined, then some of the overrides become mandatory
+  requestOverride: ApproveAccessRequestOverrides,
+  options?: AccessBaseOptions
+): Promise<VerifiableCredential>;
+/**
+ * @deprecated Please remove the `resourceOwner` parameter.
+ */
+export async function approveAccessRequest(
+  resourceOwner: WebId,
+  requestVc: undefined,
+  // If the VC is undefined, then some of the overrides become mandatory
+  requestOverride: ApproveAccessRequestOverrides,
+  options?: AccessBaseOptions
+): Promise<VerifiableCredential>;
+export async function approveAccessRequest(
+  resourceOwnerOrRequestVc:
+    | WebId
+    | VerifiableCredential
+    | URL
+    | UrlString
+    | undefined,
+  requestVcOrOverride?:
+    | VerifiableCredential
+    | URL
+    | UrlString
+    | Partial<ApproveAccessRequestOverrides>,
+  requestOverrideOrOptions?:
+    | Partial<ApproveAccessRequestOverrides>
+    | AccessBaseOptions,
+  options?: AccessBaseOptions
+): Promise<VerifiableCredential> {
+  if (typeof options === "object") {
+    // The deprecated signature is being used, so ignore the first parameter.
+    return internal_approveAccessRequest(
+      requestVcOrOverride as VerifiableCredential | URL | UrlString,
+      requestOverrideOrOptions as Partial<ApproveAccessRequestOverrides>,
+      options
+    );
+  }
+  return internal_approveAccessRequest(
+    resourceOwnerOrRequestVc as VerifiableCredential | URL | UrlString,
+    requestVcOrOverride as Partial<ApproveAccessRequestOverrides>,
+    requestOverrideOrOptions as AccessBaseOptions
+  );
 }
 
 export default approveAccessRequest;

--- a/src/manage/denyAccessRequest.test.ts
+++ b/src/manage/denyAccessRequest.test.ts
@@ -67,7 +67,6 @@ describe("denyAccessRequest", () => {
       expect.anything(),
       expect.anything(),
       expect.anything(),
-      expect.anything(),
       {
         fetch: scab.fetch,
       }
@@ -115,7 +114,6 @@ describe("denyAccessRequest", () => {
       "https://some.access-endpoint.override/".concat("issue"),
       expect.anything(),
       expect.anything(),
-      expect.anything(),
       expect.anything()
     );
   });
@@ -141,7 +139,6 @@ describe("denyAccessRequest", () => {
       expect.anything(),
       expect.anything(),
       expect.anything(),
-      expect.anything(),
       { fetch: mockedFetch }
     );
   });
@@ -155,18 +152,13 @@ describe("denyAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    await denyAccessRequest(
-      "https://some.resource/owner",
-      mockAccessRequestVc(),
-      {
-        fetch: jest.fn(global.fetch),
-      }
-    );
+    await denyAccessRequest(mockAccessRequestVc(), {
+      fetch: jest.fn(global.fetch),
+    });
 
     // TODO: Should we expect "isProvidedTo": "https://some.requestor" in "providedConsent" or nest the expect.objectContaining?
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      "https://some.resource/owner",
       expect.objectContaining({
         providedConsent: {
           mode: mockAccessRequestVc().credentialSubject.hasConsent.mode,
@@ -198,17 +190,12 @@ describe("denyAccessRequest", () => {
       .mockResolvedValueOnce(
         new Response(JSON.stringify(mockAccessRequestVc()))
       );
-    await denyAccessRequest(
-      "https://some.resource/owner",
-      "https://some.credential",
-      {
-        fetch: mockedFetch,
-      }
-    );
+    await denyAccessRequest("https://some.credential", {
+      fetch: mockedFetch,
+    });
 
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      "https://some.resource/owner",
       expect.objectContaining({
         id: "https://some.resource/owner",
         providedConsent: expect.objectContaining({
@@ -240,18 +227,13 @@ describe("denyAccessRequest", () => {
       .mockResolvedValueOnce(
         new Response(JSON.stringify(mockAccessRequestVc()))
       );
-    await denyAccessRequest(
-      "https://some.resource/owner",
-      new URL("https://some.credential"),
-      {
-        fetch: mockedFetch,
-      }
-    );
+    await denyAccessRequest(new URL("https://some.credential"), {
+      fetch: mockedFetch,
+    });
 
     // TODO: Should we expect "isProvidedTo": "https://some.requestor" in "providedConsent" or nest the expect.objectContaining?
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      "https://some.resource/owner",
       expect.objectContaining({
         id: "https://some.resource/owner",
         providedConsent: expect.objectContaining({

--- a/src/manage/denyAccessRequest.test.ts
+++ b/src/manage/denyAccessRequest.test.ts
@@ -58,10 +58,7 @@ describe("denyAccessRequest", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const scab = jest.requireMock("@inrupt/solid-client-authn-browser") as any;
 
-    await denyAccessRequest(
-      "https://some.resource/owner",
-      mockAccessRequestVc()
-    );
+    await denyAccessRequest(mockAccessRequestVc());
 
     expect(mockedIssue).toHaveBeenCalledWith(
       expect.anything(),
@@ -76,7 +73,7 @@ describe("denyAccessRequest", () => {
   it("throws if the provided VC isn't a Solid access request", async () => {
     mockAccessApiEndpoint();
     await expect(
-      denyAccessRequest("https://some.resource/owner", {
+      denyAccessRequest({
         ...mockAccessRequestVc(),
         type: ["NotASolidAccessRequest"],
       })
@@ -87,9 +84,7 @@ describe("denyAccessRequest", () => {
 
   it("throws if there is no well known access endpoint", async () => {
     mockAccessApiEndpoint(false);
-    await expect(
-      denyAccessRequest("https://some.resource/owner", mockAccessRequestVc())
-    ).rejects.toThrow(
+    await expect(denyAccessRequest(mockAccessRequestVc())).rejects.toThrow(
       "No access issuer listed for property [verifiable_credential_issuer] in"
     );
   });
@@ -102,14 +97,10 @@ describe("denyAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    await denyAccessRequest(
-      "https://some.resource/owner",
-      mockAccessRequestVc(),
-      {
-        accessEndpoint: "https://some.access-endpoint.override/",
-        fetch: jest.fn(),
-      }
-    );
+    await denyAccessRequest(mockAccessRequestVc(), {
+      accessEndpoint: "https://some.access-endpoint.override/",
+      fetch: jest.fn(),
+    });
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       "https://some.access-endpoint.override/".concat("issue"),
       expect.anything(),
@@ -197,7 +188,6 @@ describe("denyAccessRequest", () => {
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
       expect.objectContaining({
-        id: "https://some.resource/owner",
         providedConsent: expect.objectContaining({
           mode: mockAccessRequestVc().credentialSubject.hasConsent.mode,
           hasStatus: "https://w3id.org/GConsent#ConsentStatusDenied",
@@ -235,13 +225,87 @@ describe("denyAccessRequest", () => {
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
       expect.objectContaining({
-        id: "https://some.resource/owner",
         providedConsent: expect.objectContaining({
           mode: mockAccessRequestVc().credentialSubject.hasConsent.mode,
           hasStatus: "https://w3id.org/GConsent#ConsentStatusDenied",
           forPersonalData:
             mockAccessRequestVc().credentialSubject.hasConsent.forPersonalData,
         }),
+        inbox: mockAccessRequestVc().credentialSubject.inbox,
+      }),
+      expect.objectContaining({
+        type: ["SolidAccessDenial"],
+      }),
+      expect.anything()
+    );
+  });
+
+  it("issues a proper denied access VC using the deprecated signature and VC value", async () => {
+    mockAccessApiEndpoint();
+    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
+      issueVerifiableCredential: () => unknown;
+    };
+    const spiedIssueRequest = jest.spyOn(
+      mockedVcModule,
+      "issueVerifiableCredential"
+    );
+    await denyAccessRequest(
+      "https://some.resource.owner",
+      mockAccessRequestVc(),
+      {
+        fetch: jest.fn(global.fetch),
+      }
+    );
+
+    // TODO: Should we expect "isProvidedTo": "https://some.requestor" in "providedConsent" or nest the expect.objectContaining?
+    expect(spiedIssueRequest).toHaveBeenCalledWith(
+      `${MOCKED_ACCESS_ISSUER}/issue`,
+      expect.objectContaining({
+        providedConsent: {
+          mode: mockAccessRequestVc().credentialSubject.hasConsent.mode,
+          hasStatus: "https://w3id.org/GConsent#ConsentStatusDenied",
+          forPersonalData:
+            mockAccessRequestVc().credentialSubject.hasConsent.forPersonalData,
+          isProvidedTo: "https://some.requestor",
+        },
+        inbox: mockAccessRequestVc().credentialSubject.inbox,
+      }),
+      expect.objectContaining({
+        type: ["SolidAccessDenial"],
+      }),
+      expect.anything()
+    );
+  });
+
+  it("issues a proper denied access VC using the deprecated signature and VC IRI", async () => {
+    mockAccessApiEndpoint();
+    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
+      issueVerifiableCredential: () => unknown;
+    };
+    const spiedIssueRequest = jest.spyOn(
+      mockedVcModule,
+      "issueVerifiableCredential"
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const scab = jest.requireMock("@inrupt/solid-client-authn-browser") as any;
+    scab.fetch = jest
+      .fn(global.fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(mockAccessRequestVc()))
+      );
+    await denyAccessRequest("https://some.resource.owner", "https://some.vc");
+
+    // TODO: Should we expect "isProvidedTo": "https://some.requestor" in "providedConsent" or nest the expect.objectContaining?
+    expect(spiedIssueRequest).toHaveBeenCalledWith(
+      `${MOCKED_ACCESS_ISSUER}/issue`,
+      expect.objectContaining({
+        providedConsent: {
+          mode: mockAccessRequestVc().credentialSubject.hasConsent.mode,
+          hasStatus: "https://w3id.org/GConsent#ConsentStatusDenied",
+          forPersonalData:
+            mockAccessRequestVc().credentialSubject.hasConsent.forPersonalData,
+          isProvidedTo: "https://some.requestor",
+        },
         inbox: mockAccessRequestVc().credentialSubject.inbox,
       }),
       expect.objectContaining({

--- a/src/manage/denyAccessRequest.ts
+++ b/src/manage/denyAccessRequest.ts
@@ -79,7 +79,7 @@ async function denyAccessRequest(
 async function denyAccessRequest(
   resourceOwner: WebId,
   vc: VerifiableCredential | URL | UrlString,
-  options: AccessBaseOptions
+  options?: AccessBaseOptions
 ): Promise<VerifiableCredential>;
 async function denyAccessRequest(
   resourceOwnerOrVc: WebId | VerifiableCredential | URL | UrlString,

--- a/src/manage/denyAccessRequest.ts
+++ b/src/manage/denyAccessRequest.ts
@@ -35,6 +35,7 @@ import { getBaseAccessRequestVerifiableCredential } from "../util/getBaseAccessV
 import { initializeGrantParameters } from "../util/initializeGrantParameters";
 
 // Merge back in denyAccessRequest after the deprecated signature has been removed.
+// eslint-disable-next-line camelcase
 async function internal_denyAccessRequest(
   vc: VerifiableCredential | URL | UrlString,
   options: AccessBaseOptions

--- a/src/manage/getAccessGrantAll.test.ts
+++ b/src/manage/getAccessGrantAll.test.ts
@@ -82,7 +82,9 @@ describe("getAccessGrantAll", () => {
   });
 
   it("Calls @inrupt/solid-client-vc/getVerifiableCredentialAllFromShape with the appropriate requestor", async () => {
-    const paramsInput: Partial<IssueAccessRequestParameters> = {
+    const paramsInput: Partial<
+      IssueAccessRequestParameters & { requestor: string }
+    > = {
       requestor: "https://some.requestor",
     };
 
@@ -156,7 +158,6 @@ describe("getAccessGrantAll", () => {
           mode: ["http://www.w3.org/ns/auth/acl#Read"],
           forPersonalData: [resource.href],
           hasStatus: "https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-          isProvidedTo: paramsInput.requestor,
         },
       },
     };

--- a/src/manage/getAccessGrantAll.ts
+++ b/src/manage/getAccessGrantAll.ts
@@ -46,7 +46,9 @@ import { getSessionFetch } from "../util/getSessionFetch";
 async function getAccessGrantAll(
   resource: URL | UrlString,
   params: Partial<
-    Pick<IssueAccessRequestParameters, "requestor" | "access" | "purpose">
+    Pick<IssueAccessRequestParameters, "access" | "purpose"> & {
+      requestor: string;
+    }
   > = {},
   options: AccessBaseOptions = {}
 ): Promise<Array<VerifiableCredential>> {

--- a/src/request/issueAccessRequest.test.ts
+++ b/src/request/issueAccessRequest.test.ts
@@ -324,7 +324,6 @@ describe("issueAccessRequest", () => {
       expect.anything(),
       expect.anything(),
       expect.anything(),
-      expect.anything(),
       {
         fetch: scab.fetch,
       }

--- a/src/request/issueAccessRequest.test.ts
+++ b/src/request/issueAccessRequest.test.ts
@@ -62,7 +62,6 @@ describe("getRequestBody", () => {
   it("can generate a minimal request body", () => {
     const requestBody = getRequestBody({
       access: { append: true },
-      requestor: MOCK_REQUESTOR_IRI,
       resources: ["https://some.pod/resource"],
       status: "https://w3id.org/GConsent#ConsentStatusRequested",
       requestorInboxUrl: MOCK_REQUESTOR_INBOX,
@@ -79,7 +78,6 @@ describe("getRequestBody", () => {
           hasStatus: "https://w3id.org/GConsent#ConsentStatusRequested",
           mode: ["http://www.w3.org/ns/auth/acl#Append"],
         },
-        id: MOCK_REQUESTOR_IRI,
         inbox: MOCK_REQUESTOR_INBOX,
       },
       type: ["SolidAccessRequest"],
@@ -94,7 +92,6 @@ describe("getRequestBody", () => {
         controlRead: true,
         controlWrite: true,
       },
-      requestor: MOCK_REQUESTOR_IRI,
       resources: ["https://some.pod/resource"],
       issuanceDate: new Date(Date.UTC(1955, 5, 8, 13, 37, 42, 42)),
       expirationDate: new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 42)),
@@ -119,7 +116,6 @@ describe("getRequestBody", () => {
             "http://www.w3.org/ns/auth/acl#Control",
           ],
         },
-        id: MOCK_REQUESTOR_IRI,
         inbox: "https://some.pod/inbox/",
       },
       expirationDate: "1990-11-12T13:37:42.042Z",
@@ -159,7 +155,6 @@ describe("issueAccessRequest", () => {
     await issueAccessRequest(
       {
         access: { read: true },
-        requestor: MOCK_REQUESTOR_IRI,
         resourceOwner: MOCK_REQUESTEE_IRI,
         resources: ["https://some.pod/resource"],
         requestorInboxUrl: MOCK_REQUESTOR_INBOX,
@@ -171,9 +166,7 @@ describe("issueAccessRequest", () => {
 
     expect(mockedIssue).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      MOCK_REQUESTOR_IRI,
       expect.objectContaining({
-        id: MOCK_REQUESTOR_IRI,
         hasConsent: {
           mode: ["http://www.w3.org/ns/auth/acl#Read"],
           hasStatus: "https://w3id.org/GConsent#ConsentStatusRequested",
@@ -202,14 +195,12 @@ describe("issueAccessRequest", () => {
 
     await issueAccessRequest({
       access: { read: true },
-      requestor: MOCK_REQUESTOR_IRI,
       resourceOwner: MOCK_REQUESTEE_IRI,
       resources: ["https://some.pod/resource"],
       requestorInboxUrl: MOCK_REQUESTOR_INBOX,
     });
 
     expect(mockedIssue).toHaveBeenCalledWith(
-      expect.anything(),
       expect.anything(),
       expect.anything(),
       expect.anything(),
@@ -236,7 +227,6 @@ describe("issueAccessRequest", () => {
     await issueAccessRequest(
       {
         access: { read: true },
-        requestor: MOCK_REQUESTOR_IRI,
         resourceOwner: MOCK_REQUESTEE_IRI,
         resources: ["https://some.pod/resource"],
         purpose: ["https://some.vocab/purpose#save-the-world"],
@@ -251,9 +241,7 @@ describe("issueAccessRequest", () => {
 
     expect(mockedIssue).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      MOCK_REQUESTOR_IRI,
       expect.objectContaining({
-        id: MOCK_REQUESTOR_IRI,
         hasConsent: {
           mode: ["http://www.w3.org/ns/auth/acl#Read"],
           hasStatus: "https://w3id.org/GConsent#ConsentStatusRequested",
@@ -286,7 +274,6 @@ describe("issueAccessRequest", () => {
 
     await issueAccessRequest({
       access: { read: true },
-      requestor: MOCK_REQUESTOR_IRI,
       resourceOwner: MOCK_REQUESTEE_IRI,
       resources: ["https://some.pod/resource"],
       purpose: ["https://some.vocab/purpose#save-the-world"],
@@ -295,9 +282,7 @@ describe("issueAccessRequest", () => {
 
     expect(mockedIssue).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
-      MOCK_REQUESTOR_IRI,
       expect.objectContaining({
-        id: MOCK_REQUESTOR_IRI,
         hasConsent: {
           mode: ["http://www.w3.org/ns/auth/acl#Read"],
           hasStatus: "https://w3id.org/GConsent#ConsentStatusRequested",
@@ -327,7 +312,6 @@ describe("issueAccessRequest", () => {
 
     await issueAccessRequest({
       access: { read: true },
-      requestor: MOCK_REQUESTOR_IRI,
       resourceOwner: MOCK_REQUESTEE_IRI,
       resources: ["https://some.pod/resource"],
       purpose: ["https://some.vocab/purpose#save-the-world"],

--- a/src/request/issueAccessRequest.ts
+++ b/src/request/issueAccessRequest.ts
@@ -23,7 +23,10 @@ import type { VerifiableCredential } from "@inrupt/solid-client-vc";
 import { getRequestBody, issueAccessVc } from "../util/issueAccessVc";
 import { GC_CONSENT_STATUS_REQUESTED } from "../constants";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
-import type { IssueAccessRequestParameters } from "../type/IssueAccessRequestParameters";
+import type {
+  DeprecatedAccessRequestParameters,
+  IssueAccessRequestParameters,
+} from "../type/IssueAccessRequestParameters";
 
 /**
  * Request access to a given Resource.
@@ -35,6 +38,17 @@ import type { IssueAccessRequestParameters } from "../type/IssueAccessRequestPar
  */
 async function issueAccessRequest(
   params: IssueAccessRequestParameters,
+  options?: AccessBaseOptions
+): Promise<VerifiableCredential>;
+/**
+ * @deprecated Please remove the `requestor` parameter.
+ */
+async function issueAccessRequest(
+  params: DeprecatedAccessRequestParameters,
+  options?: AccessBaseOptions
+): Promise<VerifiableCredential>;
+async function issueAccessRequest(
+  params: IssueAccessRequestParameters,
   options: AccessBaseOptions = {}
 ): Promise<VerifiableCredential> {
   const accessRequest = getRequestBody({
@@ -42,7 +56,7 @@ async function issueAccessRequest(
     status: GC_CONSENT_STATUS_REQUESTED,
   });
 
-  return issueAccessVc(params.requestor, accessRequest, options);
+  return issueAccessVc(accessRequest, options);
 }
 
 export default issueAccessRequest;

--- a/src/type/AccessVerifiableCredential.ts
+++ b/src/type/AccessVerifiableCredential.ts
@@ -47,37 +47,48 @@ export type CredentialSubject = {
   providedConsent?: ConsentGrantAttributes;
 };
 
-export type RequestOrGrantCredentialSubject = Required<
-  Omit<CredentialSubject, "id">
+export type RequestCredentialSubject = Required<
+  Omit<CredentialSubject, "providedConsent">
 >;
 
-export type RequestCredentialSubject = Required<
-  Omit<RequestOrGrantCredentialSubject, "providedConsent">
+export type RequestCredentialSubjectPayload = Omit<
+  RequestCredentialSubject,
+  "id"
 >;
 
 export type GrantCredentialSubject = Required<
-  Omit<RequestOrGrantCredentialSubject, "hasConsent">
+  Omit<CredentialSubject, "hasConsent">
 >;
+
+export type GrantCredentialSubjectPayload = Omit<GrantCredentialSubject, "id">;
 
 export type BaseAccessVcBody = {
   "@context": typeof CONSENT_CONTEXT;
   type: AccessCredentialType[];
-  credentialSubject: RequestCredentialSubject | GrantCredentialSubject;
+  credentialSubject:
+    | RequestCredentialSubject
+    | GrantCredentialSubject
+    | Omit<RequestCredentialSubject, "id">
+    | Omit<GrantCredentialSubject, "id">;
   issuanceDate?: string;
 };
 
-export type BaseRequestBody = {
-  "@context": typeof CONSENT_CONTEXT;
-  type: AccessCredentialType[];
+export type BaseRequestBody = BaseAccessVcBody & {
   credentialSubject: RequestCredentialSubject;
-  issuanceDate?: string;
 };
 
-export type BaseGrantBody = {
-  "@context": typeof CONSENT_CONTEXT;
-  type: AccessCredentialType[];
+export type BaseGrantBody = BaseAccessVcBody & {
   credentialSubject: GrantCredentialSubject;
-  issuanceDate?: string;
+};
+
+// When sending a VC payload to be issued, the subject id is omitted.
+export type BaseRequestPayload = BaseAccessVcBody & {
+  credentialSubject: Omit<RequestCredentialSubject, "id">;
+};
+
+// When sending a VC payload to be issued, the subject id is omitted.
+export type BaseGrantPayload = BaseAccessVcBody & {
+  credentialSubject: Omit<GrantCredentialSubject, "id">;
 };
 
 // TODO: Check why the access credentials would not have optional expiration dates

--- a/src/type/AccessVerifiableCredential.ts
+++ b/src/type/AccessVerifiableCredential.ts
@@ -47,12 +47,16 @@ export type CredentialSubject = {
   providedConsent?: ConsentGrantAttributes;
 };
 
+export type RequestOrGrantCredentialSubject = Required<
+  Omit<CredentialSubject, "id">
+>;
+
 export type RequestCredentialSubject = Required<
-  Omit<CredentialSubject, "providedConsent">
+  Omit<RequestOrGrantCredentialSubject, "providedConsent">
 >;
 
 export type GrantCredentialSubject = Required<
-  Omit<CredentialSubject, "hasConsent">
+  Omit<RequestOrGrantCredentialSubject, "hasConsent">
 >;
 
 export type BaseAccessVcBody = {

--- a/src/type/IssueAccessRequestParameters.ts
+++ b/src/type/IssueAccessRequestParameters.ts
@@ -41,13 +41,16 @@ import type { access, UrlString, WebId } from "@inrupt/solid-client";
 // TODO: Get rid of BaseRequestParameters in favour of this
 export type IssueAccessRequestParameters = {
   access: Partial<access.Access>;
-  requestor: WebId;
   requestorInboxUrl?: UrlString;
   resourceOwner: WebId;
   resources: Array<UrlString>;
   purpose?: Array<UrlString>;
   issuanceDate?: Date;
   expirationDate?: Date;
+};
+
+export type DeprecatedAccessRequestParameters = IssueAccessRequestParameters & {
+  requestor: WebId;
 };
 
 /**

--- a/src/type/Parameter.ts
+++ b/src/type/Parameter.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import type { access, UrlString, WebId } from "@inrupt/solid-client";
+import type { access, UrlString } from "@inrupt/solid-client";
 import type {
   GC_CONSENT_STATUS_REQUESTED,
   GC_CONSENT_STATUS_EXPLICITLY_GIVEN,

--- a/src/type/Parameter.ts
+++ b/src/type/Parameter.ts
@@ -28,7 +28,6 @@ import type { ConsentStatus } from "./ConsentStatus";
 
 export type BaseRequestParameters = {
   access: Partial<access.Access>;
-  requestor: UrlString;
   requestorInboxUrl?: UrlString;
   resources: Array<UrlString>;
   status: ConsentStatus;
@@ -48,8 +47,8 @@ export type ConsentRequestParameters = AccessRequestParameters &
   BaseConsentParameters;
 
 export type AccessGrantParameters = BaseRequestParameters & {
-  resourceOwner: WebId;
   status: typeof GC_CONSENT_STATUS_EXPLICITLY_GIVEN;
+  requestor: UrlString;
 };
 
 export type ConsentGrantParameters = AccessGrantParameters &

--- a/src/util/issueAccessVc.ts
+++ b/src/util/issueAccessVc.ts
@@ -37,7 +37,9 @@ import type {
   BaseConsentGrantBody,
   BaseConsentRequestBody,
   BaseGrantBody,
+  BaseGrantPayload,
   BaseRequestBody,
+  BaseRequestPayload,
   ConsentAttributes,
   ConsentGrantAttributes,
   ConsentGrantBody,
@@ -46,7 +48,6 @@ import type {
 import { isConsentRequest } from "../guard/isConsentRequest";
 import type {
   BaseConsentParameters,
-  BaseRequestParameters,
   ConsentRequestParameters,
   AccessRequestParameters,
   ConsentGrantParameters,
@@ -88,15 +89,15 @@ function getConsentAttributes(
 function getBaseBody(
   params: AccessRequestParameters,
   type: "BaseRequestBody"
-): BaseRequestBody;
+): BaseRequestPayload;
 function getBaseBody(
   params: AccessGrantParameters,
   type: "BaseGrantBody"
-): BaseGrantBody;
+): BaseGrantPayload;
 function getBaseBody(
   params: AccessRequestParameters | AccessGrantParameters,
   type: "BaseRequestBody" | "BaseGrantBody"
-): BaseRequestBody | BaseGrantBody {
+): BaseRequestPayload | BaseGrantPayload {
   const body = {
     "@context": CONSENT_CONTEXT,
     type: [
@@ -134,7 +135,7 @@ function getBaseBody(
 
 function getConsentBaseBody(
   params: BaseConsentParameters,
-  baseBody: BaseGrantBody | BaseRequestBody
+  baseBody: BaseGrantPayload | BaseRequestPayload
 ) {
   const request = { ...baseBody };
   // This makes request a ConsentGrantBody
@@ -161,7 +162,7 @@ function getConsentGrantBody(
 
 function getConsentRequestBody(
   params: BaseConsentParameters,
-  baseBody: BaseRequestBody
+  baseBody: BaseRequestPayload
 ): ConsentRequestBody {
   const request = getConsentBaseBody(params, baseBody);
   (request as ConsentRequestBody).credentialSubject.hasConsent.forPurpose =

--- a/src/util/issueAccessVc.ts
+++ b/src/util/issueAccessVc.ts
@@ -19,7 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { WebId } from "@inrupt/solid-client";
 import {
   issueVerifiableCredential,
   VerifiableCredential,


### PR DESCRIPTION
This deprecates passing the VC subject to VC issuing functions part of the access request/grant flow. It aligns with the changes implemented in https://github.com/inrupt/solid-client-vc-js/pull/271, which are soon to be released (the tests have been implemented using `npm link locally`). 

This is a non-breaking change, the deprecated signatures are maintained in the API.

Overall, it feels like the codebase is a bit convoluted, and that it should have been a simpler change than what it actually was, but we can address the tech debt later. 

# Checklist

- [X] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).