### PR TITLE
Add support for resource owner in access requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The following changes have been implemented but not released yet:
 - `getAccessGrantAll` supports a new option, `includeExpired`. By default,
   only grants that are still valid are returned by the VC provider. If set to true,
   grants that have expired will also be included in the response.
+- `issueAccessRequest` now generates an access request VC including the resource
+  owner in the `hasConsent` field with the `isConsentForDataSubject` predicate. This
+  will enable resource owners to dereference access requests IRIs to their resources.
 
 ### Bugfix
 

--- a/src/discover/getAccessApiEndpoint.test.ts
+++ b/src/discover/getAccessApiEndpoint.test.ts
@@ -23,7 +23,7 @@
 import { jest, describe, it, expect } from "@jest/globals";
 import {
   MOCKED_ACCESS_ISSUER,
-  MOCK_REQUESTEE_IRI,
+  MOCK_RESOURCE_OWNER_IRI,
   mockAccessApiEndpoint,
 } from "../request/request.mock";
 
@@ -35,13 +35,13 @@ jest.mock("cross-fetch");
 describe("getAccessApiEndpoint", () => {
   it("can find the access endpoint for a given resource", async () => {
     mockAccessApiEndpoint();
-    const accessEndpoint = await getAccessApiEndpoint(MOCK_REQUESTEE_IRI);
+    const accessEndpoint = await getAccessApiEndpoint(MOCK_RESOURCE_OWNER_IRI);
     expect(accessEndpoint).toBe(MOCKED_ACCESS_ISSUER);
   });
 
   it("can find the access endpoint via the accessEndpoint option", async () => {
     mockAccessApiEndpoint();
-    const accessEndpoint = await getAccessApiEndpoint(MOCK_REQUESTEE_IRI, {
+    const accessEndpoint = await getAccessApiEndpoint(MOCK_RESOURCE_OWNER_IRI, {
       accessEndpoint: "https://access.inrupt.com",
     });
     expect(accessEndpoint).toBe("https://access.inrupt.com");
@@ -58,7 +58,7 @@ describe("getAccessApiEndpoint", () => {
       fetch: typeof global.fetch;
     };
     crossFetchModule.fetch = mockedFetch;
-    await expect(getAccessApiEndpoint(MOCK_REQUESTEE_IRI)).rejects.toThrow(
+    await expect(getAccessApiEndpoint(MOCK_RESOURCE_OWNER_IRI)).rejects.toThrow(
       "Expected a 401 error with a WWW-Authenticate header, got a [200: Ok] response lacking the WWW-Authenticate header"
     );
   });
@@ -76,7 +76,7 @@ describe("getAccessApiEndpoint", () => {
       fetch: typeof global.fetch;
     };
     crossFetchModule.fetch = mockedFetch;
-    await expect(getAccessApiEndpoint(MOCK_REQUESTEE_IRI)).rejects.toThrow(
+    await expect(getAccessApiEndpoint(MOCK_RESOURCE_OWNER_IRI)).rejects.toThrow(
       "Unsupported authorization scheme: [someScheme]"
     );
   });
@@ -103,7 +103,7 @@ describe("getAccessApiEndpoint", () => {
       fetch: typeof global.fetch;
     };
     crossFetchModule.fetch = mockedFetch;
-    await expect(getAccessApiEndpoint(MOCK_REQUESTEE_IRI)).rejects.toThrow(
+    await expect(getAccessApiEndpoint(MOCK_RESOURCE_OWNER_IRI)).rejects.toThrow(
       /No access issuer listed for property \[verifiable_credential_issuer\] in.*some_property.*some value/
     );
   });

--- a/src/guard/isAccessRequest.ts
+++ b/src/guard/isAccessRequest.ts
@@ -29,6 +29,7 @@ export function isAccessRequest(
   return (
     isBaseAccessRequestVerifiableCredential(x) &&
     x.credentialSubject.hasConsent.hasStatus === GC_CONSENT_STATUS_REQUESTED &&
+    x.credentialSubject.hasConsent.isConsentForDataSubject !== undefined &&
     typeof x.issuanceDate === "string"
   );
 }

--- a/src/manage/approveAccessRequest.mock.ts
+++ b/src/manage/approveAccessRequest.mock.ts
@@ -43,6 +43,7 @@ export const mockAccessRequestVc = (
         forPersonalData: options?.resources ?? ["https://some.resource"],
         hasStatus: "https://w3id.org/GConsent#ConsentStatusRequested",
         mode: options?.modes ?? ["http://www.w3.org/ns/auth/acl#Read"],
+        isConsentForDataSubject: "https://some.pod/profile#you",
       },
       inbox: "https://some.inbox",
     },

--- a/src/request/request.mock.ts
+++ b/src/request/request.mock.ts
@@ -39,7 +39,7 @@ export const MOCKED_CREDENTIAL_ID = "https://some.credential";
 export const MOCKED_ISSUANCE_DATE = "2021-09-07T09:59:00Z";
 export const MOCK_REQUESTOR_IRI = "https://some.pod/profile#me";
 export const MOCK_REQUESTOR_INBOX = "https://some.pod/consent/inbox";
-export const MOCK_REQUESTEE_IRI = "https://some.pod/profile#you";
+export const MOCK_RESOURCE_OWNER_IRI = "https://some.pod/profile#you";
 
 export const mockAccessGrant = (
   issuer: string,

--- a/src/type/AccessVerifiableCredential.ts
+++ b/src/type/AccessVerifiableCredential.ts
@@ -30,15 +30,19 @@ import type { ResourceAccessMode } from "./ResourceAccessMode";
 import type { GConsentStatus } from "./GConsentStatus";
 import type { AccessCredentialType } from "./AccessCredentialType";
 
-export type GConsentRequestAttributes = {
+export type GConsentAttributes = {
   mode: ResourceAccessMode[];
   hasStatus: GConsentStatus;
   forPersonalData: UrlString[];
   forPurpose?: UrlString[];
 };
 
-export type GConsentGrantAttributes = GConsentRequestAttributes & {
+export type GConsentGrantAttributes = GConsentAttributes & {
   isProvidedTo: UrlString;
+};
+
+export type GConsentRequestAttributes = GConsentAttributes & {
+  isConsentForDataSubject?: UrlString;
 };
 
 export type CredentialSubject = {

--- a/src/type/IssueAccessRequestParameters.ts
+++ b/src/type/IssueAccessRequestParameters.ts
@@ -23,8 +23,8 @@
  * @module interfaces
  */
 
-import type { UrlString, WebId } from "@inrupt/solid-client";
-import { AccessModes } from "./AccessModes";
+import type { WebId } from "@inrupt/solid-client";
+import { InputAccessRequestParameters } from "./Parameter";
 
 /**
  * Required parameters to request access to one or more Resources.
@@ -44,15 +44,7 @@ import { AccessModes } from "./AccessModes";
 // TODO: Find out about the overlap with BaseRequestParameters (differs in status and resource owner)
 // This parameter if not present should be fetched from the profile according to the design document
 // TODO: Get rid of BaseRequestParameters in favour of this
-export interface IssueAccessRequestParameters {
-  access: AccessModes;
-  requestorInboxUrl?: UrlString;
-  resourceOwner: WebId;
-  resources: Array<UrlString>;
-  purpose?: Array<UrlString>;
-  issuanceDate?: Date;
-  expirationDate?: Date;
-}
+export type IssueAccessRequestParameters = InputAccessRequestParameters;
 
 /**
  * @hidden

--- a/src/type/Parameter.ts
+++ b/src/type/Parameter.ts
@@ -23,29 +23,34 @@
  * @module interfaces
  */
 
-import { UrlString } from "@inrupt/solid-client";
+import type { UrlString } from "@inrupt/solid-client";
+
 import type {
   GC_CONSENT_STATUS_REQUESTED,
   GC_CONSENT_STATUS_EXPLICITLY_GIVEN,
 } from "../constants";
-import type { GConsentStatus } from "./GConsentStatus";
 import { AccessModes } from "./AccessModes";
 
 export interface BaseRequestParameters {
   access: AccessModes;
   requestorInboxUrl?: UrlString;
   resources: Array<UrlString>;
-  status: GConsentStatus;
   purpose?: Array<UrlString>;
   issuanceDate?: Date;
   expirationDate?: Date;
 }
 
-export interface AccessRequestParameters extends BaseRequestParameters {
+export interface InputAccessRequestParameters extends BaseRequestParameters {
+  resourceOwner: UrlString;
+}
+export interface AccessRequestParameters extends InputAccessRequestParameters {
   status: typeof GC_CONSENT_STATUS_REQUESTED;
 }
 
-export interface AccessGrantParameters extends BaseRequestParameters {
-  status: typeof GC_CONSENT_STATUS_EXPLICITLY_GIVEN;
+export interface InputAccessGrantParameters extends BaseRequestParameters {
   requestor: UrlString;
+}
+
+export interface AccessGrantParameters extends InputAccessGrantParameters {
+  status: typeof GC_CONSENT_STATUS_EXPLICITLY_GIVEN;
 }

--- a/src/util/issueAccessVc.ts
+++ b/src/util/issueAccessVc.ts
@@ -76,9 +76,12 @@ function getGConsentAttributes(
     return {
       ...consentAttributes,
       isProvidedTo: (params as AccessGrantParameters).requestor,
-    } as GConsentGrantAttributes;
+    };
   }
-  return consentAttributes;
+  return {
+    ...consentAttributes,
+    isConsentForDataSubject: (params as AccessRequestParameters).resourceOwner,
+  };
 }
 
 function getBaseBody(


### PR DESCRIPTION
This alters how access requests are created: the resource owner is now part of the requested consent, using the predicate `isConsentForDataSubject`. Note that the resource owner was already provided as an input to `issueAccessRequest`, but this parameter wasn't used when constructing the access request. This discrepency is now resolved, as the consent VC issuer now requires the resource owner to be present in the access request.

The rationale for the resource owner being in the access request being access control: the VC holder checks predefined property paths in order to verify if a given request should be given access to a given VC based on the WebID of the authenticated agent who issued the request.

# Checklist

- [X] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).