### PR TITLE
Denied access grants are access grants too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The following changes have been implemented but not released yet:
 
 ### Bugfix
 
+- When type-checking an Access Grant (e.g. using `getAccessGrant`), only accepted
+  Grants were supported. Support for denied Grant has now been added.
 - When using an Access Grant to get an Access Token, one of the claims from the
   server response was unaligned with the spec. This inconsistency has been fixed on
   the server-side with backwards-compatibility, and now on the client side too. This

--- a/src/guard/isAccessGrant.ts
+++ b/src/guard/isAccessGrant.ts
@@ -19,7 +19,10 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { GC_CONSENT_STATUS_EXPLICITLY_GIVEN } from "../constants";
+import {
+  GC_CONSENT_STATUS_DENIED,
+  GC_CONSENT_STATUS_EXPLICITLY_GIVEN,
+} from "../constants";
 import {
   AccessGrantBody,
   BaseAccessVcBody,
@@ -30,8 +33,9 @@ export function isAccessGrant(
 ): vc is BaseAccessVcBody & AccessGrantBody {
   return (
     (vc as AccessGrantBody).credentialSubject.providedConsent !== undefined &&
-    (vc as AccessGrantBody).credentialSubject.providedConsent.hasStatus ===
-      GC_CONSENT_STATUS_EXPLICITLY_GIVEN &&
+    [GC_CONSENT_STATUS_EXPLICITLY_GIVEN, GC_CONSENT_STATUS_DENIED].includes(
+      (vc as AccessGrantBody).credentialSubject.providedConsent.hasStatus
+    ) &&
     typeof (vc as AccessGrantBody).credentialSubject.providedConsent
       .isProvidedTo === "string"
   );

--- a/src/manage/getAccessGrant.test.ts
+++ b/src/manage/getAccessGrant.test.ts
@@ -108,6 +108,21 @@ describe("getAccessGrant", () => {
     );
   });
 
+  it("supports denied access grants with a given IRI", async () => {
+    mockAccessApiEndpoint();
+    const mockedAccessGrant = mockAccessGrantVc();
+    mockedAccessGrant.credentialSubject.providedConsent.hasStatus =
+      "https://w3id.org/GConsent#ConsentStatusDenied";
+    const mockedFetch = jest
+      .fn(global.fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify(mockedAccessGrant)));
+
+    const accessGrant = await getAccessGrant("https://some.vc.url", {
+      fetch: mockedFetch,
+    });
+    expect(accessGrant).toEqual(mockedAccessGrant);
+  });
+
   it("returns the access grant with the given IRI", async () => {
     mockAccessApiEndpoint();
     const mockedAccessGrant = mockAccessGrantVc();


### PR DESCRIPTION
The access grant type guard was too strict, and enforced the access grant status only to be accepted, while denied is also valid.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).