### PR TITLE
Fix new option name in the Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The following changes have been implemented but not released yet:
 
 ### New features
 
-- `getAccessGrantAll` supports a new option, `includeExpiredGrants`. By default,
+- `getAccessGrantAll` supports a new option, `includeExpired`. By default,
   only grants that are still valid are returned by the VC provider. If set to true,
   grants that have expired will also be included in the response.
 


### PR DESCRIPTION
I prematurely clicked merge on the PR including this change and left an incorrect name in the changelog.