### PR TITLE
Instanciate VC context based on issuer domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Fix Node 14 atob/btoa compatibility issue.
 - The JSON-LD context of issued VCs was hard-coded, instead of being relative to
-the issuer domain as mandated by the [ESS documentation](https://docs.inrupt.com/ess/latest/services/service-vc/#ess-vc-service-endpoints).
+  the issuer domain as mandated by the [ESS documentation](https://docs.inrupt.com/ess/latest/services/service-vc/#ess-vc-service-endpoints).
 
 ## [1.0.1](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v1.0.1) - 2022-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Bugfix
 
 - Fix Node 14 atob/btoa compatibility issue.
+- The JSON-LD context of issued VCs was hard-coded, instead of being relative to
+the issuer domain as mandated by the [ESS documentation](https://docs.inrupt.com/ess/latest/services/service-vc/#ess-vc-service-endpoints).
 
 ## [1.0.1](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v1.0.1) - 2022-06-06
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,9 +56,22 @@ export const PIM_STORAGE = "http://www.w3.org/ns/pim/space#storage";
 export const PREFERRED_CONSENT_MANAGEMENT_UI =
   "http://inrupt.com/ns/ess#ConsentManagementUI";
 
-export const ACCESS_GRANT_CONTEXT = [
-  "https://www.w3.org/2018/credentials/v1",
-  "https://vc.inrupt.com/credentials/v1",
+export const CONTEXT_VC_W3C = "https://www.w3.org/2018/credentials/v1" as const;
+
+// According to the [ESS documentation](https://docs.inrupt.com/ess/latest/services/service-vc/#ess-vc-service-endpoints),
+// the JSON-LD context for ESS-issued VCs will match the following template.
+const instanciateContextVcEssTemplate = (essDomain: string): string =>
+  `https://vc.${essDomain}/credentials/v1`;
+
+// When issuing a VC using a given service, be sure to set the context using the following.
+export const instanciateEssAccessGrantContext = (
+  essDomain: string
+): string[] => [CONTEXT_VC_W3C, instanciateContextVcEssTemplate(essDomain)];
+
+// A default context value is provided for mocking purpose accross the codebase.
+export const ACCESS_GRANT_CONTEXT_DEFAULT = [
+  CONTEXT_VC_W3C,
+  instanciateContextVcEssTemplate("inrupt.com"),
 ] as const;
 
 export const WELL_KNOWN_SOLID = ".well-known/solid";

--- a/src/guard/isAccessGrantContext.ts
+++ b/src/guard/isAccessGrantContext.ts
@@ -19,9 +19,9 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { ACCESS_GRANT_CONTEXT } from "../constants";
+import { ACCESS_GRANT_CONTEXT_DEFAULT } from "../constants";
 import { AccessGrantContext } from "../type/AccessGrantContext";
 
 export function isAccessGrantContext(x: unknown): x is AccessGrantContext {
-  return Array.isArray(x) && ACCESS_GRANT_CONTEXT.every((y) => x.includes(y));
+  return Array.isArray(x) && ACCESS_GRANT_CONTEXT_DEFAULT.every((y) => x.includes(y));
 }

--- a/src/guard/isAccessGrantContext.ts
+++ b/src/guard/isAccessGrantContext.ts
@@ -19,9 +19,9 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { ACCESS_GRANT_CONTEXT_DEFAULT } from "../constants";
+import { CONTEXT_VC_W3C } from "../constants";
 import { AccessGrantContext } from "../type/AccessGrantContext";
 
 export function isAccessGrantContext(x: unknown): x is AccessGrantContext {
-  return Array.isArray(x) && ACCESS_GRANT_CONTEXT_DEFAULT.every((y) => x.includes(y));
+  return Array.isArray(x) && x.includes(CONTEXT_VC_W3C);
 }

--- a/src/request/issueAccessRequest.test.ts
+++ b/src/request/issueAccessRequest.test.ts
@@ -196,7 +196,7 @@ describe("issueAccessRequest", () => {
       },
       "issueVerifiableCredential"
     );
-    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+    mockedIssue.mockResolvedValueOnce(mockAccessRequestVc());
 
     await issueAccessRequest(
       {

--- a/src/request/issueAccessRequest.test.ts
+++ b/src/request/issueAccessRequest.test.ts
@@ -36,7 +36,7 @@ import {
   MOCK_RESOURCE_OWNER_IRI,
 } from "./request.mock";
 import { mockAccessGrantVc, mockAccessRequestVc } from "../util/access.mock";
-import { ACCESS_GRANT_CONTEXT } from "../constants";
+import { ACCESS_GRANT_CONTEXT_DEFAULT } from "../constants";
 
 jest.mock("@inrupt/solid-client", () => {
   // TypeScript can't infer the type of modules imported via Jest;
@@ -186,6 +186,40 @@ describe("issueAccessRequest", () => {
         }
       )
     ).rejects.toThrow();
+  });
+
+  it("computes the correct context based on the issuer", async () => {
+    mockAccessApiEndpoint();
+    const mockedIssue = jest.spyOn(
+      jest.requireMock("@inrupt/solid-client-vc") as {
+        issueVerifiableCredential: typeof issueVerifiableCredential;
+      },
+      "issueVerifiableCredential"
+    );
+    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+
+    await issueAccessRequest(
+      {
+        access: { read: true },
+        resourceOwner: MOCK_RESOURCE_OWNER_IRI,
+        resources: ["https://some.pod/resource"],
+        requestorInboxUrl: MOCK_REQUESTOR_INBOX,
+      },
+      {
+        fetch: jest.fn(),
+      }
+    );
+
+    expect(mockedIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        "@context": expect.arrayContaining([
+          "https://vc.access-issuer.iri/credentials/v1",
+        ]),
+      }),
+      expect.anything(),
+      expect.anything()
+    );
   });
 
   it("falls back to @inrupt/solid-client-authn-browser if no fetch function was passed", async () => {
@@ -499,7 +533,7 @@ describe("isAccessRequest", () => {
   it("returns true if the credential matches the expected shape", () => {
     expect(
       isAccessRequest({
-        "@context": ACCESS_GRANT_CONTEXT,
+        "@context": ACCESS_GRANT_CONTEXT_DEFAULT,
         credentialSubject: {
           id: "https://some.id",
           inbox: "https://some.inbox",

--- a/src/request/request.mock.ts
+++ b/src/request/request.mock.ts
@@ -29,13 +29,18 @@ import {
   UrlString,
   WithServerResourceInfo,
 } from "@inrupt/solid-client";
-import { PREFERRED_CONSENT_MANAGEMENT_UI } from "../constants";
+import { VerifiableCredential } from "@inrupt/solid-client-vc";
+import {
+  ACCESS_GRANT_CONTEXT_DEFAULT,
+  PREFERRED_CONSENT_MANAGEMENT_UI
+} from "../constants";
 
 export const MOCKED_CREDENTIAL_ID = "https://some.credential";
 export const MOCKED_ISSUANCE_DATE = "2021-09-07T09:59:00Z";
 export const MOCK_REQUESTOR_IRI = "https://some.pod/profile#me";
 export const MOCK_REQUESTOR_INBOX = "https://some.pod/consent/inbox";
 export const MOCK_RESOURCE_OWNER_IRI = "https://some.pod/profile#you";
+
 export const MOCKED_ACCESS_ISSUER = "https://access-issuer.iri";
 export const MOCKED_ACCESS_UI_IRI = "https://some-consent.app";
 export const MOCKED_STORAGE = "https://pod-provider.iri";

--- a/src/request/request.mock.ts
+++ b/src/request/request.mock.ts
@@ -32,7 +32,7 @@ import {
 import { VerifiableCredential } from "@inrupt/solid-client-vc";
 import {
   ACCESS_GRANT_CONTEXT_DEFAULT,
-  PREFERRED_CONSENT_MANAGEMENT_UI
+  PREFERRED_CONSENT_MANAGEMENT_UI,
 } from "../constants";
 
 export const MOCKED_CREDENTIAL_ID = "https://some.credential";

--- a/src/type/AccessGrantContext.ts
+++ b/src/type/AccessGrantContext.ts
@@ -19,6 +19,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import type { ACCESS_GRANT_CONTEXT } from "../constants";
+import type { ACCESS_GRANT_CONTEXT_DEFAULT } from "../constants";
 
-export type AccessGrantContext = typeof ACCESS_GRANT_CONTEXT;
+export type AccessGrantContext = typeof ACCESS_GRANT_CONTEXT_DEFAULT;

--- a/src/type/AccessVerifiableCredential.ts
+++ b/src/type/AccessVerifiableCredential.ts
@@ -21,7 +21,7 @@
 
 import type { UrlString } from "@inrupt/solid-client";
 import type {
-  ACCESS_GRANT_CONTEXT,
+  ACCESS_GRANT_CONTEXT_DEFAULT,
   GC_CONSENT_STATUS_DENIED,
   GC_CONSENT_STATUS_EXPLICITLY_GIVEN,
   GC_CONSENT_STATUS_REQUESTED,
@@ -68,7 +68,7 @@ export type GrantCredentialSubject = Required<
 export type GrantCredentialSubjectPayload = Omit<GrantCredentialSubject, "id">;
 
 export type BaseAccessVcBody = {
-  "@context": typeof ACCESS_GRANT_CONTEXT;
+  "@context": typeof ACCESS_GRANT_CONTEXT_DEFAULT;
   type: AccessCredentialType[];
   credentialSubject:
     | RequestCredentialSubject

--- a/src/util/access.mock.ts
+++ b/src/util/access.mock.ts
@@ -26,7 +26,7 @@ import {
   BaseRequestBody,
 } from "../type/AccessVerifiableCredential";
 import {
-  ACCESS_GRANT_CONTEXT,
+  ACCESS_GRANT_CONTEXT_DEFAULT,
   CREDENTIAL_TYPE_ACCESS_GRANT,
   CREDENTIAL_TYPE_ACCESS_REQUEST,
   GC_CONSENT_STATUS_EXPLICITLY_GIVEN,
@@ -41,7 +41,7 @@ export const mockAccessRequestVc = (
   }>
 ): VerifiableCredential & BaseRequestBody => {
   return {
-    "@context": ACCESS_GRANT_CONTEXT,
+    "@context": ACCESS_GRANT_CONTEXT_DEFAULT,
     id: "https://some.credential",
     credentialSubject: {
       id: "https://some.requestor",
@@ -71,7 +71,7 @@ export const mockAccessGrantVc = (
   subjectId = "https://some.resource.owner"
 ): VerifiableCredential & BaseGrantBody => {
   return {
-    "@context": ACCESS_GRANT_CONTEXT,
+    "@context": ACCESS_GRANT_CONTEXT_DEFAULT,
     id: "https://some.credential",
     credentialSubject: {
       id: subjectId,

--- a/src/util/issueAccessVc.ts
+++ b/src/util/issueAccessVc.ts
@@ -24,9 +24,10 @@ import {
   VerifiableCredential,
 } from "@inrupt/solid-client-vc";
 import {
-  ACCESS_GRANT_CONTEXT,
+  ACCESS_GRANT_CONTEXT_DEFAULT,
   CREDENTIAL_TYPE_ACCESS_GRANT,
   CREDENTIAL_TYPE_ACCESS_REQUEST,
+  instanciateEssAccessGrantContext,
 } from "../constants";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import { getSessionFetch } from "./getSessionFetch";
@@ -97,7 +98,7 @@ function getBaseBody(
   type: "BaseRequestBody" | "BaseGrantBody"
 ): BaseRequestPayload | BaseGrantPayload {
   const body = {
-    "@context": ACCESS_GRANT_CONTEXT,
+    "@context": ACCESS_GRANT_CONTEXT_DEFAULT,
     type: [
       type === "BaseGrantBody"
         ? CREDENTIAL_TYPE_ACCESS_GRANT
@@ -170,7 +171,9 @@ export async function issueAccessVc(
   return issueVerifiableCredential(
     accessIssuerEndpoint.href,
     {
-      "@context": vcBody["@context"],
+      "@context": instanciateEssAccessGrantContext(
+        accessIssuerEndpoint.hostname
+      ),
       ...vcBody.credentialSubject,
     },
     {


### PR DESCRIPTION
According to the [ESS documentation](https://docs.inrupt.com/ess/latest/services/service-vc/#ess-vc-service-endpoints), the JON-LD context for issued VCs will depend on the issuer's domain. This adds a function to instantiate the context properly under these assumptions.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).