### PR TITLE
Improve access return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### New features
+
+- `approveAccessRequest`, `getAccessGrant`, `getAccessGrantFromRedirectUrl` now accurately return an `AccessGrant`.
+- `getAccessRequestFromRedirectUrl` now accurately return an `AccessRequest`.
+
 ## [1.0.1](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v1.0.0) - 2022-06-06
 
 ### New features

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,18 +163,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
-      "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
@@ -200,27 +188,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.10.tgz",
-      "integrity": "sha512-wDeej0pu3WN/ffTxMNCPW5UCiOav8IcLRxSIyp/9+IF2xJUM9h/OYjg0IJLHaL6F8oU8kqMz9nc1vryXhMsgXg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.16.7",
-        "@babel/helper-member-expression-to-functions": "^7.16.7",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/helper-replace-supers": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -273,18 +240,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.7.tgz",
-      "integrity": "sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
@@ -316,39 +271,11 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
-      "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
       "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz",
-      "integrity": "sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-member-expression-to-functions": "^7.16.7",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -360,18 +287,6 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
-      "integrity": "sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -461,153 +376,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/plugin-proposal-class-properties": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz",
-      "integrity": "sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-dynamic-import": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz",
-      "integrity": "sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-export-namespace-from": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.7.tgz",
-      "integrity": "sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.7.tgz",
-      "integrity": "sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.7.tgz",
-      "integrity": "sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-numeric-separator": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz",
-      "integrity": "sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-optional-chaining": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.7.tgz",
-      "integrity": "sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-private-methods": {
-      "version": "7.16.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.11.tgz",
-      "integrity": "sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.16.10",
-        "@babel/helper-plugin-utils": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.7.tgz",
-      "integrity": "sha512-rMQkjcOFbm+ufe3bTZLyOfsOUOxyvLXZJCTARhJr+8UMSoZmqTe1K1BgkFcrW37rAchWg57yI69ORxiWvUINuQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-create-class-features-plugin": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
@@ -639,30 +407,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-dynamic-import": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-export-namespace-from": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -764,21 +508,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-private-property-in-object": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.13.tgz",
@@ -798,58 +527,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.8.tgz",
-      "integrity": "sha512-oflKPvsLT2+uKQopesJt3ApiaIS2HW+hzHFcwRNtyDGieAeC/dIHZX8buJQ2J2X1rxGPy4eRcUijm3qcSPjYcA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/helper-simple-access": "^7.16.7",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz",
-      "integrity": "sha512-bHdQ9k7YpBDO2d0NVfkj51DpQcvwIzIusJ7mEUaMlbZq3Kt/U47j24inXZHQ5MDiYpCs+oZiwnXyKedE8+q7AQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-typescript": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/preset-typescript": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz",
-      "integrity": "sha512-WbVEmgXdIyvzB77AQjGBEyYPZx+8tTsO50XtfozQrkW8QB2rLJpH2lgx0TRw5EJrBxOZQ+wCcyPVQvS8tjEHpQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/helper-validator-option": "^7.16.7",
-        "@babel/plugin-transform-typescript": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1760,135 +1437,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.21.0.tgz",
-      "integrity": "sha512-jvgN3ZeAG6rw85z4u9Rc4uyj6qIaYlq2xrOtS7J2+CDYhzKOttab9ix9ELcvBOCHuQ6wgTfxfJYdh6DRZmQ9hg==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.22.2.tgz",
+      "integrity": "sha512-cCl96BEBGPtptFz7C2FOSN3PrTnJ3rPpENe+gYCMx4GNNDlN4tmo2D89y13feGKTMMAIVrXfSQ/UmaQKLy1XLA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "7.16.7",
-        "@babel/core": "7.16.12",
-        "@babel/helper-plugin-utils": "7.16.7",
-        "@babel/plugin-proposal-class-properties": "7.16.7",
-        "@babel/plugin-proposal-dynamic-import": "7.16.7",
-        "@babel/plugin-proposal-export-namespace-from": "7.16.7",
-        "@babel/plugin-proposal-logical-assignment-operators": "7.16.7",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "7.16.7",
-        "@babel/plugin-proposal-numeric-separator": "7.16.7",
-        "@babel/plugin-proposal-optional-chaining": "7.16.7",
-        "@babel/plugin-proposal-private-methods": "7.16.11",
-        "@babel/plugin-proposal-private-property-in-object": "7.16.7",
-        "@babel/plugin-syntax-async-generators": "7.8.4",
-        "@babel/plugin-syntax-json-strings": "7.8.3",
-        "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "7.8.3",
-        "@babel/plugin-transform-modules-commonjs": "7.16.8",
-        "@babel/preset-typescript": "7.16.7",
-        "colors": "1.4.0",
-        "commander": "8.3.0",
-        "debug": "4.3.3",
-        "expect": "27.2.5",
-        "jest-matcher-utils": "27.2.5",
-        "json5": "2.2.1",
-        "mime": "3.0.0",
-        "minimatch": "3.0.4",
-        "ms": "2.1.3",
-        "open": "8.4.0",
-        "pirates": "4.0.4",
-        "playwright-core": "1.21.0",
-        "rimraf": "3.0.2",
-        "source-map-support": "0.4.18",
-        "stack-utils": "2.0.5",
-        "yazl": "2.5.1"
+        "@types/node": "*",
+        "playwright-core": "1.22.2"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/@babel/core": {
-      "version": "7.16.12",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.12.tgz",
-      "integrity": "sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.16.8",
-        "@babel/helper-compilation-targets": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helpers": "^7.16.7",
-        "@babel/parser": "^7.16.12",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.10",
-        "@babel/types": "^7.16.8",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
-        "semver": "^6.3.0",
-        "source-map": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-      "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
-    "node_modules/@playwright/test/node_modules/pirates": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz",
-      "integrity": "sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "dependencies": {
-        "source-map": "^0.5.6"
+        "node": ">=14"
       }
     },
     "node_modules/@rdfjs/data-model": {
@@ -2199,16 +1760,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
       "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
       "dev": true
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.19.0",
@@ -2803,15 +2354,6 @@
         "@types/yargs-parser": "*"
       }
     },
-    "node_modules/babel-plugin-dynamic-import-node": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
-      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-      "dev": true,
-      "dependencies": {
-        "object.assign": "^4.1.0"
-      }
-    },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -2978,15 +2520,6 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -3174,15 +2707,6 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3193,15 +2717,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/commondir": {
@@ -3369,15 +2884,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -3525,15 +3031,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.4.0"
-      }
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
@@ -4216,95 +3713,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expect": {
-      "version": "27.2.5",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.5.tgz",
-      "integrity": "sha512-ZrO0w7bo8BgGoP/bLz+HDCI+0Hfei9jUSZs5yI/Wyn9VkG9w8oJ7rHRgYj+MA7yqqFa0IwHA3flJzZtYugShJA==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "^27.2.5",
-        "ansi-styles": "^5.0.0",
-        "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.2.5",
-        "jest-message-util": "^27.2.5",
-        "jest-regex-util": "^27.0.6"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/@jest/types": {
-      "version": "27.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.0.tgz",
-      "integrity": "sha512-oDHEp7gwSgA82RZ6pzUL3ugM2njP/lVB1MsxRZNOBk+CoNvh9SpH1lQixPFc/kDlV50v59csiW4HLixWmhmgPQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^16.0.0",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/@types/yargs": {
-      "version": "16.0.4",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/expect/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/fast-check": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-2.24.0.tgz",
@@ -4377,15 +3785,6 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "dev": true,
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fetch-blob": {
@@ -4939,12 +4338,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-      "dev": true
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -5013,21 +4406,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-docker": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
-      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
-      "dev": true,
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extglob": {
@@ -5191,18 +4569,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/isexe": {
@@ -6771,12 +6137,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/jpeg-js": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
-      "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==",
-      "dev": true
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7216,18 +6576,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
@@ -7567,23 +6915,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/open": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
-      "dev": true,
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/openid-client": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.3.tgz",
@@ -7787,12 +7118,6 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -7818,27 +7143,6 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pixelmatch": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
-      "integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
-      "dev": true,
-      "dependencies": {
-        "pngjs": "^4.0.1"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
-      }
-    },
-    "node_modules/pixelmatch/node_modules/pngjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.1.tgz",
-      "integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -7924,65 +7228,15 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.21.0.tgz",
-      "integrity": "sha512-yDGVs9qaaW6WiefgR7wH1CGt9D6D/X4U3jNpIzH0FjjrrWLCOYQo78Tu3SkW8X+/kWlBpj49iWf3QNSxhYc12Q==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.2.tgz",
+      "integrity": "sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==",
       "dev": true,
