### PR TITLE
Override the expiration date of an access request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - `getAccessRequestFromRedirectUrl` and `getAccessGrantFromRedirectUrl` now accept URL
   objects as well as plain strings.
 - `approveAccessRequest` now accepts a `null` expiration date override, resulting
-in the expiration date from the Access Request not being applied to the Access Grant.
+  in the expiration date from the Access Request not being applied to the Access Grant.
 
 ## [1.1.0](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v1.1.0) - 2022-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - `getAccessRequestFromRedirectUrl` and `getAccessGrantFromRedirectUrl` now accept URL
   objects as well as plain strings.
+- `approveAccessRequest` now accepts a `null` expiration date override, resulting
+in the expiration date from the Access Request not being applied to the Access Grant.
 
 ## [1.1.0](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v1.1.0) - 2022-09-02
 

--- a/src/manage/approveAccessRequest.ts
+++ b/src/manage/approveAccessRequest.ts
@@ -42,9 +42,9 @@ import { isAccessGrant } from "../guard/isAccessGrant";
 import { isBaseAccessGrantVerifiableCredential } from "../guard/isBaseAccessGrantVerifiableCredential";
 
 export type ApproveAccessRequestOverrides = Omit<
-  AccessGrantParameters,
-  "status"
->;
+  Omit<AccessGrantParameters, "status">,
+  "expirationDate"
+> & { expirationDate?: Date | null };
 
 function getAccessModesFromAccessGrant(request: AccessGrantBody): AccessModes {
   const accessMode: AccessModes = {};
@@ -135,7 +135,7 @@ async function internal_approveAccessRequest(
     requestorInboxUrl: internalGrantOptions.requestorInboxUrl,
     purpose: internalGrantOptions.purpose,
     issuanceDate: internalGrantOptions.issuanceDate,
-    expirationDate: internalGrantOptions.expirationDate,
+    expirationDate: internalGrantOptions.expirationDate ?? undefined,
     status: GC_CONSENT_STATUS_EXPLICITLY_GIVEN,
   });
 

--- a/src/util/initializeGrantParameters.ts
+++ b/src/util/initializeGrantParameters.ts
@@ -84,23 +84,29 @@ export function initializeGrantParameters(
   requestVc: (AccessRequestBody & { issuanceDate: string }) | undefined,
   requestOverride?: Partial<ApproveAccessRequestOverrides>
 ): ApproveAccessRequestOverrides {
-  return requestVc === undefined
-    ? (requestOverride as ApproveAccessRequestOverrides)
-    : {
-        requestor:
-          requestOverride?.requestor ?? getRequestorFromRequest(requestVc),
-        access:
-          requestOverride?.access ??
-          modesToAccess(getModesFromRequest(requestVc)),
-        resources:
-          requestOverride?.resources ?? getResourcesFromRequest(requestVc),
-        requestorInboxUrl:
-          requestOverride?.requestorInboxUrl ?? getInboxFromRequest(requestVc),
-        issuanceDate:
-          requestOverride?.issuanceDate ?? getIssuanceFromRequest(requestVc),
-        purpose: requestOverride?.purpose ?? getPurposeFromRequest(requestVc),
-        expirationDate:
-          requestOverride?.expirationDate ??
-          getExpirationFromRequest(requestVc),
-      };
+  const resultGrant =
+    requestVc === undefined
+      ? (requestOverride as ApproveAccessRequestOverrides)
+      : {
+          requestor:
+            requestOverride?.requestor ?? getRequestorFromRequest(requestVc),
+          access:
+            requestOverride?.access ??
+            modesToAccess(getModesFromRequest(requestVc)),
+          resources:
+            requestOverride?.resources ?? getResourcesFromRequest(requestVc),
+          requestorInboxUrl:
+            requestOverride?.requestorInboxUrl ??
+            getInboxFromRequest(requestVc),
+          issuanceDate:
+            requestOverride?.issuanceDate ?? getIssuanceFromRequest(requestVc),
+          purpose: requestOverride?.purpose ?? getPurposeFromRequest(requestVc),
+          expirationDate:
+            requestOverride?.expirationDate ??
+            getExpirationFromRequest(requestVc),
+        };
+  if (requestOverride?.expirationDate === null) {
+    resultGrant.expirationDate = undefined;
+  }
+  return resultGrant;
 }


### PR DESCRIPTION
# New feature description

When approving an access request, one may provide overrides to control exactly what is being granted. In case of an undefined override value, the original value is kept. For expiration dates, it wasn't possible to erase the proposed date and just set the value to nothing. It is now possible using null instead of undefined.

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).