### PR TITLE
Accept URL object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### New features
+
+- `getAccessRequestFromRedirectUrl` and `getAccessGrantFromRedirectUrl` now accept URL
+  objects as well as plain strings.
+
 ## [1.1.0](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v1.1.0) - 2022-09-02
 
 ### New Features

--- a/src/manage/getAccessRequestFromRedirectUrl.test.ts
+++ b/src/manage/getAccessRequestFromRedirectUrl.test.ts
@@ -150,7 +150,7 @@ describe("getAccessRequestFromRedirectUrl", () => {
     );
 
     const { accessRequest, requestorRedirectUrl } =
-      await getAccessRequestFromRedirectUrl(redirectedToUrl.href);
+      await getAccessRequestFromRedirectUrl(redirectedToUrl);
     expect(accessRequest).toStrictEqual(mockAccessRequestVc());
     expect(requestorRedirectUrl).toBe("https://requestor.redirect.url");
   });

--- a/src/manage/getAccessRequestFromRedirectUrl.ts
+++ b/src/manage/getAccessRequestFromRedirectUrl.ts
@@ -47,13 +47,14 @@ import { getSessionFetch } from "../util/getSessionFetch";
  * @since 0.5.0
  */
 export async function getAccessRequestFromRedirectUrl(
-  redirectUrl: UrlString,
+  redirectUrl: UrlString | URL,
   options: { fetch?: typeof fetch } = {}
 ): Promise<{
   accessRequest: AccessRequest;
   requestorRedirectUrl: UrlString;
 }> {
-  const redirectUrlObj = new URL(redirectUrl);
+  const redirectUrlObj =
+    typeof redirectUrl === "string" ? new URL(redirectUrl) : redirectUrl;
   const authFetch = options.fetch ?? (await getSessionFetch(options));
 
   // Get the URL where the requestor expects the user to be redirected with

--- a/src/request/getAccessGrantFromRedirectUrl.test.ts
+++ b/src/request/getAccessGrantFromRedirectUrl.test.ts
@@ -116,7 +116,7 @@ describe("getAccessGrantFromRedirectUrl", () => {
       encodeURI("https://some.vc")
     );
 
-    const fetchedVc = await getAccessGrantFromRedirectUrl(redirectUrl.href);
+    const fetchedVc = await getAccessGrantFromRedirectUrl(redirectUrl);
     expect(fetchedVc).toStrictEqual(mockAccessGrantVc());
   });
 

--- a/src/request/getAccessGrantFromRedirectUrl.ts
+++ b/src/request/getAccessGrantFromRedirectUrl.ts
@@ -46,10 +46,11 @@ import { getSessionFetch } from "../util/getSessionFetch";
  * @since 0.5.0
  */
 export async function getAccessGrantFromRedirectUrl(
-  redirectUrl: UrlString,
+  redirectUrl: UrlString | URL,
   options: { fetch?: typeof fetch } = {}
 ): Promise<AccessGrant> {
-  const redirectUrlObj = new URL(redirectUrl);
+  const redirectUrlObj =
+    typeof redirectUrl === "string" ? new URL(redirectUrl) : redirectUrl;
   const authFetch = options.fetch ?? (await getSessionFetch(options));
 
   const accessGrantValue = redirectUrlObj.searchParams.get(GRANT_VC_PARAM_NAME);


### PR DESCRIPTION
Retrieving data from redirect URLs is a pattern this library relies on. In some cases, the URL being passed will have been parsed first, depending on the framework used, so accepting URL objects should make the API slightly friendlier to some use cases.

- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).