### PR TITLE
chore: replace GH_TOKEN secret with GITHUB_TOKEN from actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,7 +33,7 @@ jobs:
           # The deployment runs in parallel with CI, so status checks will never have succeeded yet:
           required_contexts: "[]"
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Determine npm tag
         id: determine-npm-tag
         run: |
@@ -62,7 +62,7 @@ jobs:
           state: in_progress
           mediaType: '{"previews": ["flash", "ant-man"]}'
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/setup-node@v3
         with:
           node-version: "16.x"
@@ -108,7 +108,7 @@ jobs:
           mediaType: '{"previews": ["flash", "ant-man"]}'
           state: success
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Mark GitHub Deployment as failed
         uses: octokit/request-action@v2.x
         if: failure()
@@ -122,7 +122,7 @@ jobs:
           mediaType: '{"previews": ["flash", "ant-man"]}'
           state: failure
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Waiting for npm CDNs to update...
         run: |
           echo "Giving npm some time to make the newly-published package available…"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           # The deployment runs in parallel with CI, so status checks will never have succeeded yet:
           required_contexts: "[]"
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
   publish-npm:
     runs-on: ubuntu-20.04
@@ -47,7 +47,7 @@ jobs:
           state: in_progress
           mediaType: '{"previews": ["flash", "ant-man"]}'
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Prepare for publication to npm
         uses: actions/setup-node@v3
         with:
@@ -75,7 +75,7 @@ jobs:
           mediaType: '{"previews": ["flash", "ant-man"]}'
           state: success
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Mark GitHub Deployment as failed
         uses: octokit/request-action@v2.x
         if: failure()
@@ -89,7 +89,7 @@ jobs:
           mediaType: '{"previews": ["flash", "ant-man"]}'
           state: failure
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Waiting for npm CDNs to update...
         run: |
           echo "Giving npm some time to make the newly-published package available…"


### PR DESCRIPTION
We were previously using a custom github token from actions for controlling deployments, this can be done with the `GITHUB_TOKEN` secret from Actions.