### PR TITLE
Disable running sonarcube on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - run: git fetch --unshallow
         if: ${{ matrix.node-version == '16' }}
       - uses: SonarSource/sonarcloud-github-action@v1.6
-        if: ${{ matrix.node-version == '16' }}
+        if: ${{ matrix.node-version == '16' && github.actor != 'dependabot[bot]' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
SonarCube requires access to repository secrets, which aren't configured yet for dependabot. When dependabot secrets are set up, this may be reversed.