-      "dependencies": {
-        "colors": "1.4.0",
-        "commander": "8.3.0",
-        "debug": "4.3.3",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.0",
-        "jpeg-js": "0.4.3",
-        "mime": "3.0.0",
-        "pixelmatch": "5.2.1",
-        "pngjs": "6.0.0",
-        "progress": "2.0.3",
-        "proper-lockfile": "4.1.2",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "socks-proxy-agent": "6.1.1",
-        "stack-utils": "2.0.5",
-        "ws": "8.4.2",
-        "yauzl": "2.10.0",
-        "yazl": "2.5.1"
-      },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/playwright-core/node_modules/ws": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
-      "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -8052,38 +7306,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
-    },
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
-    },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -8305,15 +7532,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -8579,44 +7797,6 @@
       "dev": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
-      "dev": true,
-      "dependencies": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
-      "dev": true,
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.1",
-        "socks": "^2.6.1"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/source-map": {
@@ -9670,25 +8850,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "dev": true,
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yazl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-      "dev": true,
-      "dependencies": {
-        "buffer-crc32": "~0.2.3"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -9786,15 +8947,6 @@
         }
       }
     },
-    "@babel/helper-annotate-as-pure": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
-      "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
-    },
     "@babel/helper-compilation-targets": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
@@ -9813,21 +8965,6 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
-      }
-    },
-    "@babel/helper-create-class-features-plugin": {
-      "version": "7.16.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.10.tgz",
-      "integrity": "sha512-wDeej0pu3WN/ffTxMNCPW5UCiOav8IcLRxSIyp/9+IF2xJUM9h/OYjg0IJLHaL6F8oU8kqMz9nc1vryXhMsgXg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.16.7",
-        "@babel/helper-member-expression-to-functions": "^7.16.7",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/helper-replace-supers": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -9868,15 +9005,6 @@
         "@babel/types": "^7.16.7"
       }
     },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.7.tgz",
-      "integrity": "sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
-    },
     "@babel/helper-module-imports": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
@@ -9902,33 +9030,11 @@
         "@babel/types": "^7.16.7"
       }
     },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
-      "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
-    },
     "@babel/helper-plugin-utils": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
       "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
       "dev": true
-    },
-    "@babel/helper-replace-supers": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz",
-      "integrity": "sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-member-expression-to-functions": "^7.16.7",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
-      }
     },
     "@babel/helper-simple-access": {
       "version": "7.16.7",
@@ -9937,15 +9043,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
-      "integrity": "sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -10010,99 +9107,6 @@
       "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
       "dev": true
     },
-    "@babel/plugin-proposal-class-properties": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz",
-      "integrity": "sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7"
-      }
-    },
-    "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz",
-      "integrity": "sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
-      }
-    },
-    "@babel/plugin-proposal-export-namespace-from": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.7.tgz",
-      "integrity": "sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
-      }
-    },
-    "@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.7.tgz",
-      "integrity": "sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
-      }
-    },
-    "@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.7.tgz",
-      "integrity": "sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
-      }
-    },
-    "@babel/plugin-proposal-numeric-separator": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz",
-      "integrity": "sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
-      }
-    },
-    "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.7.tgz",
-      "integrity": "sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
-      }
-    },
-    "@babel/plugin-proposal-private-methods": {
-      "version": "7.16.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.11.tgz",
-      "integrity": "sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.16.10",
-        "@babel/helper-plugin-utils": "^7.16.7"
-      }
-    },
-    "@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.7.tgz",
-      "integrity": "sha512-rMQkjcOFbm+ufe3bTZLyOfsOUOxyvLXZJCTARhJr+8UMSoZmqTe1K1BgkFcrW37rAchWg57yI69ORxiWvUINuQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-create-class-features-plugin": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
-      }
-    },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
@@ -10128,24 +9132,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-syntax-dynamic-import": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      }
-    },
-    "@babel/plugin-syntax-export-namespace-from": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-syntax-import-meta": {
@@ -10220,15 +9206,6 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
-    "@babel/plugin-syntax-private-property-in-object": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      }
-    },
     "@babel/plugin-syntax-top-level-await": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.13.tgz",
@@ -10245,40 +9222,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.16.7"
-      }
-    },
-    "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.8.tgz",
-      "integrity": "sha512-oflKPvsLT2+uKQopesJt3ApiaIS2HW+hzHFcwRNtyDGieAeC/dIHZX8buJQ2J2X1rxGPy4eRcUijm3qcSPjYcA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/helper-simple-access": "^7.16.7",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
-      }
-    },
-    "@babel/plugin-transform-typescript": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz",
-      "integrity": "sha512-bHdQ9k7YpBDO2d0NVfkj51DpQcvwIzIusJ7mEUaMlbZq3Kt/U47j24inXZHQ5MDiYpCs+oZiwnXyKedE8+q7AQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/plugin-syntax-typescript": "^7.16.7"
-      }
-    },
-    "@babel/preset-typescript": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz",
-      "integrity": "sha512-WbVEmgXdIyvzB77AQjGBEyYPZx+8tTsO50XtfozQrkW8QB2rLJpH2lgx0TRw5EJrBxOZQ+wCcyPVQvS8tjEHpQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/helper-validator-option": "^7.16.7",
-        "@babel/plugin-transform-typescript": "^7.16.7"
       }
     },
     "@babel/template": {
@@ -11040,109 +9983,13 @@
       }
     },
     "@playwright/test": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.21.0.tgz",
-      "integrity": "sha512-jvgN3ZeAG6rw85z4u9Rc4uyj6qIaYlq2xrOtS7J2+CDYhzKOttab9ix9ELcvBOCHuQ6wgTfxfJYdh6DRZmQ9hg==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.22.2.tgz",
+      "integrity": "sha512-cCl96BEBGPtptFz7C2FOSN3PrTnJ3rPpENe+gYCMx4GNNDlN4tmo2D89y13feGKTMMAIVrXfSQ/UmaQKLy1XLA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.16.7",
-        "@babel/core": "7.16.12",
-        "@babel/helper-plugin-utils": "7.16.7",
-        "@babel/plugin-proposal-class-properties": "7.16.7",
-        "@babel/plugin-proposal-dynamic-import": "7.16.7",
-        "@babel/plugin-proposal-export-namespace-from": "7.16.7",
-        "@babel/plugin-proposal-logical-assignment-operators": "7.16.7",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "7.16.7",
-        "@babel/plugin-proposal-numeric-separator": "7.16.7",
-        "@babel/plugin-proposal-optional-chaining": "7.16.7",
-        "@babel/plugin-proposal-private-methods": "7.16.11",
-        "@babel/plugin-proposal-private-property-in-object": "7.16.7",
-        "@babel/plugin-syntax-async-generators": "7.8.4",
-        "@babel/plugin-syntax-json-strings": "7.8.3",
-        "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "7.8.3",
-        "@babel/plugin-transform-modules-commonjs": "7.16.8",
-        "@babel/preset-typescript": "7.16.7",
-        "colors": "1.4.0",
-        "commander": "8.3.0",
-        "debug": "4.3.3",
-        "expect": "27.2.5",
-        "jest-matcher-utils": "27.2.5",
-        "json5": "2.2.1",
-        "mime": "3.0.0",
-        "minimatch": "3.0.4",
-        "ms": "2.1.3",
-        "open": "8.4.0",
-        "pirates": "4.0.4",
-        "playwright-core": "1.21.0",
-        "rimraf": "3.0.2",
-        "source-map-support": "0.4.18",
-        "stack-utils": "2.0.5",
-        "yazl": "2.5.1"
-      },
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.16.12",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.12.tgz",
-          "integrity": "sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.16.7",
-            "@babel/generator": "^7.16.8",
-            "@babel/helper-compilation-targets": "^7.16.7",
-            "@babel/helper-module-transforms": "^7.16.7",
-            "@babel/helpers": "^7.16.7",
-            "@babel/parser": "^7.16.12",
-            "@babel/template": "^7.16.7",
-            "@babel/traverse": "^7.16.10",
-            "@babel/types": "^7.16.8",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.2",
-            "json5": "^2.1.2",
-            "semver": "^6.3.0",
-            "source-map": "^0.5.0"
-          }
-        },
-        "json5": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        },
-        "pirates": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz",
-          "integrity": "sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.4.18",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-          "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-          "dev": true,
-          "requires": {
-            "source-map": "^0.5.6"
-          }
-        }
+        "@types/node": "*",
+        "playwright-core": "1.22.2"
       }
     },
     "@rdfjs/data-model": {
@@ -11426,16 +10273,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
       "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
       "dev": true
-    },
-    "@types/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.19.0",
@@ -11840,15 +10677,6 @@
         }
       }
     },
