### PR TITLE
No longer accept VCs being passed by value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### Deprecation notice
+
+- `getAccessRequestFromRedirectUrl` and `getAccessGrantFromRedirectUrl` no longer
+  pick up VC passed by value, and only support passing by IRI. This is for security
+  reasons, as passing a VC by value in the IR leaks information.
+
 ### New features
 
 - `getAccessRequestFromRedirectUrl` and `getAccessGrantFromRedirectUrl` now accept URL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
-### Deprecation notice
+### Breaking change
 
 - `getAccessRequestFromRedirectUrl` and `getAccessGrantFromRedirectUrl` no longer
   pick up VC passed by value, and only support passing by IRI. This is for security
-  reasons, as passing a VC by value in the IR leaks information.
+  reasons, as passing a VC by value in the IRI leaks information. This removes a
+  behavior that has been deprecated in v0.5.0. This change doesn't affect you if
+  you are using the query parameters accessors (`getAccessRequestFromRedirectUrl`
+  and `getAccessGrantFromRedirectUrl`).
 
 ### New features
 
@@ -48,8 +51,6 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - `GRANT_VC_URL_PARAM_NAME` is now exported from the base package. This is the name of the parameter
   used in URL redirects to an access grant management application.
-
-The following changes have been implemented but not released yet:
 
 ## [1.0.0](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v1.0.0) - 2022-06-06
 

--- a/src/discover/redirectToAccessManagementUi.browser.test.ts
+++ b/src/discover/redirectToAccessManagementUi.browser.test.ts
@@ -262,34 +262,13 @@ describe("redirectToAccessManagementUi", () => {
       });
       const redirectIri = new URL(redirectCallback.mock.calls[0][0] as string);
       expect(redirectIri.origin).toBe("https://some.access.ui");
-      expect(redirectIri.searchParams.get("requestVc")).toBe(
-        base64url.encode(JSON.stringify(mockAccessRequestVc()))
+      expect(redirectIri.searchParams.get("requestVcUrl")).toBe(
+        mockAccessRequestVc().id
       );
       expect(redirectIri.searchParams.get("redirectUrl")).toBe(
         "https://some.redirect.iri"
       );
       expect(window.location.href).toBe("https://some.site");
-    });
-
-    // DEPRECATED: This test should be removed with the next major upgrade.
-    it("supports the legacy approach of passing the VC as a value in the query parameters", async () => {
-      mockAccessManagementUiDiscovery("https://some.access.ui");
-      // redirectToAccessManagementUi never resolves, which prevents checking values
-      // if it is awaited.
-      // eslint-disable-next-line no-void
-      void redirectToAccessManagementUi(
-        mockAccessRequestVc(),
-        "https://some.redirect.iri"
-      );
-      // Yield the event loop to make sure the blocking promises completes.
-      await new Promise((resolve) => {
-        setImmediate(resolve);
-      });
-      const targetIri = new URL(window.location.href);
-      const encodedVc = targetIri.searchParams.get("requestVc") as string;
-      expect(JSON.parse(base64url.decode(encodedVc).toString())).toStrictEqual(
-        mockAccessRequestVc()
-      );
     });
   });
 });

--- a/src/discover/redirectToAccessManagementUi.browser.test.ts
+++ b/src/discover/redirectToAccessManagementUi.browser.test.ts
@@ -27,7 +27,6 @@ import {
   beforeEach,
   afterEach,
 } from "@jest/globals";
