### PR TITLE
Add includeExpiredGrants options to grant request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The following changes have been implemented but not released yet:
 
 ### New features
 
--
+- `getAccessGrantAll` supports a new option, `includeExpiredGrants`. By default,
+  only grants that are still valid are returned by the VC provider. If set to true,
+  grants that have expired will also be included in the response.
 
 ### Bugfix
 

--- a/e2e/browser/src/package-lock.json
+++ b/e2e/browser/src/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@inrupt/prism-react-components": "^0.13.1-alpha.2",
-        "@inrupt/solid-client": "^1.18.0",
+        "@inrupt/solid-client": "^1.20.1",
         "@inrupt/solid-client-access-grants": "*",
         "@inrupt/solid-ui-react": "^2.7.0",
         "@material-ui/core": "^4.12.3",
@@ -99,12 +99,12 @@
       }
     },
     "node_modules/@inrupt/solid-client": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.18.0.tgz",
-      "integrity": "sha512-KHr/XesIiIWXbc973x9RI+eqjvWtKwWcX0mFHdg0nIxRpOQEvUrzhPhrZQ0s1a1t5Qq6yI6608TcZ05qA1oxqw==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.20.1.tgz",
+      "integrity": "sha512-io8Aw6SHm2OeTtvy4MuqNQmFwCyzpwWz5ZAWfyDgGqFEvc6vKv3bYr4YBY5jGh0uI4LHSJ9iFd5PKbVdmD7c9A==",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
-        "@rdfjs/types": "^1.0.1",
+        "@rdfjs/types": "^1.1.0",
         "@types/n3": "^1.10.0",
         "@types/rdfjs__dataset": "^1.0.4",
         "cross-fetch": "^3.0.4",
@@ -516,9 +516,9 @@
       }
     },
     "node_modules/@rdfjs/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-YxVkH0XrCNG3MWeZxfg596GFe+oorTVusmNxRP6ZHTsGczZ8AGvG3UchRNkg3Fy4MyysI7vBAA5YZbESL+VmHQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -685,11 +685,11 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "dependencies": {
-        "node-fetch": "2.6.1"
+        "node-fetch": "2.6.7"
       }
     },
     "node_modules/crypto-js": {
@@ -1178,11 +1178,22 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-assign": {
@@ -1472,6 +1483,11 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "node_modules/typescript": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
@@ -1507,6 +1523,20 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/xtend": {
@@ -1580,12 +1610,12 @@
       }
     },
     "@inrupt/solid-client": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.18.0.tgz",
-      "integrity": "sha512-KHr/XesIiIWXbc973x9RI+eqjvWtKwWcX0mFHdg0nIxRpOQEvUrzhPhrZQ0s1a1t5Qq6yI6608TcZ05qA1oxqw==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.20.1.tgz",
+      "integrity": "sha512-io8Aw6SHm2OeTtvy4MuqNQmFwCyzpwWz5ZAWfyDgGqFEvc6vKv3bYr4YBY5jGh0uI4LHSJ9iFd5PKbVdmD7c9A==",
       "requires": {
         "@rdfjs/dataset": "^1.1.0",
-        "@rdfjs/types": "^1.0.1",
+        "@rdfjs/types": "^1.1.0",
         "@types/n3": "^1.10.0",
         "@types/rdfjs__dataset": "^1.0.4",
         "cross-fetch": "^3.0.4",
@@ -1824,9 +1854,9 @@
       }
     },
     "@rdfjs/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-YxVkH0XrCNG3MWeZxfg596GFe+oorTVusmNxRP6ZHTsGczZ8AGvG3UchRNkg3Fy4MyysI7vBAA5YZbESL+VmHQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
       "requires": {
         "@types/node": "*"
       }
@@ -1960,11 +1990,11 @@
       "integrity": "sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g=="
     },
     "cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "requires": {
-        "node-fetch": "2.6.1"
+        "node-fetch": "2.6.7"
       }
     },
     "crypto-js": {
@@ -2345,9 +2375,12 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "object-assign": {
       "version": "4.1.1",
@@ -2569,6 +2602,11 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "typescript": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
@@ -2592,6 +2630,20 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/e2e/browser/src/package.json
+++ b/e2e/browser/src/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@inrupt/prism-react-components": "^0.13.1-alpha.2",
-    "@inrupt/solid-client": "^1.18.0",
+    "@inrupt/solid-client": "^1.20.1",
     "@inrupt/solid-client-access-grants": "*",
     "@inrupt/solid-ui-react": "^2.7.0",
     "@material-ui/core": "^4.12.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@inrupt/solid-client": "^1.18.0",
         "@inrupt/solid-client-authn-core": "^1.11.2",
-        "@inrupt/solid-client-vc": "^0.4.0",
+        "@inrupt/solid-client-vc": "^0.5.0",
         "auth-header": "^1.0.0",
         "cross-fetch": "^3.1.4",
         "events": "^3.3.0",
@@ -2002,9 +2002,9 @@
       }
     },
     "node_modules/@inrupt/solid-client-vc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.4.0.tgz",
