### PR TITLE
Do not include default VC domain in request

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,18 +60,18 @@ export const CONTEXT_VC_W3C = "https://www.w3.org/2018/credentials/v1" as const;
 
 // According to the [ESS documentation](https://docs.inrupt.com/ess/latest/services/service-vc/#ess-vc-service-endpoints),
 // the JSON-LD context for ESS-issued VCs will match the following template.
-const instanciateContextVcEssTemplate = (essDomain: string): string =>
-  `https://vc.${essDomain}/credentials/v1`;
+const instanciateContextVcEssTemplate = (essVcDomain: string): string =>
+  `https://${essVcDomain}/credentials/v1`;
 
 // When issuing a VC using a given service, be sure to set the context using the following.
 export const instanciateEssAccessGrantContext = (
-  essDomain: string
-): string[] => [CONTEXT_VC_W3C, instanciateContextVcEssTemplate(essDomain)];
+  essVcDomain: string
+): string[] => [CONTEXT_VC_W3C, instanciateContextVcEssTemplate(essVcDomain)];
 
 // A default context value is provided for mocking purpose accross the codebase.
 export const ACCESS_GRANT_CONTEXT_DEFAULT = [
   CONTEXT_VC_W3C,
-  instanciateContextVcEssTemplate("inrupt.com"),
+  instanciateContextVcEssTemplate("vc.inrupt.com"),
 ] as const;
 
 export const WELL_KNOWN_SOLID = ".well-known/solid";

--- a/src/request/issueAccessRequest.test.ts
+++ b/src/request/issueAccessRequest.test.ts
@@ -24,6 +24,7 @@
 import { jest, describe, it, expect } from "@jest/globals";
 import {
   issueVerifiableCredential,
+  JsonLd,
   VerifiableCredential,
 } from "@inrupt/solid-client-vc";
 import { issueAccessRequest } from "./issueAccessRequest";
@@ -210,15 +211,27 @@ describe("issueAccessRequest", () => {
       }
     );
 
-    expect(mockedIssue).toHaveBeenCalledWith(
-      expect.anything(),
+    // Casting is required because TS picks up the deprecated signature.
+    const subjectClaims = mockedIssue.mock.calls[0][1] as unknown as JsonLd;
+    const credentialClaims = mockedIssue.mock.calls[0][2] as unknown as
+      | JsonLd
+      | undefined;
+
+    expect(subjectClaims).toStrictEqual(
       expect.objectContaining({
         "@context": expect.arrayContaining([
-          "https://vc.access-issuer.iri/credentials/v1",
+          "https://access-issuer.iri/credentials/v1",
         ]),
-      }),
-      expect.anything(),
-      expect.anything()
+      })
+    );
+
+    // Ensure that the default context has been removed
+    expect(subjectClaims["@context"]).not.toContain(
+      ACCESS_GRANT_CONTEXT_DEFAULT
+    );
+
+    expect(credentialClaims?.["@context"]).not.toContain(
+      ACCESS_GRANT_CONTEXT_DEFAULT
     );
   });
 

--- a/src/util/issueAccessVc.ts
+++ b/src/util/issueAccessVc.ts
@@ -177,7 +177,7 @@ export async function issueAccessVc(
       ...vcBody.credentialSubject,
     },
     {
-      "@context": vcBody["@context"],
+      "@context": [],
       type: vcBody.type,
       issuanceDate: vcBody.issuanceDate,
       expirationDate: vcBody.expirationDate,

--- a/src/util/issueAccessVc.ts
+++ b/src/util/issueAccessVc.ts
@@ -177,6 +177,9 @@ export async function issueAccessVc(
       ...vcBody.credentialSubject,
     },
     {
+      // All the required context is provided by instanciateEssAccessGrantContext,
+      // and vcBody contains a default context we don't want to include in the
+      // result VC.
       "@context": [],
       type: vcBody.type,
       issuanceDate: vcBody.issuanceDate,


### PR DESCRIPTION
The default fetch is bound to the default Inrupt VC domain, and we don't want to include it in all VCs.

This fixes an issue introduced in the previous commit, which was automerged by mistake because e2e tests were not gating (which they are now).

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).