### PR TITLE
chore: use shared jest jsdom polyfills

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   preset: "ts-jest",
-  setupFilesAfterEnv: ["<rootDir>/tests/setupFile.js"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   clearMocks: true,
   injectGlobals: false,
   collectCoverage: true,

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -19,28 +19,4 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-/* eslint-disable global-require */
-/* eslint-disable @typescript-eslint/no-var-requires */
-
-// TextEncoder / TextDecoder APIs are used by Jose, but are not provided by
-// jsdom, all node versions supported provide these via the util module
-if (
-  typeof globalThis.TextEncoder === "undefined" ||
-  typeof globalThis.TextDecoder === "undefined"
-) {
-  const utils = require("util");
-  globalThis.TextEncoder = utils.TextEncoder;
-  globalThis.TextDecoder = utils.TextDecoder;
-}
-
-// Node.js doesn't support Blob or File, so we're polyfilling those with
-// https://github.com/web-std/io
-if (typeof globalThis.Blob === "undefined") {
-  const stdBlob = require("@web-std/blob");
-  globalThis.Blob = stdBlob.Blob;
-}
-
-if (typeof globalThis.File === "undefined") {
-  const stdFile = require("@web-std/file");
-  globalThis.File = stdFile.File;
-}
+import "@inrupt/jest-jsdom-polyfills";

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@inrupt/eslint-config-lib": "^1.0.0",
+        "@inrupt/jest-jsdom-polyfills": "^1.3.0",
         "@inrupt/solid-client-authn-browser": "^1.12.1",
         "@inrupt/solid-client-authn-node": "^1.12.1",
         "@playwright/test": "^1.23.0",
@@ -29,8 +30,6 @@
         "@types/dotenv-flow": "^3.1.0",
         "@types/jest": "^27.4.0",
         "@types/parse-link-header": "^2.0.0",
-        "@web-std/blob": "^3.0.4",
-        "@web-std/file": "^3.0.2",
         "dotenv-flow": "^3.2.0",
         "eslint": "^8.18.0",
         "jest": "^27.5.1",
@@ -713,6 +712,16 @@
         "@typescript-eslint/eslint-plugin": "^5.29.0",
         "@typescript-eslint/parser": "^5.29.0",
         "typescript": ">=4.7.4"
+      }
+    },
+    "node_modules/@inrupt/jest-jsdom-polyfills": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.3.0.tgz",
+      "integrity": "sha512-ynGhXWGbbyf0h5YrEV5ndzpwkgAQzgyhiJ4/psZKcb5Ra+pkTjBNMe1In1VeNs0uJJRH99LCAvI47FJagyTVyQ==",
+      "dev": true,
+      "dependencies": {
+        "@web-std/blob": "^3.0.4",
+        "@web-std/file": "^3.0.2"
       }
     },
     "node_modules/@inrupt/oidc-client": {
@@ -9265,6 +9274,16 @@
         "@typescript-eslint/eslint-plugin": "^5.29.0",
         "@typescript-eslint/parser": "^5.29.0",
         "typescript": ">=4.7.4"
+      }
+    },
+    "@inrupt/jest-jsdom-polyfills": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.3.0.tgz",
+      "integrity": "sha512-ynGhXWGbbyf0h5YrEV5ndzpwkgAQzgyhiJ4/psZKcb5Ra+pkTjBNMe1In1VeNs0uJJRH99LCAvI47FJagyTVyQ==",
+      "dev": true,
+      "requires": {
+        "@web-std/blob": "^3.0.4",
+        "@web-std/file": "^3.0.2"
       }
     },
     "@inrupt/oidc-client": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   },
   "devDependencies": {
     "@inrupt/eslint-config-lib": "^1.0.0",
+    "@inrupt/jest-jsdom-polyfills": "^1.3.0",
     "@inrupt/solid-client-authn-browser": "^1.12.1",
     "@inrupt/solid-client-authn-node": "^1.12.1",
     "@playwright/test": "^1.23.0",
@@ -88,8 +89,6 @@
     "@types/dotenv-flow": "^3.1.0",
     "@types/jest": "^27.4.0",
     "@types/parse-link-header": "^2.0.0",
-    "@web-std/blob": "^3.0.4",
-    "@web-std/file": "^3.0.2",
     "dotenv-flow": "^3.2.0",
     "eslint": "^8.18.0",
     "jest": "^27.5.1",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,6 +4,7 @@
     "src/**/*.test.ts",
     "e2e/**/*.ts",
     "examples/**/*.ts",
-    "tests/**/*.js"
+    "jest.config.ts",
+    "jest.setup.ts"
   ]
 }


### PR DESCRIPTION
This migrates this SDK to our recently released `@inrupt/jest-jsdom-polyfills` package.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