-    "babel-plugin-dynamic-import-node": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
-      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-      "dev": true,
-      "requires": {
-        "object.assign": "^4.1.0"
-      }
-    },
     "babel-plugin-istanbul": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -11971,12 +10799,6 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
-    },
-    "buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -12124,12 +10946,6 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true
-    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -12138,12 +10954,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -12281,12 +11091,6 @@
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
-    "define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "dev": true
-    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -12399,15 +11203,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
-      "requires": {
-        "once": "^1.4.0"
-      }
     },
     "enquirer": {
       "version": "2.3.6",
@@ -12918,73 +11713,6 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
-    "expect": {
-      "version": "27.2.5",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.5.tgz",
-      "integrity": "sha512-ZrO0w7bo8BgGoP/bLz+HDCI+0Hfei9jUSZs5yI/Wyn9VkG9w8oJ7rHRgYj+MA7yqqFa0IwHA3flJzZtYugShJA==",
-      "dev": true,
-      "requires": {
-        "@jest/types": "^27.2.5",
-        "ansi-styles": "^5.0.0",
-        "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.2.5",
-        "jest-message-util": "^27.2.5",
-        "jest-regex-util": "^27.0.6"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "27.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.0.tgz",
-          "integrity": "sha512-oDHEp7gwSgA82RZ6pzUL3ugM2njP/lVB1MsxRZNOBk+CoNvh9SpH1lQixPFc/kDlV50v59csiW4HLixWmhmgPQ==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^16.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "16.0.4",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
-          "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        }
-      }
-    },
-    "extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "requires": {
-        "@types/yauzl": "^2.9.1",
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        }
-      }
-    },
     "fast-check": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-2.24.0.tgz",
@@ -13047,15 +11775,6 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
-      }
-    },
-    "fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-      "dev": true,
-      "requires": {
-        "pend": "~1.2.0"
       }
     },
     "fetch-blob": {
@@ -13452,12 +12171,6 @@
         "side-channel": "^1.0.4"
       }
     },
-    "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-      "dev": true
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -13502,12 +12215,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
-    },
-    "is-docker": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
-      "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
       "dev": true
     },
     "is-extglob": {
@@ -13617,15 +12324,6 @@
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
-      }
-    },
-    "is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "requires": {
-        "is-docker": "^2.0.0"
       }
     },
     "isexe": {
@@ -14908,12 +13606,6 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.5.0.tgz",
       "integrity": "sha512-GFcVFQwYQKbQTUOo2JlpFGXTkgBw26uzDsRMD2q1WgSKNSnpKS9Ug7bdQ8dS+p4sZHNH6iRPu6WK2jLIjspaMA=="
     },
-    "jpeg-js": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
-      "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -15253,12 +13945,6 @@
         "picomatch": "^2.2.3"
       }
     },
-    "mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true
-    },
     "mime-db": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
@@ -15525,17 +14211,6 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "open": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
-      "dev": true,
-      "requires": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      }
-    },
     "openid-client": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.3.tgz",
@@ -15701,12 +14376,6 @@
         }
       }
     },
-    "pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "dev": true
-    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -15724,23 +14393,6 @@
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
       "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
       "dev": true
-    },
-    "pixelmatch": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
-      "integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
-      "dev": true,
-      "requires": {
-        "pngjs": "^4.0.1"
-      },
-      "dependencies": {
-        "pngjs": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.1.tgz",
-          "integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==",
-          "dev": true
-        }
-      }
     },
     "pkg-dir": {
       "version": "4.2.0",
@@ -15803,44 +14455,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.21.0.tgz",
-      "integrity": "sha512-yDGVs9qaaW6WiefgR7wH1CGt9D6D/X4U3jNpIzH0FjjrrWLCOYQo78Tu3SkW8X+/kWlBpj49iWf3QNSxhYc12Q==",
-      "dev": true,
-      "requires": {
-        "colors": "1.4.0",
-        "commander": "8.3.0",
-        "debug": "4.3.3",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.0",
-        "jpeg-js": "0.4.3",
-        "mime": "3.0.0",
-        "pixelmatch": "5.2.1",
-        "pngjs": "6.0.0",
-        "progress": "2.0.3",
-        "proper-lockfile": "4.1.2",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "socks-proxy-agent": "6.1.1",
-        "stack-utils": "2.0.5",
-        "ws": "8.4.2",
-        "yauzl": "2.10.0",
-        "yazl": "2.5.1"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "8.4.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
-          "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
-          "dev": true,
-          "requires": {}
-        }
-      }
-    },
-    "pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.2.tgz",
+      "integrity": "sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==",
       "dev": true
     },
     "prelude-ls": {
@@ -15888,38 +14505,11 @@
         }
       }
     },
-    "proper-lockfile": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.2.4",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
-    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -16083,12 +14673,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
-      "dev": true
-    },
-    "retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
     "reusify": {
@@ -16286,33 +14870,6 @@
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
-    },
-    "smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true
-    },
-    "socks": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
-      "dev": true,
-      "requires": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.2.0"
-      }
-    },
-    "socks-proxy-agent": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
-      "dev": true,
-      "requires": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.1",
-        "socks": "^2.6.1"
-      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -17133,25 +15690,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
       "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==",
       "dev": true
-    },
-    "yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
-    "yazl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
-      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
-      "dev": true,
-      "requires": {
-        "buffer-crc32": "~0.2.3"
-      }
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/src/discover/redirectToAccessManagementUi.test.ts
+++ b/src/discover/redirectToAccessManagementUi.test.ts
@@ -34,7 +34,7 @@ import {
   getAccessManagementUiFromWellKnown,
   getAccessManagementUi,
 } from "./getAccessManagementUi";
-import { mockAccessRequestVc } from "../manage/approveAccessRequest.mock";
+import { mockAccessRequestVc } from "../util/access.mock";
 
 jest.mock("./getAccessManagementUi");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+export type { AccessGrant } from "./type/AccessGrant";
 export type { AccessBaseOptions } from "./type/AccessBaseOptions";
 export type { AccessCredentialType } from "./type/AccessCredentialType";
 export type { AccessGrantContext } from "./type/AccessGrantContext";

--- a/src/manage/approveAccessRequest.test.ts
+++ b/src/manage/approveAccessRequest.test.ts
@@ -22,16 +22,18 @@
 /* eslint-disable no-shadow */
 import { mockSolidDatasetFrom } from "@inrupt/solid-client";
 import { jest, it, describe, expect } from "@jest/globals";
