### PR TITLE
Use default fetch consistently approving request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The following changes have been implemented but not released yet:
   server response was unaligned with the spec. This inconsistency has been fixed on
   the server-side with backwards-compatibility, and now on the client side too. This
   change is transparent to users.
+- `approveAccessRequest` wasn't using the default session from `@inrupt/solid-client-authn-browser`
+  to set the ACR access appropriately, resulting in `401 Unauthenticated` errors.
 
 ## [0.5.0](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v0.5.0) - 2022-03-01
 

--- a/src/manage/approveAccessRequest.test.ts
+++ b/src/manage/approveAccessRequest.test.ts
@@ -72,13 +72,15 @@ const mockAcpClient = (
     options?.updatedResource ?? {}
   );
   solidClientModule.acp_v4.getResourceInfoWithAcr.mockResolvedValueOnce(
-    (options?.initialResource ?? {}) as never
+    options?.initialResource ?? {}
   );
+  solidClientModule.acp_v4.saveAcrFor = jest.fn();
+  return solidClientModule;
 };
 
 describe("approveAccessRequest", () => {
   it("falls back to @inrupt/solid-client-authn-browser if no fetch function was passed", async () => {
-    mockAcpClient();
+    const mockedAcpClient = mockAcpClient();
     const crossFetchModule = jest.requireMock("cross-fetch") as {
       fetch: typeof global.fetch;
     };
@@ -96,6 +98,12 @@ describe("approveAccessRequest", () => {
 
     await approveAccessRequest(mockAccessRequestVc());
 
+    expect(mockedAcpClient.acp_v4.saveAcrFor).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        fetch: scab.fetch,
+      }
+    );
     expect(mockedIssue).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),


### PR DESCRIPTION
When approving an access request, the library must also change the ACR associated to the resource so that it explicitly supports being accessed by an agent providing an Access Grant. In the case when the calling library is relying on `@inrupt/solid-client-authn-browser` being present and picked up by the VC library, the same assumption is now extended to modifying the ACR: previously, the call to the ACR was unauthenticated. Now, if sca-b is in the app's dependencies, the default session is picked up.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).