### PR TITLE
Align token claim with UMA spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The following changes have been implemented but not released yet:
 
 -
 
+### Bugfix
+
+- When using an Access Grant to get an Access Token, one of the claims from the
+  server response was unaligned with the spec. This inconsistency has been fixed on
+  the server-side with backwards-compatibility, and now on the client side too. This
+  change is transparent to users.
+
 ## [0.5.0](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v0.5.0) - 2022-03-01
 
 ### New features

--- a/src/fetch/index.test.ts
+++ b/src/fetch/index.test.ts
@@ -171,7 +171,7 @@ describe("exchangeTicketForAccessToken", () => {
       },
       body: simpleFormUrlEncoded({
         claim_token: btoa(JSON.stringify({ verifiableCredential: [MOCK_VC] })),
-        claim_token_type: "https://www.w3.org/TR/vc-data-model/#json-ld",
+        claim_token_format: "https://www.w3.org/TR/vc-data-model/#json-ld",
         grant_type: "urn:ietf:params:oauth:grant-type:uma-ticket",
         ticket: authTicket,
       }),

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -107,7 +107,7 @@ export async function exchangeTicketForAccessToken(
     },
     body: simpleFormUrlEncoded({
       claim_token: btoa(JSON.stringify(credentialPresentation)),
-      claim_token_type: VC_CLAIM_TOKEN_TYPE,
+      claim_token_format: VC_CLAIM_TOKEN_TYPE,
       grant_type: UMA_GRANT_TYPE,
       ticket: authTicket,
     }),


### PR DESCRIPTION
Specifying the token type should be done using the `claim_token_format` claim, as per the [UMA specification](https://docs.kantarainitiative.org/uma/wg/rec-oauth-uma-grant-2.0.html#uma-grant-type). The former value `claim_token_type` has been replaced.

# Checklist

- [X] All acceptance criteria are met.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).