+import type { issueVerifiableCredential } from "@inrupt/solid-client-vc";
 import {
   mockAccessApiEndpoint,
   MOCKED_ACCESS_ISSUER,
 } from "../request/request.mock";
 import { approveAccessRequest } from "./approveAccessRequest";
 import {
+  mockAccessGrantVc,
   mockAccessRequestVc,
   mockConsentGrantVc,
   mockConsentRequestVc,
-} from "./approveAccessRequest.mock";
+} from "../util/access.mock";
 
 jest.mock("@inrupt/solid-client", () => {
   // TypeScript can't infer the type of modules imported via Jest;
@@ -87,10 +89,11 @@ describe("approveAccessRequest", () => {
     crossFetchModule.fetch = mockAccessApiEndpoint();
     const mockedIssue = jest.spyOn(
       jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: () => unknown;
+        issueVerifiableCredential: typeof issueVerifiableCredential;
       },
       "issueVerifiableCredential"
     );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     // TypeScript can't infer the type of mock modules imported via Jest;
     // skip type checking for those:
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -132,6 +135,13 @@ describe("approveAccessRequest", () => {
     );
     const spiedAcrUpdate = jest.spyOn(mockedClientModule.acp_v4, "setVcAccess");
     const spiedAcrSave = jest.spyOn(mockedClientModule.acp_v4, "saveAcrFor");
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
 
     await approveAccessRequest(
       mockAccessRequestVc({
@@ -210,6 +220,13 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(mockAccessRequestVc(), undefined, {
       accessEndpoint: "https://some.consent-endpoint.override/",
       fetch: jest.fn(),
@@ -233,6 +250,13 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(mockAccessRequestVc(), undefined, {
       fetch: mockedFetch,
     });
@@ -254,6 +278,13 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(mockAccessRequestVc(), undefined, {
       fetch: jest.fn(global.fetch),
     });
@@ -280,23 +311,22 @@ describe("approveAccessRequest", () => {
   it("issues a proper access grant from a given request VC IRI", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
-    const spiedIssueRequest = jest.spyOn(
-      mockedVcModule,
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
       "issueVerifiableCredential"
     );
-    const mockedFetch = jest
-      .fn(global.fetch)
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify(mockConsentRequestVc()))
-      );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+    const mockedFetch = jest.fn(global.fetch);
+    mockedFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(mockConsentRequestVc()))
+    );
     await approveAccessRequest("https://some.credential", undefined, {
       fetch: mockedFetch,
     });
 
-    expect(spiedIssueRequest).toHaveBeenCalledWith(
+    expect(mockedIssue).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
       expect.objectContaining({
         providedConsent: {
@@ -317,6 +347,28 @@ describe("approveAccessRequest", () => {
     );
   });
 
+  it("Throws if the returned VC is not an access grant from a VC IRI", async () => {
+    mockAcpClient();
+    mockAccessApiEndpoint();
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessRequestVc());
+    const mockedFetch = jest.fn(global.fetch);
+    mockedFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(mockConsentRequestVc()))
+    );
+
+    await expect(
+      approveAccessRequest("https://some.credential", undefined, {
+        fetch: mockedFetch,
+      })
+    ).rejects.toThrow();
+  });
+
   it("issues a proper access grant from a given request VC with purpose", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
@@ -327,6 +379,13 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(mockConsentRequestVc(), undefined, {
       fetch: jest.fn(global.fetch),
     });
@@ -363,6 +422,13 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       mockConsentRequestVc(),
       {
@@ -403,6 +469,13 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       mockConsentRequestVc(),
       {
@@ -448,6 +521,13 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       undefined,
       {
@@ -493,6 +573,13 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       mockConsentRequestVc(),
       {
@@ -537,6 +624,13 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       mockConsentRequestVc(),
       {
@@ -580,6 +674,13 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       {
         ...mockConsentRequestVc(),
@@ -623,6 +724,13 @@ describe("approveAccessRequest", () => {
       mockedVcModule,
       "issueVerifiableCredential"
     );
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       "https://some.resource.owner",
       mockAccessRequestVc(),
@@ -649,5 +757,34 @@ describe("approveAccessRequest", () => {
       }),
       expect.anything()
     );
+  });
+
+  it("throws if the returned VC is not an Access Grant using the deprecated signature", async () => {
+    mockAcpClient();
+    mockAccessApiEndpoint();
+    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
+      issueVerifiableCredential: () => unknown;
+    };
+    const spiedIssueRequest = jest.spyOn(
+      mockedVcModule,
+      "issueVerifiableCredential"
+    );
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessRequestVc());
+    await expect(
+      approveAccessRequest(
+        "https://some.resource.owner",
+        mockAccessRequestVc(),
+        undefined,
+        {
+          fetch: jest.fn(global.fetch),
+        }
+      )
+    ).rejects.toThrow();
   });
 });

--- a/src/manage/approveAccessRequest.test.ts
+++ b/src/manage/approveAccessRequest.test.ts
@@ -762,13 +762,6 @@ describe("approveAccessRequest", () => {
   it("throws if the returned VC is not an Access Grant using the deprecated signature", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
-    const spiedIssueRequest = jest.spyOn(
-      mockedVcModule,
-      "issueVerifiableCredential"
-    );
     const mockedIssue = jest.spyOn(
       jest.requireMock("@inrupt/solid-client-vc") as {
         issueVerifiableCredential: typeof issueVerifiableCredential;

--- a/src/manage/approveAccessRequest.ts
+++ b/src/manage/approveAccessRequest.ts
@@ -19,6 +19,12 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+import type { AccessBaseOptions } from "../type/AccessBaseOptions";
+import type { AccessGrantBody } from "../type/AccessVerifiableCredential";
+import type { AccessGrantParameters } from "../type/Parameter";
+import type { AccessModes } from "../type/AccessModes";
+import type { AccessGrant } from "../type/AccessGrant";
+
 // eslint-disable-next-line camelcase
 import { UrlString, WebId, acp_v4 } from "@inrupt/solid-client";
 import { VerifiableCredential } from "@inrupt/solid-client-vc";
@@ -31,14 +37,9 @@ import {
   GC_CONSENT_STATUS_EXPLICITLY_GIVEN,
 } from "../constants";
 import { getBaseAccessRequestVerifiableCredential } from "../util/getBaseAccessVerifiableCredential";
-import { AccessBaseOptions } from "../type/AccessBaseOptions";
 import { initializeGrantParameters } from "../util/initializeGrantParameters";
 import { getSessionFetch } from "../util/getSessionFetch";
-import { AccessGrantBody } from "../type/AccessVerifiableCredential";
-import { AccessGrantParameters } from "../type/Parameter";
-import { AccessModes } from "../type/AccessModes";
 import { isAccessGrant } from "../guard/isAccessGrant";
-import { isBaseAccessVcBody } from "../guard/isBaseAccessVcBody";
 import { isBaseAccessGrantVerifiableCredential } from "../guard/isBaseAccessGrantVerifiableCredential";
 
 export type ApproveAccessRequestOverrides = Omit<
@@ -161,7 +162,7 @@ export async function approveAccessRequest(
   requestVc: VerifiableCredential | URL | UrlString,
   requestOverride?: Partial<ApproveAccessRequestOverrides>,
   options?: AccessBaseOptions
-): Promise<VerifiableCredential & AccessGrantBody>;
+): Promise<AccessGrant>;
 
 /**
  * Approve an access request. The content of the approved access request is provided
@@ -178,7 +179,7 @@ export async function approveAccessRequest(
   // If the VC is undefined, then some of the overrides become mandatory
   requestOverride: ApproveAccessRequestOverrides,
   options?: AccessBaseOptions
-): Promise<VerifiableCredential & AccessGrantBody>;
+): Promise<AccessGrant>;
 
 /**
  * @deprecated Please remove the `resourceOwner` parameter.
@@ -190,7 +191,7 @@ export async function approveAccessRequest(
   requestVc: VerifiableCredential | URL | UrlString,
   requestOverride?: Partial<ApproveAccessRequestOverrides>,
   options?: AccessBaseOptions
-): Promise<VerifiableCredential & AccessGrantBody>;
+): Promise<AccessGrant>;
 
 /**
  * @deprecated Please remove the `resourceOwner` parameter.
@@ -202,7 +203,7 @@ export async function approveAccessRequest(
   // If the VC is undefined, then some of the overrides become mandatory
   requestOverride: ApproveAccessRequestOverrides,
   options?: AccessBaseOptions
-): Promise<VerifiableCredential & AccessGrantBody>;
+): Promise<AccessGrant>;
 export async function approveAccessRequest(
   resourceOwnerOrRequestVc:
     | WebId
@@ -219,7 +220,7 @@ export async function approveAccessRequest(
     | Partial<ApproveAccessRequestOverrides>
     | AccessBaseOptions,
   options?: AccessBaseOptions
-): Promise<VerifiableCredential & AccessGrantBody> {
+): Promise<AccessGrant> {
   if (typeof options === "object") {
     // The deprecated signature is being used, so ignore the first parameter.
     const accessGrant = await internal_approveAccessRequest(

--- a/src/manage/approveAccessRequest.ts
+++ b/src/manage/approveAccessRequest.ts
@@ -19,15 +19,14 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+// eslint-disable-next-line camelcase
+import { UrlString, WebId, acp_v4 } from "@inrupt/solid-client";
+import { VerifiableCredential } from "@inrupt/solid-client-vc";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import type { AccessGrantBody } from "../type/AccessVerifiableCredential";
 import type { AccessGrantParameters } from "../type/Parameter";
 import type { AccessModes } from "../type/AccessModes";
 import type { AccessGrant } from "../type/AccessGrant";
-
-// eslint-disable-next-line camelcase
-import { UrlString, WebId, acp_v4 } from "@inrupt/solid-client";
-import { VerifiableCredential } from "@inrupt/solid-client-vc";
 import { getGrantBody, issueAccessVc } from "../util/issueAccessVc";
 import { isAccessRequest } from "../guard/isAccessRequest";
 import {

--- a/src/manage/denyAccessRequest.test.ts
+++ b/src/manage/denyAccessRequest.test.ts
@@ -22,7 +22,7 @@
 /* eslint-disable no-shadow */
 import { jest, it, describe, expect } from "@jest/globals";
 import { denyAccessRequest } from "./denyAccessRequest";
-import { mockAccessRequestVc } from "./approveAccessRequest.mock";
+import { mockAccessRequestVc } from "../util/access.mock";
 import {
   mockAccessApiEndpoint,
   MOCKED_ACCESS_ISSUER,

--- a/src/manage/getAccessGrant.test.ts
+++ b/src/manage/getAccessGrant.test.ts
@@ -22,10 +22,7 @@
 // eslint-disable-next-line no-shadow
 import { jest, it, describe, expect } from "@jest/globals";
 import { mockAccessApiEndpoint } from "../request/request.mock";
-import {
-  mockAccessGrantVc,
-  mockConsentRequestVc,
-} from "./approveAccessRequest.mock";
+import { mockAccessGrantVc, mockConsentRequestVc } from "../util/access.mock";
 import { getAccessGrant } from "./getAccessGrant";
 
 jest.mock("@inrupt/solid-client-authn-browser");

--- a/src/manage/getAccessGrant.ts
+++ b/src/manage/getAccessGrant.ts
@@ -19,11 +19,10 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import type { AccessBaseOptions } from "../type/AccessBaseOptions";
-import type { AccessGrant } from "../type/AccessGrant";
-
 import { UrlString } from "@inrupt/solid-client";
 import { isVerifiableCredential } from "@inrupt/solid-client-vc";
+import type { AccessBaseOptions } from "../type/AccessBaseOptions";
+import type { AccessGrant } from "../type/AccessGrant";
 import { isBaseAccessGrantVerifiableCredential } from "../guard/isBaseAccessGrantVerifiableCredential";
 import { isAccessGrant } from "../guard/isAccessGrant";
 import { getSessionFetch } from "../util/getSessionFetch";

--- a/src/manage/getAccessGrant.ts
+++ b/src/manage/getAccessGrant.ts
@@ -19,13 +19,13 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+import type { AccessBaseOptions } from "../type/AccessBaseOptions";
+import type { AccessGrant } from "../type/AccessGrant";
+
 import { UrlString } from "@inrupt/solid-client";
-import type { VerifiableCredential } from "@inrupt/solid-client-vc";
 import { isVerifiableCredential } from "@inrupt/solid-client-vc";
 import { isBaseAccessGrantVerifiableCredential } from "../guard/isBaseAccessGrantVerifiableCredential";
 import { isAccessGrant } from "../guard/isAccessGrant";
-import type { AccessGrantBody } from "../type/AccessVerifiableCredential";
-import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import { getSessionFetch } from "../util/getSessionFetch";
 
 /**
@@ -39,7 +39,7 @@ import { getSessionFetch } from "../util/getSessionFetch";
 export async function getAccessGrant(
   accessGrantVcUrl: UrlString | URL,
   options?: AccessBaseOptions
-): Promise<VerifiableCredential & AccessGrantBody> {
+): Promise<AccessGrant> {
   const sessionFetch = await getSessionFetch(options ?? {});
   const vcUrl =
     typeof accessGrantVcUrl === "string"

--- a/src/manage/getAccessRequestFromRedirectUrl.ts
+++ b/src/manage/getAccessRequestFromRedirectUrl.ts
@@ -23,7 +23,6 @@ import { UrlString } from "@inrupt/solid-client";
 import {
   isVerifiableCredential,
   getVerifiableCredential,
-  VerifiableCredential,
 } from "@inrupt/solid-client-vc";
 import {
   REDIRECT_URL_PARAM_NAME,
@@ -31,7 +30,7 @@ import {
   REQUEST_VC_URL_PARAM_NAME,
 } from "../discover/redirectToAccessManagementUi";
 import { isAccessRequest } from "../guard/isAccessRequest";
-import { AccessRequestBody } from "../type/AccessVerifiableCredential";
+import type { AccessRequest } from "../type/AccessRequest";
 import { getSessionFetch } from "../util/getSessionFetch";
 
 /**
@@ -50,7 +49,7 @@ export async function getAccessRequestFromRedirectUrl(
   redirectUrl: UrlString,
   options: { fetch?: typeof fetch } = {}
 ): Promise<{
-  accessRequest: VerifiableCredential & AccessRequestBody;
+  accessRequest: AccessRequest;
   requestorRedirectUrl: UrlString;
 }> {
   const redirectUrlObj = new URL(redirectUrl);

--- a/src/manage/getAccessRequestFromRedirectUrl.ts
+++ b/src/manage/getAccessRequestFromRedirectUrl.ts
@@ -30,6 +30,8 @@ import {
   REQUEST_VC_PARAM_NAME,
   REQUEST_VC_URL_PARAM_NAME,
 } from "../discover/redirectToAccessManagementUi";
+import { isAccessRequest } from "../guard/isAccessRequest";
+import { AccessRequestBody } from "../type/AccessVerifiableCredential";
 import { getSessionFetch } from "../util/getSessionFetch";
 
 /**
@@ -48,7 +50,7 @@ export async function getAccessRequestFromRedirectUrl(
   redirectUrl: UrlString,
   options: { fetch?: typeof fetch } = {}
 ): Promise<{
-  accessRequest: VerifiableCredential;
+  accessRequest: VerifiableCredential & AccessRequestBody;
   requestorRedirectUrl: UrlString;
 }> {
   const redirectUrlObj = new URL(redirectUrl);
@@ -94,6 +96,12 @@ export async function getAccessRequestFromRedirectUrl(
   if (!isVerifiableCredential(accessRequest)) {
     throw new Error(
       `${JSON.stringify(accessRequest)} is not a Verifiable Credential`
+    );
+  }
+
+  if (!isAccessRequest(accessRequest)) {
+    throw new Error(
+      `${JSON.stringify(accessRequest)} is not an Access Request`
     );
   }
   return { accessRequest, requestorRedirectUrl };

--- a/src/manage/revokeAccessGrant.test.ts
+++ b/src/manage/revokeAccessGrant.test.ts
@@ -24,8 +24,8 @@
 import { revokeVerifiableCredential } from "@inrupt/solid-client-vc";
 import { jest, describe, it, expect } from "@jest/globals";
 import { revokeAccessGrant } from "./revokeAccessGrant";
-import { mockAccessGrant, MOCKED_CREDENTIAL_ID } from "../request/request.mock";
-import { mockAccessRequestVc } from "./approveAccessRequest.mock";
+import { MOCKED_CREDENTIAL_ID } from "../request/request.mock";
+import { mockAccessGrantVc, mockAccessRequestVc } from "../util/access.mock";
 
 jest.mock("@inrupt/solid-client-authn-browser");
 jest.mock("@inrupt/solid-client-vc");
@@ -40,7 +40,7 @@ describe("revokeAccessGrant", () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify(
-            mockAccessGrant("https://some.issuer", "https://some.subject")
+            mockAccessGrantVc("https://some.issuer", "https://some.subject")
           )
         )
       );
@@ -74,7 +74,7 @@ describe("revokeAccessGrant", () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify(
-            mockAccessGrant("https://some.issuer", "https://some.subject")
+            mockAccessGrantVc("https://some.issuer", "https://some.subject")
           )
         )
       );
@@ -98,7 +98,7 @@ describe("revokeAccessGrant", () => {
       mockedVcModule,
       "revokeVerifiableCredential"
     );
-    const mockedVc = mockAccessGrant(
+    const mockedVc = mockAccessGrantVc(
       "https://some.issuer",
       "https://some.subject"
     );
@@ -144,7 +144,7 @@ describe("revokeAccessGrant", () => {
     );
     const mockedFetch = jest.fn(global.fetch);
     await revokeAccessGrant(
-      mockAccessGrant("https://some.issuer", "https://some.subject"),
+      mockAccessGrantVc("https://some.issuer", "https://some.subject"),
       {
         fetch: mockedFetch,
       }

--- a/src/request/cancelAccessRequest.test.ts
+++ b/src/request/cancelAccessRequest.test.ts
@@ -23,7 +23,8 @@
 import { jest, describe, it, expect } from "@jest/globals";
 import { revokeVerifiableCredential } from "@inrupt/solid-client-vc";
 import { cancelAccessRequest } from "./cancelAccessRequest";
-import { mockAccessGrant, MOCKED_CREDENTIAL_ID } from "./request.mock";
+import { MOCKED_CREDENTIAL_ID } from "./request.mock";
+import { mockAccessGrantVc } from "../util/access.mock";
 
 jest.mock("@inrupt/solid-client", () => {
   // TypeScript can't infer the type of modules imported via Jest;
@@ -49,7 +50,7 @@ describe("cancelAccessRequest", () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify(
-            mockAccessGrant("https://some.issuer", "https://some.subject")
+            mockAccessGrantVc("https://some.issuer", "https://some.subject")
           )
         )
       );
@@ -83,7 +84,7 @@ describe("cancelAccessRequest", () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify(
-            mockAccessGrant("https://some.issuer", "https://some.subject")
+            mockAccessGrantVc("https://some.issuer", "https://some.subject")
           )
         )
       );
@@ -107,7 +108,7 @@ describe("cancelAccessRequest", () => {
       mockedVcModule,
       "revokeVerifiableCredential"
     );
-    const mockedVc = mockAccessGrant(
+    const mockedVc = mockAccessGrantVc(
       "https://some.issuer",
       "https://some.subject"
     );
@@ -147,7 +148,7 @@ describe("cancelAccessRequest", () => {
     );
     const mockedFetch = jest.fn(global.fetch);
     await cancelAccessRequest(
-      mockAccessGrant("https://some.issuer", "https://some.subject"),
+      mockAccessGrantVc("https://some.issuer", "https://some.subject"),
       {
         fetch: mockedFetch,
       }

--- a/src/request/getAccessGrantFromRedirectUrl.ts
+++ b/src/request/getAccessGrantFromRedirectUrl.ts
@@ -25,10 +25,13 @@ import {
   isVerifiableCredential,
   VerifiableCredential,
 } from "@inrupt/solid-client-vc";
+import { isAccessGrant } from "../guard/isAccessGrant";
+import { isBaseAccessVcBody } from "../guard/isBaseAccessVcBody";
 import {
   GRANT_VC_PARAM_NAME,
   GRANT_VC_URL_PARAM_NAME,
 } from "../manage/redirectToRequestor";
+import type { AccessGrantBody } from "../type/AccessVerifiableCredential";
 import { getSessionFetch } from "../util/getSessionFetch";
 
 /**
@@ -45,7 +48,7 @@ import { getSessionFetch } from "../util/getSessionFetch";
 export async function getAccessGrantFromRedirectUrl(
   redirectUrl: UrlString,
   options: { fetch?: typeof fetch } = {}
-): Promise<VerifiableCredential> {
+): Promise<VerifiableCredential & AccessGrantBody> {
   const redirectUrlObj = new URL(redirectUrl);
   const authFetch = options.fetch ?? (await getSessionFetch(options));
 
@@ -71,6 +74,10 @@ export async function getAccessGrantFromRedirectUrl(
     throw new Error(
       `${JSON.stringify(accessGrant)} is not a Verifiable Credential`
     );
+  }
+
+  if (!isBaseAccessVcBody(accessGrant) || !isAccessGrant(accessGrant)) {
+    throw new Error(`${JSON.stringify(accessGrant)} is not an Access Grant`);
   }
 
   return accessGrant;

--- a/src/request/getAccessGrantFromRedirectUrl.ts
+++ b/src/request/getAccessGrantFromRedirectUrl.ts
@@ -19,13 +19,12 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import type { AccessGrant } from "../type/AccessGrant";
-
 import { UrlString } from "@inrupt/solid-client";
 import {
   getVerifiableCredential,
   isVerifiableCredential,
 } from "@inrupt/solid-client-vc";
+import type { AccessGrant } from "../type/AccessGrant";
 import { isAccessGrant } from "../guard/isAccessGrant";
 import { isBaseAccessVcBody } from "../guard/isBaseAccessVcBody";
 import {

--- a/src/request/getAccessGrantFromRedirectUrl.ts
+++ b/src/request/getAccessGrantFromRedirectUrl.ts
@@ -19,11 +19,12 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+import type { AccessGrant } from "../type/AccessGrant";
+
 import { UrlString } from "@inrupt/solid-client";
 import {
   getVerifiableCredential,
   isVerifiableCredential,
-  VerifiableCredential,
 } from "@inrupt/solid-client-vc";
 import { isAccessGrant } from "../guard/isAccessGrant";
 import { isBaseAccessVcBody } from "../guard/isBaseAccessVcBody";
@@ -31,7 +32,6 @@ import {
   GRANT_VC_PARAM_NAME,
   GRANT_VC_URL_PARAM_NAME,
 } from "../manage/redirectToRequestor";
-import type { AccessGrantBody } from "../type/AccessVerifiableCredential";
 import { getSessionFetch } from "../util/getSessionFetch";
 
 /**
@@ -48,7 +48,7 @@ import { getSessionFetch } from "../util/getSessionFetch";
 export async function getAccessGrantFromRedirectUrl(
   redirectUrl: UrlString,
   options: { fetch?: typeof fetch } = {}
-): Promise<VerifiableCredential & AccessGrantBody> {
+): Promise<AccessGrant> {
   const redirectUrlObj = new URL(redirectUrl);
   const authFetch = options.fetch ?? (await getSessionFetch(options));
 

--- a/src/request/issueAccessRequest.test.ts
+++ b/src/request/issueAccessRequest.test.ts
@@ -30,13 +30,12 @@ import { issueAccessRequest } from "./issueAccessRequest";
 import { getRequestBody } from "../util/issueAccessVc";
 import { isAccessRequest } from "../guard/isAccessRequest";
 import {
-  mockAccessGrant,
   mockAccessApiEndpoint,
   MOCKED_ACCESS_ISSUER,
-  MOCK_REQUESTOR_IRI,
   MOCK_REQUESTOR_INBOX,
   MOCK_RESOURCE_OWNER_IRI,
 } from "./request.mock";
+import { mockAccessGrantVc, mockAccessRequestVc } from "../util/access.mock";
 import { ACCESS_GRANT_CONTEXT } from "../constants";
 
 jest.mock("@inrupt/solid-client", () => {
@@ -133,11 +132,7 @@ describe("issueAccessRequest", () => {
       },
       "issueVerifiableCredential"
     );
-    mockedIssue.mockResolvedValueOnce(
-      mockAccessGrant(MOCKED_ACCESS_ISSUER, MOCK_REQUESTOR_IRI, {
-        someClaim: "some value",
-      })
-    );
+    mockedIssue.mockResolvedValueOnce(mockAccessRequestVc());
 
     await issueAccessRequest(
       {
@@ -168,6 +163,31 @@ describe("issueAccessRequest", () => {
     );
   });
 
+  it("throws if the VC returned is not an Access Request", async () => {
+    mockAccessApiEndpoint();
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+
+    await expect(
+      issueAccessRequest(
+        {
+          access: { read: true },
+          resourceOwner: MOCK_RESOURCE_OWNER_IRI,
+          resources: ["https://some.pod/resource"],
+          requestorInboxUrl: MOCK_REQUESTOR_INBOX,
+        },
+        {
+          fetch: jest.fn(),
+        }
+      )
+    ).rejects.toThrow();
+  });
+
   it("falls back to @inrupt/solid-client-authn-browser if no fetch function was passed", async () => {
     mockAccessApiEndpoint();
     const mockedIssue = jest.spyOn(
@@ -176,6 +196,7 @@ describe("issueAccessRequest", () => {
       },
       "issueVerifiableCredential"
     );
+    mockedIssue.mockResolvedValueOnce(mockAccessRequestVc());
     // TypeScript can't infer the type of mock modules imported via Jest;
     // skip type checking for those:
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -206,11 +227,7 @@ describe("issueAccessRequest", () => {
       },
       "issueVerifiableCredential"
     );
-    mockedIssue.mockResolvedValueOnce(
-      mockAccessGrant(MOCKED_ACCESS_ISSUER, MOCK_REQUESTOR_IRI, {
-        someClaim: "some value",
-      })
-    );
+    mockedIssue.mockResolvedValueOnce(mockAccessRequestVc());
 
     await issueAccessRequest(
       {
@@ -255,11 +272,7 @@ describe("issueAccessRequest", () => {
       },
       "issueVerifiableCredential"
     );
-    mockedIssue.mockResolvedValueOnce(
-      mockAccessGrant(MOCKED_ACCESS_ISSUER, MOCK_REQUESTOR_IRI, {
-        someClaim: "some value",
-      })
-    );
+    mockedIssue.mockResolvedValueOnce(mockAccessRequestVc());
 
     await issueAccessRequest({
       access: { read: true },
@@ -295,6 +308,7 @@ describe("issueAccessRequest", () => {
       },
       "issueVerifiableCredential"
     );
+    mockedIssue.mockResolvedValueOnce(mockAccessRequestVc());
     // TypeScript can't infer the type of mock modules imported via Jest;
     // skip type checking for those:
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/request/issueAccessRequest.ts
+++ b/src/request/issueAccessRequest.ts
@@ -27,7 +27,7 @@ import type {
   DeprecatedAccessRequestParameters,
   IssueAccessRequestParameters,
 } from "../type/IssueAccessRequestParameters";
-import { AccessRequestBody } from "../type/AccessVerifiableCredential";
+import type { AccessRequest } from "../type/AccessRequest";
 import { isAccessRequest } from "../guard/isAccessRequest";
 
 /**
@@ -41,18 +41,18 @@ import { isAccessRequest } from "../guard/isAccessRequest";
 async function issueAccessRequest(
   params: IssueAccessRequestParameters,
   options?: AccessBaseOptions
-): Promise<VerifiableCredential & AccessRequestBody>;
+): Promise<AccessRequest>;
 /**
  * @deprecated Please remove the `requestor` parameter.
  */
 async function issueAccessRequest(
   params: DeprecatedAccessRequestParameters,
   options?: AccessBaseOptions
-): Promise<VerifiableCredential & AccessRequestBody>;
+): Promise<AccessRequest>;
 async function issueAccessRequest(
   params: IssueAccessRequestParameters,
   options: AccessBaseOptions = {}
-): Promise<VerifiableCredential & AccessRequestBody> {
+): Promise<AccessRequest> {
   const requestBody = getRequestBody({
     ...params,
     status: GC_CONSENT_STATUS_REQUESTED,

--- a/src/request/issueAccessRequest.ts
+++ b/src/request/issueAccessRequest.ts
@@ -61,7 +61,9 @@ async function issueAccessRequest(
   const accessRequest = await issueAccessVc(requestBody, options);
 
   if (!isAccessRequest(accessRequest)) {
-    throw new Error(`${JSON.stringify(accessRequest)} is not an Access Request`);
+    throw new Error(
+      `${JSON.stringify(accessRequest)} is not an Access Request`
+    );
   }
 
   return accessRequest;

--- a/src/request/request.mock.ts
+++ b/src/request/request.mock.ts
@@ -29,49 +29,13 @@ import {
   UrlString,
   WithServerResourceInfo,
 } from "@inrupt/solid-client";
-import { VerifiableCredential } from "@inrupt/solid-client-vc";
-import {
-  ACCESS_GRANT_CONTEXT,
-  PREFERRED_CONSENT_MANAGEMENT_UI,
-} from "../constants";
+import { PREFERRED_CONSENT_MANAGEMENT_UI } from "../constants";
 
 export const MOCKED_CREDENTIAL_ID = "https://some.credential";
 export const MOCKED_ISSUANCE_DATE = "2021-09-07T09:59:00Z";
 export const MOCK_REQUESTOR_IRI = "https://some.pod/profile#me";
 export const MOCK_REQUESTOR_INBOX = "https://some.pod/consent/inbox";
 export const MOCK_RESOURCE_OWNER_IRI = "https://some.pod/profile#you";
-
-export const mockAccessGrant = (
-  issuer: string,
-  subjectId: string,
-  subjectClaims?: Record<string, string>
-): VerifiableCredential => {
-  return {
-    "@context": ACCESS_GRANT_CONTEXT,
-    credentialSubject: {
-      id: subjectId,
-      providedConsent: {
-        forPersonalData: ["https://some.resource"],
-        hasStatus: "https://w3id.org/GConsent#ConsentStatusRequested",
-        mode: ["http://www.w3.org/ns/auth/acl#Read"],
-      },
-      inbox: "https://some.inbox",
-      ...subjectClaims,
-    },
-    type: ["SolidCredential", "SolidAccessRequest"],
-    id: MOCKED_CREDENTIAL_ID,
-    issuanceDate: MOCKED_ISSUANCE_DATE,
-    issuer,
-    proof: {
-      created: MOCKED_ISSUANCE_DATE,
-      proofPurpose: "assertionMethod",
-      verificationMethod: "https://issuer.jwks",
-      proofValue: "eyJhbGciO..E1og50tS9tH8WyXMlXyo45CA",
-      type: "Ed25519Signature2018",
-    },
-  };
-};
-
 export const MOCKED_ACCESS_ISSUER = "https://access-issuer.iri";
 export const MOCKED_ACCESS_UI_IRI = "https://some-consent.app";
 export const MOCKED_STORAGE = "https://pod-provider.iri";

--- a/src/resource/getFile.test.ts
+++ b/src/resource/getFile.test.ts
@@ -22,7 +22,7 @@
 /* eslint @typescript-eslint/no-explicit-any: 0 */
 // eslint-disable-next-line no-shadow
 import { it, jest, describe, expect } from "@jest/globals";
-import { mockAccessRequestVc } from "../manage/approveAccessRequest.mock";
+import { mockAccessRequestVc } from "../util/access.mock";
 import { getFile } from "./getFile";
 import { fetchWithVc } from "../fetch";
 

--- a/src/resource/getSolidDataset.test.ts
+++ b/src/resource/getSolidDataset.test.ts
@@ -23,7 +23,7 @@
 // eslint-disable-next-line no-shadow
 import { it, jest, describe, expect } from "@jest/globals";
 import { mockSolidDatasetFrom } from "@inrupt/solid-client";
-import { mockAccessRequestVc } from "../manage/approveAccessRequest.mock";
+import { mockAccessRequestVc } from "../util/access.mock";
 import { getSolidDataset } from "./getSolidDataset";
 import { fetchWithVc } from "../fetch";
 

--- a/src/resource/saveSolidDatasetAt.test.ts
+++ b/src/resource/saveSolidDatasetAt.test.ts
@@ -23,7 +23,7 @@
 // eslint-disable-next-line no-shadow
 import { it, jest, describe, expect } from "@jest/globals";
 import { mockSolidDatasetFrom } from "@inrupt/solid-client";
-import { mockAccessRequestVc } from "../manage/approveAccessRequest.mock";
+import { mockAccessRequestVc } from "../util/access.mock";
 import { saveSolidDatasetAt } from "./saveSolidDatasetAt";
 import { fetchWithVc } from "../fetch";
 

--- a/src/type/AccessGrant.ts
+++ b/src/type/AccessGrant.ts
@@ -1,3 +1,24 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
 import type { VerifiableCredential } from "@inrupt/solid-client-vc";
 import type { AccessGrantBody } from "./AccessVerifiableCredential";
 

--- a/src/type/AccessGrant.ts
+++ b/src/type/AccessGrant.ts
@@ -1,0 +1,4 @@
+import type { VerifiableCredential } from "@inrupt/solid-client-vc";
+import type { AccessGrantBody } from "./AccessVerifiableCredential";
+
+export type AccessGrant = VerifiableCredential & AccessGrantBody;

--- a/src/type/AccessRequest.ts
+++ b/src/type/AccessRequest.ts
@@ -1,3 +1,24 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
 import type { VerifiableCredential } from "@inrupt/solid-client-vc";
 import type { AccessRequestBody } from "./AccessVerifiableCredential";
 

--- a/src/type/AccessRequest.ts
+++ b/src/type/AccessRequest.ts
@@ -1,0 +1,4 @@
+import type { VerifiableCredential } from "@inrupt/solid-client-vc";
+import type { AccessRequestBody } from "./AccessVerifiableCredential";
+
+export type AccessRequest = VerifiableCredential & AccessRequestBody;

--- a/src/util/access.mock.ts
+++ b/src/util/access.mock.ts
@@ -25,7 +25,13 @@ import {
   BaseGrantBody,
   BaseRequestBody,
 } from "../type/AccessVerifiableCredential";
-import { ACCESS_GRANT_CONTEXT } from "../constants";
+import {
+  ACCESS_GRANT_CONTEXT,
+  CREDENTIAL_TYPE_ACCESS_GRANT,
+  CREDENTIAL_TYPE_ACCESS_REQUEST,
+  GC_CONSENT_STATUS_EXPLICITLY_GIVEN,
+  GC_CONSENT_STATUS_REQUESTED,
+} from "../constants";
 import { ResourceAccessMode } from "../type/ResourceAccessMode";
 
 export const mockAccessRequestVc = (
@@ -41,7 +47,7 @@ export const mockAccessRequestVc = (
       id: "https://some.requestor",
       hasConsent: {
         forPersonalData: options?.resources ?? ["https://some.resource"],
-        hasStatus: "https://w3id.org/GConsent#ConsentStatusRequested",
+        hasStatus: GC_CONSENT_STATUS_REQUESTED,
         mode: options?.modes ?? ["http://www.w3.org/ns/auth/acl#Read"],
         isConsentForDataSubject: "https://some.pod/profile#you",
       },
@@ -50,32 +56,35 @@ export const mockAccessRequestVc = (
     issuanceDate: "2022-02-22",
     issuer: "https://some.issuer",
     proof: {
-      created: "some ISO date",
+      created: "2022-06-08T15:28:51.810Z",
       proofPurpose: "some proof purpose",
       proofValue: "some proof",
       type: "some proof type",
       verificationMethod: "some method",
     },
-    type: ["SolidAccessRequest"],
+    type: [CREDENTIAL_TYPE_ACCESS_REQUEST],
   };
 };
 
-export const mockAccessGrantVc = (): VerifiableCredential & BaseGrantBody => {
+export const mockAccessGrantVc = (
+  issuer = "https://some.issuer",
+  subjectId = "https://some.resource.owner"
+): VerifiableCredential & BaseGrantBody => {
   return {
     "@context": ACCESS_GRANT_CONTEXT,
     id: "https://some.credential",
     credentialSubject: {
-      id: "https://some.resource.owner",
+      id: subjectId,
       providedConsent: {
         forPersonalData: ["https://some.resource"],
-        hasStatus: "https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
+        hasStatus: GC_CONSENT_STATUS_EXPLICITLY_GIVEN,
         mode: ["http://www.w3.org/ns/auth/acl#Read"],
         isProvidedTo: "https://some.requestor",
       },
       inbox: "https://some.inbox",
     },
     issuanceDate: "1965-08-28",
-    issuer: "https://some.issuer",
+    issuer,
     proof: {
       created: "2021-10-05",
       proofPurpose: "some proof purpose",
@@ -83,14 +92,13 @@ export const mockAccessGrantVc = (): VerifiableCredential & BaseGrantBody => {
       type: "some proof type",
       verificationMethod: "some method",
     },
-    type: ["SolidAccessRequest"],
+    type: [CREDENTIAL_TYPE_ACCESS_GRANT],
   };
 };
 
 export const mockConsentRequestVc = (): VerifiableCredential &
   BaseRequestBody => {
-  const requestVc = mockAccessRequestVc() as unknown as VerifiableCredential &
-    BaseRequestBody;
+  const requestVc = mockAccessRequestVc();
   requestVc.credentialSubject.hasConsent.forPurpose = ["https://some.purpose"];
   requestVc.expirationDate = new Date(2021, 8, 14).toISOString();
   requestVc.issuanceDate = new Date(2021, 8, 13).toISOString();
@@ -98,8 +106,7 @@ export const mockConsentRequestVc = (): VerifiableCredential &
 };
 
 export const mockConsentGrantVc = (): VerifiableCredential & BaseGrantBody => {
-  const requestVc = mockAccessGrantVc() as unknown as VerifiableCredential &
-    BaseGrantBody;
+  const requestVc = mockAccessGrantVc();
   requestVc.credentialSubject.providedConsent.forPurpose = [
     "https://some.purpose",
   ];


### PR DESCRIPTION
When using the library, we have to perform some type casting because functions like `getAccessGrantFromRedirectUrl` are returning a generic `VerifiableCredential` type.

https://github.com/inrupt/solid-client-access-grants-js/blob/caa7e91ba66d7c918601dccada0c325173895cbe/src/request/getAccessGrantFromRedirectUrl.ts#L45-L48

I would argue that if the function is aimed at returning Access Grants, then it should return an `AccessGrant` and throw if the thing is not one.

https://github.com/inrupt/solid-client-access-grants-js/blob/5eee9571384f3ef9c6610dfcc5727a23c77ee62f/src/request/getAccessGrantFromRedirectUrl.ts#L48-L51

It's actually the case in the `getAccessGrant` function:

https://github.com/inrupt/solid-client-access-grants-js/blob/caa7e91ba66d7c918601dccada0c325173895cbe/src/manage/getAccessGrant.ts#L39-L42


I'd like to discuss whether there is a specific reason not to type check, but I think it's a mistake and makes the code less usable.
