### PR TITLE
Updated JSON-LD context URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
--
+### Bugfixes
+
+- The JSON-LD context URL has changed from https://vc.inrupt.com/credentials/v1 to https://vc.inrupt.com/credentials/v1.
 
 ## [0.4.1](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v0.4.1) - 2022-01-28
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,7 +60,7 @@ export const PREFERRED_CONSENT_MANAGEMENT_UI =
 
 export const CONSENT_CONTEXT = [
   "https://www.w3.org/2018/credentials/v1",
-  "https://consent.pod.inrupt.com/credentials/v1",
+  "https://vc.inrupt.com/credentials/v1",
 ] as const;
 
 export const WELL_KNOWN_SOLID = ".well-known/solid";

--- a/src/fetch/index.test.ts
+++ b/src/fetch/index.test.ts
@@ -39,6 +39,7 @@ import {
   exchangeTicketForAccessToken,
   boundFetch,
   fetchWithVc,
+  simpleFormUrlEncoded,
 } from "./index";
 
 jest.mock("cross-fetch", () => {
@@ -52,7 +53,7 @@ jest.mock("cross-fetch", () => {
 const MOCK_VC = {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://consent.pod.inrupt.com/credentials/v1",
+    "https://vc.inrupt.com/credentials/v1",
   ],
   id: "https://example.com/id",
   issuer: "https://example.com/issuer",
@@ -168,12 +169,12 @@ describe("exchangeTicketForAccessToken", () => {
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
       },
-      // The body should be the following data as a form_urlencoded:
-      // claim_token: btoa(JSON.stringify({ verifiableCredential: [MOCK_VC] })),
-      // claim_token_type: "https://www.w3.org/TR/vc-data-model/#json-ld",
-      // grant_type: "urn:ietf:params:oauth:grant-type:uma-ticket",
-      // ticket: authTicket,
-      body: "claim_token=eyJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6W3siQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL2NvbnNlbnQucG9kLmlucnVwdC5jb20vY3JlZGVudGlhbHMvdjEiXSwiaWQiOiJodHRwczovL2V4YW1wbGUuY29tL2lkIiwiaXNzdWVyIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9pc3N1ZXIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiU29saWRDcmVkZW50aWFsIiwiU29saWRBY2Nlc3NHcmFudCJdLCJpc3N1YW5jZURhdGUiOiIyMDIxLTA1LTI2VDE2OjQwOjAzIiwiZXhwaXJhdGlvbkRhdGUiOiIyMDIxLTA2LTA5VDE2OjQwOjAzIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJodHRwczovL3BvZC5pbnJ1cHQuY29tL2FsaWNlL3Byb2ZpbGUvY2FyZCNtZSIsInByb3ZpZGVkQ29uc2VudCI6eyJtb2RlIjpbImh0dHA6Ly93d3cudzMub3JnL25zL2F1dGgvYWNsI1JlYWQiXSwiaGFzU3RhdHVzIjoiQ29uc2VudFN0YXR1c0V4cGxpY2l0bHlHaXZlbiIsImZvclBlcnNvbmFsRGF0YSI6Imh0dHBzOi8vcG9kLmlucnVwdC5jb20vYWxpY2UvcHJpdmF0ZS9kYXRhIiwiZm9yUHVycG9zZSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vU29tZVNwZWNpZmljUHVycG9zZSIsImlzUHJvdmlkZWRUb1BlcnNvbiI6Imh0dHBzOi8vcG9kLmlucnVwdC5jb20vYm9iL3Byb2ZpbGUvY2FyZCNtZSJ9fSwicHJvb2YiOnsiY3JlYXRlZCI6IjIwMjEtMDUtMjZUMTY6NDA6MDMuMDA5WiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsInByb29mVmFsdWUiOiJlcXA4aF9rTDFEd0pDcG42NXotZDFBcm55c3g2YjExLi4uamI4ajBNeFVDYzF1RFEiLCJ0eXBlIjoiRWQyNTUxOVNpZ25hdHVyZTIwMjAiLCJ2ZXJpZmljYXRpb25NZXRob2QiOiJodHRwczovL2NvbnNlbnQucG9kLmlucnVwdC5jb20va2V5LzM5NmY2ODZiIn19XX0%3D&claim_token_type=https%3A%2F%2Fwww.w3.org%2FTR%2Fvc-data-model%2F%23json-ld&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Auma-ticket&ticket=auth-ticket",
+      body: simpleFormUrlEncoded({
+        claim_token: btoa(JSON.stringify({ verifiableCredential: [MOCK_VC] })),
+        claim_token_type: "https://www.w3.org/TR/vc-data-model/#json-ld",
+        grant_type: "urn:ietf:params:oauth:grant-type:uma-ticket",
+        ticket: authTicket,
+      }),
     });
   });
 

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -79,7 +79,7 @@ export async function getUmaConfiguration(
 /**
  * @hidden
  */
-function simpleFormUrlEncoded(form: Record<string, string>): string {
+export function simpleFormUrlEncoded(form: Record<string, string>): string {
   return Object.keys(form)
     .reduce((encoded, key) => {
       encoded.push(`${key}=${encodeURIComponent(form[key])}`);

--- a/src/guard/isBaseAccessGrantVerifiableCredential.test.ts
+++ b/src/guard/isBaseAccessGrantVerifiableCredential.test.ts
@@ -27,7 +27,7 @@ const validAccessGrantVerifiableCredential = {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
     "https://w3id.org/security/suites/ed25519-2020/v1",
-    "https://consent.pod.inrupt.com/credentials/v1",
+    "https://vc.inrupt.com/credentials/v1",
   ],
   credentialSubject: {
     providedConsent: {

--- a/src/guard/isBaseAccessRequestVerifiableCredential.test.ts
+++ b/src/guard/isBaseAccessRequestVerifiableCredential.test.ts
@@ -27,7 +27,7 @@ const validAccessRequestVerifiableCredential = {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
     "https://w3id.org/security/suites/ed25519-2020/v1",
-    "https://consent.pod.inrupt.com/credentials/v1",
+    "https://vc.inrupt.com/credentials/v1",
   ],
   credentialSubject: {
     hasConsent: {

--- a/src/request/request.test.ts
+++ b/src/request/request.test.ts
@@ -71,7 +71,7 @@ describe("getRequestBody", () => {
     expect(requestBody).toStrictEqual({
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://consent.pod.inrupt.com/credentials/v1",
+        "https://vc.inrupt.com/credentials/v1",
       ],
       credentialSubject: {
         hasConsent: {
@@ -106,7 +106,7 @@ describe("getRequestBody", () => {
     expect(requestBody).toStrictEqual({
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://consent.pod.inrupt.com/credentials/v1",
+        "https://vc.inrupt.com/credentials/v1",
       ],
       credentialSubject: {
         hasConsent: {

--- a/src/verify/isValidAccessGrant.test.ts
+++ b/src/verify/isValidAccessGrant.test.ts
@@ -56,7 +56,7 @@ describe("isValidAccessGrant", () => {
   const MOCK_ACCESS_GRANT = {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
-      "https://consent.pod.inrupt.com/credentials/v1",
+      "https://vc.inrupt.com/credentials/v1",
     ],
     id: "https://example.com/id",
     issuer: "https://example.com/issuer",


### PR DESCRIPTION
Changed https://consent.pod.inrupt.com/credentials/v1 into https://vc.inrupt.com/credentials/v1

- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).