-import { base64url } from "jose";
 import { redirectToAccessManagementUi } from "./redirectToAccessManagementUi";
 import {
   getAccessManagementUiFromWellKnown,

--- a/src/discover/redirectToAccessManagementUi.ts
+++ b/src/discover/redirectToAccessManagementUi.ts
@@ -21,7 +21,6 @@
 
 import { UrlString, WebId } from "@inrupt/solid-client";
 import { VerifiableCredential } from "@inrupt/solid-client-vc";
-import { base64url } from "jose";
 import { getBaseAccessRequestVerifiableCredential } from "../util/getBaseAccessVerifiableCredential";
 import { getSessionFetch } from "../util/getSessionFetch";
 import {
@@ -100,8 +99,6 @@ export async function redirectToAccessManagementUi(
 ): Promise<void> {
   const fallbackUi = options.fallbackAccessManagementUi;
 
-  // DEPRECATED: This should be removed on the next major upgrade: the VC should
-  // be passed as an IRI, and doesn't need to be dereferenced.
   const requestVc = await getBaseAccessRequestVerifiableCredential(
     accessRequestVc,
     { fetch: options.fetch }
@@ -126,9 +123,6 @@ export async function redirectToAccessManagementUi(
   return redirectWithParameters(
     accessManagementUi,
     {
-      // DEPRECATED: This should be removed on the next major upgrade. The VC should
-      // be passed as an IRI, using the REQUEST_VC_URL_PARAM_NAME query param only.
-      [`${REQUEST_VC_PARAM_NAME}`]: base64url.encode(JSON.stringify(requestVc)),
       [`${REQUEST_VC_URL_PARAM_NAME}`]: encodeURI(requestVc.id),
       [`${REDIRECT_URL_PARAM_NAME}`]: encodeURI(
         typeof redirectUrl === "string" ? redirectUrl : redirectUrl.href

--- a/src/manage/getAccessRequestFromRedirectUrl.test.ts
+++ b/src/manage/getAccessRequestFromRedirectUrl.test.ts
@@ -21,7 +21,6 @@
 
 import { describe, it, jest, expect } from "@jest/globals";
 import { getVerifiableCredential } from "@inrupt/solid-client-vc";
-import { base64url } from "jose";
 import { getAccessRequestFromRedirectUrl } from "./getAccessRequestFromRedirectUrl";
 import { mockAccessGrantVc, mockAccessRequestVc } from "../util/access.mock";
 import { getSessionFetch } from "../util/getSessionFetch";
@@ -191,47 +190,6 @@ describe("getAccessRequestFromRedirectUrl", () => {
 
     await expect(
       getAccessRequestFromRedirectUrl(redirectedToUrl.href)
-    ).rejects.toThrow();
-  });
-
-  it("supports the legacy approach of providing the VC as a value", async () => {
-    const vcModule = jest.requireMock(
-      "@inrupt/solid-client-vc"
-    ) as jest.Mocked<{
-      getVerifiableCredential: typeof getVerifiableCredential;
-    }>;
-
-    const redirectUrl = new URL("https://redirect.url");
-    redirectUrl.searchParams.append(
-      "requestVc",
-      base64url.encode(JSON.stringify(mockAccessRequestVc()))
-    );
-    redirectUrl.searchParams.append(
-      "redirectUrl",
-      encodeURI("https://requestor.redirect.url")
-    );
-
-    const { accessRequest } = await getAccessRequestFromRedirectUrl(
-      redirectUrl.href
-    );
-    expect(accessRequest).toStrictEqual(mockAccessRequestVc());
-    // When the VC is passed as a value, nothing needs to be dereferenced.
-    expect(vcModule.getVerifiableCredential).not.toHaveBeenCalled();
-  });
-
-  it("throws if the legacy provided value is not a VC", async () => {
-    const redirectUrl = new URL("https://redirect.url");
-    redirectUrl.searchParams.append(
-      "requestVc",
-      base64url.encode(JSON.stringify({ someJson: "but not a VC" }))
-    );
-    redirectUrl.searchParams.append(
-      "redirectUrl",
-      encodeURI("https://requestor.redirect.url")
-    );
-
-    await expect(
-      getAccessRequestFromRedirectUrl(redirectUrl.href)
     ).rejects.toThrow();
   });
 });

--- a/src/request/getAccessGrantFromRedirectUrl.test.ts
+++ b/src/request/getAccessGrantFromRedirectUrl.test.ts
@@ -21,7 +21,6 @@
 
 import { describe, it, jest, expect } from "@jest/globals";
 import { getVerifiableCredential } from "@inrupt/solid-client-vc";
-import { base64url } from "jose";
 import { getAccessGrantFromRedirectUrl } from "./getAccessGrantFromRedirectUrl";
 import { getSessionFetch } from "../util/getSessionFetch";
 import { mockAccessGrantVc, mockAccessRequestVc } from "../util/access.mock";
@@ -134,36 +133,6 @@ describe("getAccessGrantFromRedirectUrl", () => {
     redirectUrl.searchParams.set(
       "accessGrantUrl",
       encodeURI("https://some.vc")
-    );
-
-    await expect(
-      getAccessGrantFromRedirectUrl(redirectUrl.href)
-    ).rejects.toThrow();
-  });
-
-  it("supports the legacy approach where the VC is provided by value", async () => {
-    const vcModule = jest.requireMock(
-      "@inrupt/solid-client-vc"
-    ) as jest.Mocked<{
-      getVerifiableCredential: typeof getVerifiableCredential;
-    }>;
-    const redirectUrl = new URL("https://redirect.url");
-    redirectUrl.searchParams.set(
-      "accessGrant",
-      base64url.encode(JSON.stringify(mockAccessGrantVc()))
-    );
-
-    const grantVc = await getAccessGrantFromRedirectUrl(redirectUrl.href);
-    expect(grantVc).toStrictEqual(mockAccessGrantVc());
-    // If the VC is provided as a value, no dereferencing should happen.
-    expect(vcModule.getVerifiableCredential).not.toHaveBeenCalled();
-  });
-
-  it("throws if the legacy provided value is not a VC", async () => {
-    const redirectUrl = new URL("https://redirect.url");
-    redirectUrl.searchParams.set(
-      "accessGrant",
-      base64url.encode(JSON.stringify({ someJson: "but not a VC" }))
     );
 
     await expect(


### PR DESCRIPTION
VCs were already no longer passed by value, and only by IRI, but now a VC being passed by value will be ignored, and not picked up.

- [ ] I've added a unit test to test for potential regressions of this bug.
(Would it makes sense to add a test to verify that the legacy parameter is now ignored ? Seems a bit overkill)
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).