### PR TITLE
Redirect to requestor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,18 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+### New features
+
+- `redirectToRequestor` has been added to the `./manage` module to help access management
+  apps redirect their users to the clients which requested access to a Resource.
+
 ### Bugfixes
 
 - The JSON-LD context URL has changed from https://vc.inrupt.com/credentials/v1 to https://vc.inrupt.com/credentials/v1.
+- `redirectToAccessManagementUi` now returns a promise that never resolves. This
+  prevents from `await`ing on it, have it resolve, and start running code in the underterministic
+  time between the moment when `window.location.href` is set (or the redirect callback
+  is called) and the moment the redirection actually happens.
 
 ### Deprecation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The following changes have been implemented but not released yet:
 
 - The JSON-LD context URL has changed from https://vc.inrupt.com/credentials/v1 to https://vc.inrupt.com/credentials/v1.
 - `redirectToAccessManagementUi` now returns a promise that never resolves. This
-  prevents from `await`ing on it, have it resolve, and start running code in the underterministic
+  prevents from `await`ing on it, have it resolve, and start running code in the undeterministic
   time between the moment when `window.location.href` is set (or the redirect callback
   is called) and the moment the redirection actually happens.
 

--- a/src/discover/redirectToAccessManagementUi.test.ts
+++ b/src/discover/redirectToAccessManagementUi.test.ts
@@ -116,56 +116,81 @@ describe("redirectToAccessManagementUi", () => {
     it("discovers the access management UI from the resource owner profile if provided", async () => {
       mockAccessManagementUiDiscovery("https://some.app");
       const resourceOwner = "https://some.webid";
-      await redirectToAccessManagementUi(
+      // redirectToAccessManagementUi never resolves, which prevents checking values
+      // if it is awaited.
+      // eslint-disable-next-line no-void
+      void redirectToAccessManagementUi(
         mockAccessRequestVc(),
         "https://some.redirect.iri",
         {
           resourceOwner,
         }
       );
+      // Yield the event loop to make sure the blocking promises completes.
+      await new Promise((resolve) => setImmediate(resolve));
       const targetIri = window.location.href;
       expect(targetIri).toContain("https://some.app");
     });
 
     it("falls back to the provided access app IRI if any", async () => {
-      await redirectToAccessManagementUi(
+      // redirectToAccessManagementUi never resolves, which prevents checking values
+      // if it is awaited.
+      // eslint-disable-next-line no-void
+      void redirectToAccessManagementUi(
         mockAccessRequestVc(),
         "https://some.redirect.iri",
         {
           fallbackAccessManagementUi: "https://some.app",
         }
       );
+      // Yield the event loop to make sure the blocking promises completes.
+      await new Promise((resolve) => setImmediate(resolve));
       const targetIri = window.location.href;
       expect(targetIri).toContain("https://some.app");
     });
 
     it("falls back to the provided access app IRI if any (legacy)", async () => {
-      await redirectToAccessManagementUi(
+      // redirectToAccessManagementUi never resolves, which prevents checking values
+      // if it is awaited.
+      // eslint-disable-next-line no-void
+      void redirectToAccessManagementUi(
         mockAccessRequestVc(),
         "https://some.redirect.iri",
         {
           fallbackConsentManagementUi: "https://some.app",
         }
       );
+      // Yield the event loop to make sure the blocking promises completes.
+      await new Promise((resolve) => setImmediate(resolve));
       const targetIri = window.location.href;
       expect(targetIri).toContain("https://some.app");
     });
 
     it("redirects to the discovered management UI IRI", async () => {
       mockAccessManagementUiDiscovery("https://some.access.ui");
-      await redirectToAccessManagementUi(
+      // redirectToAccessManagementUi never resolves, which prevents checking values
+      // if it is awaited.
+      // eslint-disable-next-line no-void
+      void redirectToAccessManagementUi(
         mockAccessRequestVc(),
         "https://some.redirect.iri"
       );
+      // Yield the event loop to make sure the blocking promises completes.
+      await new Promise((resolve) => setImmediate(resolve));
       expect(window.location.href).toContain("https://some.access.ui");
     });
 
     it("includes the VC IRI and redirect IRI as query parameters to the access UI IRI", async () => {
       mockAccessManagementUiDiscovery("https://some.access.ui");
-      await redirectToAccessManagementUi(
+      // redirectToAccessManagementUi never resolves, which prevents checking values
+      // if it is awaited.
+      // eslint-disable-next-line no-void
+      void redirectToAccessManagementUi(
         mockAccessRequestVc(),
         "https://some.redirect.iri"
       );
+      // Yield the event loop to make sure the blocking promises completes.
+      await new Promise((resolve) => setImmediate(resolve));
       const targetIri = new URL(window.location.href);
       const encodedVc = targetIri.searchParams.get("requestVc") as string;
       expect(JSON.parse(atob(encodedVc))).toEqual(mockAccessRequestVc());
@@ -181,13 +206,18 @@ describe("redirectToAccessManagementUi", () => {
         .mockResolvedValueOnce(
           new Response(JSON.stringify(mockAccessRequestVc()))
         );
-      await redirectToAccessManagementUi(
+      // redirectToAccessManagementUi never resolves, which prevents checking values
+      // if it is awaited.
+      // eslint-disable-next-line no-void
+      void redirectToAccessManagementUi(
         "https://some.request-vc.url",
         new URL("https://some.redirect.iri"),
         {
           fetch: mockedFetch,
         }
       );
+      // Yield the event loop to make sure the blocking promises completes.
+      await new Promise((resolve) => setImmediate(resolve));
       const targetIri = new URL(window.location.href);
       expect(targetIri.searchParams.get("redirectUrl")).toBe(
         "https://some.redirect.iri/"
@@ -196,10 +226,15 @@ describe("redirectToAccessManagementUi", () => {
 
     it("supports the redirect IRI being a URL object", async () => {
       mockAccessManagementUiDiscovery("https://some.access.ui");
-      await redirectToAccessManagementUi(
+      // redirectToAccessManagementUi never resolves, which prevents checking values
+      // if it is awaited.
+      // eslint-disable-next-line no-void
+      void redirectToAccessManagementUi(
         mockAccessRequestVc(),
         new URL("https://some.redirect.iri")
       );
+      // Yield the event loop to make sure the blocking promises completes.
+      await new Promise((resolve) => setImmediate(resolve));
       const targetIri = new URL(window.location.href);
       expect(targetIri.searchParams.get("redirectUrl")).toBe(
         "https://some.redirect.iri/"
@@ -209,13 +244,18 @@ describe("redirectToAccessManagementUi", () => {
     it("calls the redirection callback if provided", async () => {
       mockAccessManagementUiDiscovery("https://some.access.ui");
       const redirectCallback = jest.fn();
-      await redirectToAccessManagementUi(
+      // redirectToAccessManagementUi never resolves, which prevents checking values
+      // if it is awaited.
+      // eslint-disable-next-line no-void
+      void redirectToAccessManagementUi(
         mockAccessRequestVc(),
         "https://some.redirect.iri",
         {
           redirectCallback,
         }
       );
+      // Yield the event loop to make sure the blocking promises completes.
+      await new Promise((resolve) => setImmediate(resolve));
       const redirectIri = new URL(redirectCallback.mock.calls[0][0] as string);
       expect(redirectIri.origin).toBe("https://some.access.ui");
       expect(redirectIri.searchParams.get("requestVc")).toBe(

--- a/src/discover/redirectToAccessManagementUi.ts
+++ b/src/discover/redirectToAccessManagementUi.ts
@@ -27,6 +27,7 @@ import {
   getAccessManagementUi,
   getAccessManagementUiFromWellKnown,
 } from "./getAccessManagementUi";
+import { RedirectOptions, redirectWithParameters } from "../util/redirect";
 
 const REQUEST_VC_PARAM_NAME = "requestVc";
 const REDIRECT_URL_PARAM_NAME = "redirectUrl";
@@ -46,8 +47,7 @@ const REDIRECT_URL_PARAM_NAME = "redirectUrl";
  *
  * @since 0.4.0
  */
-export type RedirectToAccessManagementUiOptions = {
-  redirectCallback?: (url: string) => void;
+export type RedirectToAccessManagementUiOptions = RedirectOptions & {
   fetch?: typeof global.fetch;
   resourceOwner?: WebId;
   /**
@@ -123,26 +123,16 @@ export async function redirectToAccessManagementUi(
     );
   }
 
-  const targetIri = new URL(accessManagementUi);
-  targetIri.searchParams.append(
-    REQUEST_VC_PARAM_NAME,
-    btoa(JSON.stringify(requestVc))
+  return redirectWithParameters(
+    accessManagementUi,
+    {
+      [`${REQUEST_VC_PARAM_NAME}`]: btoa(JSON.stringify(requestVc)),
+      [`${REDIRECT_URL_PARAM_NAME}`]: encodeURI(
+        typeof redirectUrl === "string" ? redirectUrl : redirectUrl.href
+      ),
+    },
+    options
   );
-  targetIri.searchParams.append(
-    REDIRECT_URL_PARAM_NAME,
-    encodeURI(typeof redirectUrl === "string" ? redirectUrl : redirectUrl.href)
-  );
-
-  if (options !== undefined && options.redirectCallback !== undefined) {
-    options.redirectCallback(targetIri.href);
-  } else {
-    if (typeof window === "undefined") {
-      throw new Error(
-        "In a non-browser environment, a redirectCallback must be provided by the user."
-      );
-    }
-    window.location.href = targetIri.href;
-  }
 }
 
 /**

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -34,6 +34,7 @@ import {
   isValidAccessGrant,
   issueAccessRequest,
   redirectToAccessManagementUi,
+  redirectToRequestor,
   revokeAccessGrant,
   fetchWithVc,
   getFile,
@@ -64,6 +65,7 @@ describe("Index exports", () => {
     expect(isValidAccessGrant).toBeDefined();
     expect(issueAccessRequest).toBeDefined();
     expect(redirectToAccessManagementUi).toBeDefined();
+    expect(redirectToRequestor).toBeDefined();
     expect(revokeAccessGrant).toBeDefined();
     expect(fetchWithVc).toBeDefined();
     expect(getFile).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ export {
   denyAccessRequest,
   getAccessGrant,
   getAccessGrantAll,
+  redirectToRequestor,
   revokeAccessGrant,
   // Deprecated APIs:
   getAccessWithConsent,

--- a/src/manage/index.ts
+++ b/src/manage/index.ts
@@ -50,6 +50,8 @@ export {
   getAccessWithConsentAll,
 } from "./getAccessGrantAll";
 
+export { redirectToRequestor } from "./redirectToRequestor";
+
 export {
   revokeAccessGrant,
   // Deprecated APIs:

--- a/src/manage/redirectToRequestor.test.ts
+++ b/src/manage/redirectToRequestor.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2022 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+/* eslint-disable no-shadow */
+import {
+  jest,
+  it,
+  describe,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import { redirectToRequestor } from "./redirectToRequestor";
+
+describe("redirectToRequestor", () => {
+  describe("in a browser environment", () => {
+    const { location: savedLocation } = window;
+
+    beforeEach(() => {
+      // location and history aren't optional on window, which makes TS complain
+      // (rightfully) when we delete them. However, they are deleted on purpose
+      // here just for testing.
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      delete window.location;
+      window.location = {
+        href: "https://some.site",
+      } as Location;
+    });
+
+    afterEach(() => {
+      window.location = savedLocation;
+    });
+
+    it("redirects to the provided redirect IRI", async () => {
+      // redirectToAccessManagementUi never resolves, which prevents checking values
+      // if it is awaited.
+      // eslint-disable-next-line no-void
+      void redirectToRequestor(
+        "https://some.grant-vc.iri",
+        "https://some.redirect.iri"
+      );
+      // Yield the event loop to make sure the blocking promises completes.
+      // FIXME: Why is setImmediate undefined in this context ?
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const targetIri = window.location.href;
+      expect(targetIri).toContain("https://some.redirect.iri");
+    });
+
+    it("includes the VC IRI as query parameters to the redirect IRI", async () => {
+      // redirectToAccessManagementUi never resolves, which prevents checking values
+      // if it is awaited.
+      // eslint-disable-next-line no-void
+      void redirectToRequestor(
+        "https://some.grant-vc.iri",
+        "https://some.redirect.iri"
+      );
+      // Yield the event loop to make sure the blocking promises completes.
+      // FIXME: Why is setImmediate undefined in this context ?
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const targetIri = new URL(window.location.href);
+      expect(
+        decodeURIComponent(targetIri.searchParams.get("accessGrant") as string)
+      ).toBe("https://some.grant-vc.iri");
+    });
+
+    it("supports the redirect IRI and VC ID being URL objects", async () => {
+      // redirectToAccessManagementUi never resolves, which prevents checking values
+      // if it is awaited.
+      // eslint-disable-next-line no-void
+      void redirectToRequestor(
+        new URL("https://some.grant-vc.iri"),
+        new URL("https://some.redirect.iri")
+      );
+      // Yield the event loop to make sure the blocking promises completes.
+      // FIXME: Why is setImmediate undefined in this context ?
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const targetIri = new URL(window.location.href);
+      expect(
+        decodeURIComponent(targetIri.searchParams.get("accessGrant") as string)
+      ).toBe("https://some.grant-vc.iri/");
+      expect(targetIri.href).toContain("https://some.redirect.iri");
+    });
+
+    it("calls the redirection callback if provided", async () => {
+      const redirectCallback = jest.fn();
+      // redirectToAccessManagementUi never resolves, which prevents checking values
+      // if it is awaited.
+      // eslint-disable-next-line no-void
+      void redirectToRequestor(
+        "https://some.grant-vc.iri",
+        "https://some.redirect.iri",
+        {
+          redirectCallback,
+        }
+      );
+      // Yield the event loop to make sure the blocking promises completes.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const redirectIri = new URL(redirectCallback.mock.calls[0][0] as string);
+      expect(redirectIri.origin).toBe("https://some.redirect.iri");
+      expect(
+        decodeURIComponent(
+          redirectIri.searchParams.get("accessGrant") as string
+        )
+      ).toBe("https://some.grant-vc.iri");
+      expect(window.location.href).toBe("https://some.site");
+    });
+  });
+
+  describe("in a Node environment", () => {
+    const windowSpy = jest.spyOn(window, "window", "get");
+
+    beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      windowSpy.mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      windowSpy.mockRestore();
+    });
+
+    it("throws if the callback is undefined", async () => {
+      expect(window).toBeUndefined();
+      await expect(
+        redirectToRequestor(
+          "https://some.grant-vc.iri",
+          "https://some.redirect.iri"
+        )
+      ).rejects.toThrow(
+        `In a non-browser environment, a redirectCallback must be provided by the user.`
+      );
+    });
+  });
+});

--- a/src/manage/redirectToRequestor.ts
+++ b/src/manage/redirectToRequestor.ts
@@ -24,6 +24,19 @@ import { RedirectOptions, redirectWithParameters } from "../util/redirect";
 
 export const GRANT_VC_PARAM_NAME = "accessGrant";
 
+/**
+ * Redirect the user to the client which requested Access to a Resource. The Access
+ * Grant is sent as part of the redirect.
+ *
+ * @param accessGrantVcId The ID of the Access Grant VC, which should be a URL
+ * @param redirectUrl The URL where the client requesting access expects the
+ * user to be redirected
+ * @param options If you are in a NodeJS environment, you must specify a
+ * callback to handle the redirection.
+ * @returns A never resolving promise: the user is expected to be redirected away
+ * from the page by this call, so no code should be expected to run in that context
+ * after the redirect.
+ */
 export async function redirectToRequestor(
   accessGrantVcId: UrlString | URL,
   redirectUrl: UrlString | URL,

--- a/src/manage/redirectToRequestor.ts
+++ b/src/manage/redirectToRequestor.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2022 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { UrlString } from "@inrupt/solid-client";
+import { RedirectOptions, redirectWithParameters } from "../util/redirect";
+
+export const GRANT_VC_PARAM_NAME = "accessGrant";
+
+export async function redirectToRequestor(
+  accessGrantVcId: UrlString | URL,
+  redirectUrl: UrlString | URL,
+  options: RedirectOptions = {}
+): Promise<void> {
+  return redirectWithParameters(
+    redirectUrl.toString(),
+    {
+      [`${GRANT_VC_PARAM_NAME}`]: encodeURI(accessGrantVcId.toString()),
+    },
+    options
+  );
+}
+
+export default redirectToRequestor;

--- a/src/util/redirect.ts
+++ b/src/util/redirect.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2022 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { UrlString } from "@inrupt/solid-client";
+
+export type RedirectOptions = {
+  redirectCallback?: (url: string) => void;
+};
+
+/**
+ * Internal function implementing redirection with some query parameters.
+ *
+ * @hidden
+ */
+export async function redirectWithParameters(
+  target: UrlString,
+  queryParams: Record<string, string>,
+  options: RedirectOptions
+): Promise<void> {
+  const targetUrl = new URL(target);
+
+  Object.entries(queryParams).forEach(([key, value]) => {
+    targetUrl.searchParams.append(key, value);
+  });
+
+  if (options.redirectCallback !== undefined) {
+    options.redirectCallback(targetUrl.href);
+  } else {
+    if (typeof window === "undefined") {
+      throw new Error(
+        "In a non-browser environment, a redirectCallback must be provided by the user."
+      );
+    }
+    window.location.href = targetUrl.href;
+  }
+  // This redirects the user away from the app, so unless it throws an error,
+  // there is no code that should run afterwards (since there is no "after" in
+  // script's lifetime). Hence, this Promise never resolves:
+  return new Promise(() => undefined);
+}


### PR DESCRIPTION
This function abstracts away the query parameter returned to the requestor via the redirect. It is very similar to `redirectToAccessManagementUi`, which is already part of the API, except it's meant for the access management app to call in order to redirect users to the client requesting access with the grant VC IRI.

Note that returning the VC IRI, and not the VC value, is not consistent with the current behaviour, but it is the behaviour we actually desire. The redirection from the requestor to the access management will be fixed in a different PR, and functions abstracting the interaction with query params will be added too.

Open question for reviewers: should redirecting always return a never resolving promise, or should it do so only in the browser ? In this case, it would make sense that the redirect callback provided in Node would be async, and redirecting would return the result of that callback. 

# Checklist

- [X] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).