### PR TITLE
Fixes deserialization of the VC request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ The following changes have been implemented but not released yet:
 - `approveAccessRequest` wasn't using the default session from `@inrupt/solid-client-authn-browser`
   to set the ACR access appropriately, resulting in `401 Unauthenticated` errors.
 - `getAccessRequestFromRedirectUrl` was deserializing the received VC expecting
-an URL-encoded value, instead of a base64-encoded value, which is how it is serialized
-when redirecting the user to the VC management app.
+  an URL-encoded value, instead of a base64-encoded value, which is how it is serialized
+  when redirecting the user to the VC management app.
 
 ## [0.5.0](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v0.5.0) - 2022-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The following changes have been implemented but not released yet:
   change is transparent to users.
 - `approveAccessRequest` wasn't using the default session from `@inrupt/solid-client-authn-browser`
   to set the ACR access appropriately, resulting in `401 Unauthenticated` errors.
+- `getAccessRequestFromRedirectUrl` was deserializing the received VC expecting
+an URL-encoded value, instead of a base64-encoded value, which is how it is serialized
+when redirecting the user to the VC management app.
 
 ## [0.5.0](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v0.5.0) - 2022-03-01
 

--- a/src/manage/getAccessRequestFromRedirectUrl.test.ts
+++ b/src/manage/getAccessRequestFromRedirectUrl.test.ts
@@ -162,7 +162,7 @@ describe("getAccessRequestFromRedirectUrl", () => {
     const redirectUrl = new URL("https://redirect.url");
     redirectUrl.searchParams.append(
       "requestVc",
-      encodeURIComponent(JSON.stringify(mockAccessGrantVc()))
+      btoa(JSON.stringify(mockAccessGrantVc()))
     );
     redirectUrl.searchParams.append(
       "redirectUrl",
@@ -181,7 +181,7 @@ describe("getAccessRequestFromRedirectUrl", () => {
     const redirectUrl = new URL("https://redirect.url");
     redirectUrl.searchParams.append(
       "requestVc",
-      encodeURIComponent(JSON.stringify({ someJson: "but not a VC" }))
+      btoa(JSON.stringify({ someJson: "but not a VC" }))
     );
     redirectUrl.searchParams.append(
       "redirectUrl",

--- a/src/manage/getAccessRequestFromRedirectUrl.ts
+++ b/src/manage/getAccessRequestFromRedirectUrl.ts
@@ -84,7 +84,7 @@ export async function getAccessRequestFromRedirectUrl(
   // If the value is provided directly, no fetch is required. Providing the value
   // is deprecated though.
   const accessRequest = accessRequestValue
-    ? JSON.parse(decodeURIComponent(accessRequestValue))
+    ? JSON.parse(atob(accessRequestValue))
     : await getVerifiableCredential(accessRequestIri as string, {
         fetch: authFetch,
       });


### PR DESCRIPTION
The VC was deserialized expecting an URL-encoded value, instead of a base-64 encoded one.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).