-      "integrity": "sha512-PYmhTXSbbP6u23d/M74chIHKOvTO5zrFomjRF3fIRUVlBwUku/LokESXQL/80h0DkAOHQvXhQ9Noo2HPgnSVbA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.5.0.tgz",
+      "integrity": "sha512-Rglf0I47hhkZ/kOjM2Vtxph6sh8ZzxHN/vUOYOMZR/fiRtN8DotCFASBZ3qgMbRYmroKCxs8QDEHF36sq3ftrQ==",
       "dependencies": {
         "@inrupt/solid-client": "^1.15.0",
         "cross-fetch": "^3.1.4"
@@ -15367,9 +15367,9 @@
       }
     },
     "@inrupt/solid-client-vc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.4.0.tgz",
-      "integrity": "sha512-PYmhTXSbbP6u23d/M74chIHKOvTO5zrFomjRF3fIRUVlBwUku/LokESXQL/80h0DkAOHQvXhQ9Noo2HPgnSVbA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.5.0.tgz",
+      "integrity": "sha512-Rglf0I47hhkZ/kOjM2Vtxph6sh8ZzxHN/vUOYOMZR/fiRtN8DotCFASBZ3qgMbRYmroKCxs8QDEHF36sq3ftrQ==",
       "requires": {
         "@inrupt/solid-client": "^1.15.0",
         "cross-fetch": "^3.1.4"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   "dependencies": {
     "@inrupt/solid-client": "^1.18.0",
     "@inrupt/solid-client-authn-core": "^1.11.2",
-    "@inrupt/solid-client-vc": "^0.4.0",
+    "@inrupt/solid-client-vc": "^0.5.0",
     "auth-header": "^1.0.0",
     "cross-fetch": "^3.1.4",
     "events": "^3.3.0",

--- a/src/manage/getAccessGrantAll.test.ts
+++ b/src/manage/getAccessGrantAll.test.ts
@@ -174,7 +174,7 @@ describe("getAccessGrantAll", () => {
 
   it("Calls @inrupt/solid-client-vc/getVerifiableCredentialAllFromShape with the expiration filter if specified", async () => {
     await getAccessGrantAll(resource.href, undefined, {
-      includeExpiredGrants: true,
+      includeExpired: true,
     });
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
       "https://some.api.endpoint/derive",

--- a/src/manage/getAccessGrantAll.test.ts
+++ b/src/manage/getAccessGrantAll.test.ts
@@ -171,4 +171,18 @@ describe("getAccessGrantAll", () => {
       }
     );
   });
+
+  it("Calls @inrupt/solid-client-vc/getVerifiableCredentialAllFromShape with the expiration filter if specified", async () => {
+    await getAccessGrantAll(resource.href, undefined, {
+      includeExpiredGrants: true,
+    });
+    expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
+      "https://some.api.endpoint/derive",
+      expect.anything(),
+      {
+        fetch: clientAuthnFetch,
+        includeExpiredVc: true,
+      }
+    );
+  });
 });

--- a/src/manage/getAccessGrantAll.ts
+++ b/src/manage/getAccessGrantAll.ts
@@ -50,7 +50,7 @@ async function getAccessGrantAll(
       requestor: string;
     }
   > = {},
-  options: AccessBaseOptions = {}
+  options: AccessBaseOptions & { includeExpiredGrants?: boolean } = {}
 ): Promise<Array<VerifiableCredential>> {
   const sessionFetch = await getSessionFetch(options);
 
@@ -83,6 +83,7 @@ async function getAccessGrantAll(
     vcShape as Partial<VerifiableCredential>,
     {
       fetch: sessionFetch,
+      includeExpiredVc: options.includeExpiredGrants,
     }
   );
 }

--- a/src/manage/getAccessGrantAll.ts
+++ b/src/manage/getAccessGrantAll.ts
@@ -39,7 +39,12 @@ import { BaseGrantBody } from "../type/AccessVerifiableCredential";
  *
  * @param resource The URL of a resource to which access grants might have been issued.
  * @param grantShape The properties of grants to filter results.
- * @param options Optional properties to customise the request behaviour.
+ * @param options Optional parameter:
+ * - `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * This can be typically used for authentication. Note that if it is omitted, and
+ * `@inrupt/solid-client-authn-browser` is in your dependencies, the default session
+ * is picked up.
+ * - `options.includeExpiredGrants`: include expired grants in the result set.
  * @returns A void promise.
  * @since 0.4.0
  */

--- a/src/manage/getAccessGrantAll.ts
+++ b/src/manage/getAccessGrantAll.ts
@@ -55,7 +55,7 @@ async function getAccessGrantAll(
       requestor: string;
     }
   > = {},
-  options: AccessBaseOptions & { includeExpiredGrants?: boolean } = {}
+  options: AccessBaseOptions & { includeExpired?: boolean } = {}
 ): Promise<Array<VerifiableCredential>> {
   const sessionFetch = await getSessionFetch(options);
 
@@ -88,7 +88,7 @@ async function getAccessGrantAll(
     vcShape as Partial<VerifiableCredential>,
     {
       fetch: sessionFetch,
-      includeExpiredVc: options.includeExpiredGrants,
+      includeExpiredVc: options.includeExpired,
     }
   );
 }


### PR DESCRIPTION
By default, only grants that are still valid are returned when calling `getAccessGrantAll`. This adds a new `includeExpiredGrants` option to this function. When set to true, grants that have expired will also be included in the response.

Note: only opening this as a draft until the underlying VC library is released with this new feature.

# Checklist

- [X] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
