### PR TITLE
ODRL/gConsent Grant types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### New features
 
+- `AccessGrantOdrl`, `AccessGrantGConsent` and `AccessGrantAny` types: Both the
+  ODRL-based and the GConsent-based Access Grants now have an explicit associated
+  type. Functions that support both data model may use the `AccessGrantAllAny` union
+  type.
 - `gConsent` and `odrl` API objects: in order to support a new schema for Access
   Grants, new functions will be added to the API. They will not be compatible with
   the current data model, so the new API will be exported via the `odrl` object

--- a/package.json
+++ b/package.json
@@ -44,12 +44,11 @@
     "./discover": "./dist/gConsent/discover/index.mjs",
     "./manage": "./dist/gConsent/manage/index.mjs",
     "./request": "./dist/gConsent/request/index.mjs",
-    "./verify": "./dist/gConsent/verify/index.mjs",
+    "./verify": "./dist/common/verify/index.mjs",
     "./gConsent": "./dist/gConsent/index.mjs",
     "./gConsent/discover": "./dist/gConsent/discover/index.mjs",
     "./gConsent/manage": "./dist/gConsent/manage/index.mjs",
     "./gConsent/request": "./dist/gConsent/request/index.mjs",
-    "./gConsent/verify": "./dist/gConsent/verify/index.mjs",
     "./odrl": "./dist/odrl/index.mjs"
   },
   "typesVersions": {
@@ -64,7 +63,7 @@
         "dist/gConsent/request/index.d.ts"
       ],
       "verify": [
-        "dist/gConsent/verify/index.d.ts"
+        "dist/common/verify/index.d.ts"
       ],
       "resource": [
         "dist/resource/index.d.ts"
@@ -84,7 +83,7 @@
         "dist/gConsent/request/index.d.ts"
       ],
       "verify": [
-        "dist/gConsent/verify/index.d.ts"
+        "dist/common/verify/index.d.ts"
       ]
     }
   },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -83,6 +83,7 @@ export default [
       "./src/gConsent/type/IssueAccessRequestParameters.ts",
       "./src/gConsent/type/Parameter.ts",
       "./src/gConsent/type/ResourceAccessMode.ts",
+      "./src/odrl/type/AccessGrant.ts",
     ],
     output: {
       dir: "dist",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -56,7 +56,8 @@ export default [
       "./src/gConsent/discover/index.ts",
       "./src/gConsent/manage/index.ts",
       "./src/gConsent/request/index.ts",
-      "./src/gConsent/verify/index.ts",
+      "./src/common/verify/index.ts",
+      "./src/odrl/index.ts",
     ],
     output: {
       dir: "dist",

--- a/src/common/index.test.ts
+++ b/src/common/index.test.ts
@@ -19,12 +19,11 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-/**
- * Import this module for the access API functions available to an entity
- * verifying issued credentials for access over a resource.
- * @packageDocumentation
- */
+import { describe, it, expect } from "@jest/globals";
+import { isValidAccessGrant } from "./index";
 
-// This reexports code that has been moved to the common package, because it isn't
-// GConsent-specific.
-export { isValidAccessGrant } from "../../common/verify/isValidAccessGrant";
+describe("Index exports", () => {
+  it("exposes expected things", () => {
+    expect(isValidAccessGrant).toBeDefined();
+  });
+});

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -19,37 +19,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export type { AccessGrant, AccessGrantGConsent } from "./type/AccessGrant";
-export type {
-  AccessRequest,
-  AccessRequestGConsent,
-} from "./type/AccessRequest";
-export type { AccessBaseOptions } from "./type/AccessBaseOptions";
-export type { AccessCredentialType } from "./type/AccessCredentialType";
-export type { AccessGrantContext } from "./type/AccessGrantContext";
-export type { ApproveAccessRequestOverrides } from "./manage/approveAccessRequest";
-export type { IssueAccessRequestParameters } from "./type/IssueAccessRequestParameters";
-export type { RedirectToAccessManagementUiOptions } from "./discover";
+// This file is used to create a 'common' API object from the top-level exports.
 
-export {
-  getAccessApiEndpoint,
-  getAccessManagementUi,
-  redirectToAccessManagementUi,
-} from "./discover";
-
-export {
-  issueAccessRequest,
-  cancelAccessRequest,
-  getAccessGrantFromRedirectUrl,
-} from "./request";
-
-export {
-  approveAccessRequest,
-  denyAccessRequest,
-  getAccessGrant,
-  getAccessGrantAll,
-  getAccessRequestFromRedirectUrl,
-  redirectToRequestor,
-  revokeAccessGrant,
-  GRANT_VC_URL_PARAM_NAME,
-} from "./manage";
+export { isValidAccessGrant } from "./verify/isValidAccessGrant";

--- a/src/common/util/getSessionFetch.ts
+++ b/src/common/util/getSessionFetch.ts
@@ -20,7 +20,7 @@
 //
 
 import { fetch as crossFetch } from "cross-fetch";
-import { AccessBaseOptions } from "../type/AccessBaseOptions";
+import { AccessBaseOptions } from "../../gConsent/type/AccessBaseOptions";
 
 /**
  * Dynamically import solid-client-authn-browser so that

--- a/src/common/verify/index.test.ts
+++ b/src/common/verify/index.test.ts
@@ -19,37 +19,11 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export type { AccessGrant, AccessGrantGConsent } from "./type/AccessGrant";
-export type {
-  AccessRequest,
-  AccessRequestGConsent,
-} from "./type/AccessRequest";
-export type { AccessBaseOptions } from "./type/AccessBaseOptions";
-export type { AccessCredentialType } from "./type/AccessCredentialType";
-export type { AccessGrantContext } from "./type/AccessGrantContext";
-export type { ApproveAccessRequestOverrides } from "./manage/approveAccessRequest";
-export type { IssueAccessRequestParameters } from "./type/IssueAccessRequestParameters";
-export type { RedirectToAccessManagementUiOptions } from "./discover";
+import { describe, it, expect } from "@jest/globals";
+import { isValidAccessGrant } from "./index";
 
-export {
-  getAccessApiEndpoint,
-  getAccessManagementUi,
-  redirectToAccessManagementUi,
-} from "./discover";
-
-export {
-  issueAccessRequest,
-  cancelAccessRequest,
-  getAccessGrantFromRedirectUrl,
-} from "./request";
-
-export {
-  approveAccessRequest,
-  denyAccessRequest,
-  getAccessGrant,
-  getAccessGrantAll,
-  getAccessRequestFromRedirectUrl,
-  redirectToRequestor,
-  revokeAccessGrant,
-  GRANT_VC_URL_PARAM_NAME,
-} from "./manage";
+describe("Index exports", () => {
+  it("exposes expected things", () => {
+    expect(isValidAccessGrant).toBeDefined();
+  });
+});

--- a/src/common/verify/index.ts
+++ b/src/common/verify/index.ts
@@ -19,37 +19,4 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export type { AccessGrant, AccessGrantGConsent } from "./type/AccessGrant";
-export type {
-  AccessRequest,
-  AccessRequestGConsent,
-} from "./type/AccessRequest";
-export type { AccessBaseOptions } from "./type/AccessBaseOptions";
-export type { AccessCredentialType } from "./type/AccessCredentialType";
-export type { AccessGrantContext } from "./type/AccessGrantContext";
-export type { ApproveAccessRequestOverrides } from "./manage/approveAccessRequest";
-export type { IssueAccessRequestParameters } from "./type/IssueAccessRequestParameters";
-export type { RedirectToAccessManagementUiOptions } from "./discover";
-
-export {
-  getAccessApiEndpoint,
-  getAccessManagementUi,
-  redirectToAccessManagementUi,
-} from "./discover";
-
-export {
-  issueAccessRequest,
-  cancelAccessRequest,
-  getAccessGrantFromRedirectUrl,
-} from "./request";
-
-export {
-  approveAccessRequest,
-  denyAccessRequest,
-  getAccessGrant,
-  getAccessGrantAll,
-  getAccessRequestFromRedirectUrl,
-  redirectToRequestor,
-  revokeAccessGrant,
-  GRANT_VC_URL_PARAM_NAME,
-} from "./manage";
+export { isValidAccessGrant } from "./isValidAccessGrant";

--- a/src/common/verify/isValidAccessGrant.test.ts
+++ b/src/common/verify/isValidAccessGrant.test.ts
@@ -124,9 +124,6 @@ describe("isValidAccessGrant", () => {
   });
 
   it("retrieves the vc if a url was passed", async () => {
-    jest.mocked(getVerifiableCredentialApiConfiguration).mockResolvedValueOnce({
-      verifierService: "https://some.vc.verifier",
-    });
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest
       .fn(global.fetch)
@@ -143,7 +140,7 @@ describe("isValidAccessGrant", () => {
 
     await isValidAccessGrant("https://example.com/someVc", {
       fetch: mockedFetch as typeof fetch,
-      accessEndpoint: MOCK_ACCESS_ENDPOINT,
+      verificationEndpoint: MOCK_ACCESS_ENDPOINT,
     });
 
     expect(mockedFetch).toHaveBeenCalledWith("https://example.com/someVc");
@@ -160,7 +157,7 @@ describe("isValidAccessGrant", () => {
     await expect(
       isValidAccessGrant("https://example.com/someVc", {
         fetch: mockedFetch as typeof fetch,
-        accessEndpoint: MOCK_ACCESS_ENDPOINT,
+        verificationEndpoint: MOCK_ACCESS_ENDPOINT,
       })
     ).rejects.toThrow(
       "The request to [https://example.com/someVc] returned an unexpected response:"

--- a/src/common/verify/isValidAccessGrant.ts
+++ b/src/common/verify/isValidAccessGrant.ts
@@ -25,7 +25,6 @@ import {
   VerifiableCredential,
   getVerifiableCredentialApiConfiguration,
 } from "@inrupt/solid-client-vc";
-import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import { getSessionFetch } from "../util/getSessionFetch";
 
 /**
@@ -39,8 +38,9 @@ import { getSessionFetch } from "../util/getSessionFetch";
 // TODO: Push verification further as this just checks it's a valid VC should we not type check the consent grant?
 async function isValidAccessGrant(
   vc: VerifiableCredential | URL | UrlString,
-  options: Exclude<AccessBaseOptions, "accessEndpoint"> & {
+  options: {
     verificationEndpoint?: UrlString;
+    fetch?: typeof fetch;
   } = {}
 ): Promise<{ checks: string[]; warnings: string[]; errors: string[] }> {
   const fetcher = await getSessionFetch(options);

--- a/src/gConsent/discover/getAccessManagementUi.ts
+++ b/src/gConsent/discover/getAccessManagementUi.ts
@@ -27,7 +27,7 @@ import {
   getWellKnownSolid,
   UrlString,
 } from "@inrupt/solid-client";
-import { getSessionFetch } from "../util/getSessionFetch";
+import { getSessionFetch } from "../../common/util/getSessionFetch";
 import { AccessBaseOptions } from "../type/AccessBaseOptions";
 import { PIM_STORAGE, PREFERRED_CONSENT_MANAGEMENT_UI } from "../constants";
 

--- a/src/gConsent/discover/redirectToAccessManagementUi.ts
+++ b/src/gConsent/discover/redirectToAccessManagementUi.ts
@@ -22,7 +22,7 @@
 import { UrlString, WebId } from "@inrupt/solid-client";
 import { VerifiableCredential } from "@inrupt/solid-client-vc";
 import { getBaseAccessRequestVerifiableCredential } from "../util/getBaseAccessVerifiableCredential";
-import { getSessionFetch } from "../util/getSessionFetch";
+import { getSessionFetch } from "../../common/util/getSessionFetch";
 import {
   getAccessManagementUi,
   getAccessManagementUiFromWellKnown,

--- a/src/gConsent/guard/isAccessGrant.ts
+++ b/src/gConsent/guard/isAccessGrant.ts
@@ -40,3 +40,5 @@ export function isAccessGrant(
       .isProvidedTo === "string"
   );
 }
+
+export const CredentialIsAccessGrantGConsent = isAccessGrant;

--- a/src/gConsent/index.ts
+++ b/src/gConsent/index.ts
@@ -19,11 +19,14 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export type { AccessGrant } from "./type/AccessGrant";
+export type { AccessGrant, AccessGrantGConsent } from "./type/AccessGrant";
+export type {
+  AccessRequest,
+  AccessRequestGConsent,
+} from "./type/AccessRequest";
 export type { AccessBaseOptions } from "./type/AccessBaseOptions";
 export type { AccessCredentialType } from "./type/AccessCredentialType";
 export type { AccessGrantContext } from "./type/AccessGrantContext";
-export type { AccessRequest } from "./type/AccessRequest";
 export type { ApproveAccessRequestOverrides } from "./manage/approveAccessRequest";
 export type { IssueAccessRequestParameters } from "./type/IssueAccessRequestParameters";
 export type { RedirectToAccessManagementUiOptions } from "./discover";

--- a/src/gConsent/manage/approveAccessRequest.ts
+++ b/src/gConsent/manage/approveAccessRequest.ts
@@ -37,7 +37,7 @@ import {
 } from "../constants";
 import { getBaseAccessRequestVerifiableCredential } from "../util/getBaseAccessVerifiableCredential";
 import { initializeGrantParameters } from "../util/initializeGrantParameters";
-import { getSessionFetch } from "../util/getSessionFetch";
+import { getSessionFetch } from "../../common/util/getSessionFetch";
 import { isAccessGrant } from "../guard/isAccessGrant";
 import { isBaseAccessGrantVerifiableCredential } from "../guard/isBaseAccessGrantVerifiableCredential";
 

--- a/src/gConsent/manage/getAccessGrant.ts
+++ b/src/gConsent/manage/getAccessGrant.ts
@@ -25,7 +25,7 @@ import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import type { AccessGrant } from "../type/AccessGrant";
 import { isBaseAccessGrantVerifiableCredential } from "../guard/isBaseAccessGrantVerifiableCredential";
 import { isAccessGrant } from "../guard/isAccessGrant";
-import { getSessionFetch } from "../util/getSessionFetch";
+import { getSessionFetch } from "../../common/util/getSessionFetch";
 
 /**
  * Retrieve the Access Grant associated to the given URL.

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -30,7 +30,7 @@ import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import type { RecursivePartial } from "../../type/RecursivePartial";
 import type { IssueAccessRequestParameters } from "../type/IssueAccessRequestParameters";
 import { accessToResourceAccessModeArray } from "../util/accessToResourceAccessModeArray";
-import { getSessionFetch } from "../util/getSessionFetch";
+import { getSessionFetch } from "../../common/util/getSessionFetch";
 import type { BaseGrantBody } from "../type/AccessVerifiableCredential";
 
 /**

--- a/src/gConsent/manage/getAccessRequestFromRedirectUrl.test.ts
+++ b/src/gConsent/manage/getAccessRequestFromRedirectUrl.test.ts
@@ -23,9 +23,9 @@ import { describe, it, jest, expect } from "@jest/globals";
 import { getVerifiableCredential } from "@inrupt/solid-client-vc";
 import { getAccessRequestFromRedirectUrl } from "./getAccessRequestFromRedirectUrl";
 import { mockAccessGrantVc, mockAccessRequestVc } from "../util/access.mock";
-import { getSessionFetch } from "../util/getSessionFetch";
+import { getSessionFetch } from "../../common/util/getSessionFetch";
 
-jest.mock("../util/getSessionFetch");
+jest.mock("../../common/util/getSessionFetch");
 jest.mock("@inrupt/solid-client-vc", () => {
   const vcModule = jest.requireActual("@inrupt/solid-client-vc") as any;
   return {
@@ -62,7 +62,7 @@ describe("getAccessRequestFromRedirectUrl", () => {
   it("uses the default fetch if none is provided", async () => {
     const mockedFetch = jest.fn(fetch);
     const embeddedFetch = jest.requireMock(
-      "../util/getSessionFetch"
+      "../../common/util/getSessionFetch"
     ) as jest.Mocked<{ getSessionFetch: typeof getSessionFetch }>;
     embeddedFetch.getSessionFetch.mockResolvedValueOnce(mockedFetch);
 

--- a/src/gConsent/manage/getAccessRequestFromRedirectUrl.ts
+++ b/src/gConsent/manage/getAccessRequestFromRedirectUrl.ts
@@ -27,7 +27,7 @@ import {
 } from "../discover/redirectToAccessManagementUi";
 import { isAccessRequest } from "../guard/isAccessRequest";
 import type { AccessRequest } from "../type/AccessRequest";
-import { getSessionFetch } from "../util/getSessionFetch";
+import { getSessionFetch } from "../../common/util/getSessionFetch";
 
 /**
  * Get the Access Request out of the incoming redirect from the Access Management app.

--- a/src/gConsent/manage/revokeAccessGrant.ts
+++ b/src/gConsent/manage/revokeAccessGrant.ts
@@ -26,7 +26,7 @@ import {
 } from "@inrupt/solid-client-vc";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import { getBaseAccessGrantVerifiableCredential } from "../util/getBaseAccessVerifiableCredential";
-import { getSessionFetch } from "../util/getSessionFetch";
+import { getSessionFetch } from "../../common/util/getSessionFetch";
 
 /**
  * Makes a request to the access server to revoke a given Verifiable Credential (VC).

--- a/src/gConsent/request/getAccessGrantFromRedirectUrl.test.ts
+++ b/src/gConsent/request/getAccessGrantFromRedirectUrl.test.ts
@@ -22,10 +22,10 @@
 import { describe, it, jest, expect } from "@jest/globals";
 import { getVerifiableCredential } from "@inrupt/solid-client-vc";
 import { getAccessGrantFromRedirectUrl } from "./getAccessGrantFromRedirectUrl";
-import { getSessionFetch } from "../util/getSessionFetch";
+import { getSessionFetch } from "../../common/util/getSessionFetch";
 import { mockAccessGrantVc, mockAccessRequestVc } from "../util/access.mock";
 
-jest.mock("../util/getSessionFetch");
+jest.mock("../../common/util/getSessionFetch");
 jest.mock("@inrupt/solid-client-vc", () => {
   // TypeScript can't infer the type of modules imported via Jest;
   // skip type checking for those:
@@ -47,7 +47,7 @@ describe("getAccessGrantFromRedirectUrl", () => {
   it("uses the default fetch if none is provided", async () => {
     const mockedFetch = jest.fn(fetch);
     const embeddedFetch = jest.requireMock(
-      "../util/getSessionFetch"
+      "../../common/util/getSessionFetch"
     ) as jest.Mocked<{ getSessionFetch: typeof getSessionFetch }>;
     embeddedFetch.getSessionFetch.mockResolvedValueOnce(mockedFetch);
 

--- a/src/gConsent/request/getAccessGrantFromRedirectUrl.ts
+++ b/src/gConsent/request/getAccessGrantFromRedirectUrl.ts
@@ -25,7 +25,7 @@ import type { AccessGrant } from "../type/AccessGrant";
 import { isAccessGrant } from "../guard/isAccessGrant";
 import { isBaseAccessVcBody } from "../guard/isBaseAccessVcBody";
 import { GRANT_VC_URL_PARAM_NAME } from "../manage/redirectToRequestor";
-import { getSessionFetch } from "../util/getSessionFetch";
+import { getSessionFetch } from "../../common/util/getSessionFetch";
 
 /**
  * Get the Access Grant out of the incoming redirect from the Access Management app.

--- a/src/gConsent/type/AccessRequest.ts
+++ b/src/gConsent/type/AccessRequest.ts
@@ -23,3 +23,6 @@ import type { VerifiableCredential } from "@inrupt/solid-client-vc";
 import type { AccessRequestBody } from "./AccessVerifiableCredential";
 
 export type AccessRequest = VerifiableCredential & AccessRequestBody;
+// Alias with the explicit GConsent suffix, to be used in functions accepting both
+// gConsent-based and ODRL-based grants.
+export type AccessRequestGConsent = AccessRequest;

--- a/src/gConsent/util/getBaseAccessVerifiableCredential.ts
+++ b/src/gConsent/util/getBaseAccessVerifiableCredential.ts
@@ -26,7 +26,7 @@ import type {
   AccessGrantBody,
   AccessRequestBody,
 } from "../type/AccessVerifiableCredential";
-import { getSessionFetch } from "./getSessionFetch";
+import { getSessionFetch } from "../../common/util/getSessionFetch";
 import { isBaseAccessRequestVerifiableCredential } from "../guard/isBaseAccessRequestVerifiableCredential";
 import { isBaseAccessGrantVerifiableCredential } from "../guard/isBaseAccessGrantVerifiableCredential";
 

--- a/src/gConsent/util/issueAccessVc.ts
+++ b/src/gConsent/util/issueAccessVc.ts
@@ -30,7 +30,7 @@ import {
   instanciateEssAccessGrantContext,
 } from "../constants";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
-import { getSessionFetch } from "./getSessionFetch";
+import { getSessionFetch } from "../../common/util/getSessionFetch";
 import type {
   AccessGrantBody,
   AccessRequestBody,

--- a/src/gConsent/verify/index.ts
+++ b/src/gConsent/verify/index.ts
@@ -25,5 +25,6 @@
  * @packageDocumentation
  */
 
-// TODO: Allow verification of different types of consent & access grants
-export { isValidAccessGrant } from "./isValidAccessGrant";
+// This reexports code that has been moved to the common package, because it isn't
+// GConsent-specific.
+export { isValidAccessGrant } from "../../common/verify/isValidAccessGrant";

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export type {
 export type { FetchOptions } from "./type/FetchOptions";
 export type { RedirectOptions } from "./type/RedirectOptions";
 export type { AccessModes } from "./type/AccessModes";
+export type { AccessGrantAny } from "./type/AccessGrant";
 
 export {
   getAccessApiEndpoint,

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,6 @@ export {
   redirectToRequestor,
   revokeAccessGrant,
   GRANT_VC_URL_PARAM_NAME,
-  isValidAccessGrant,
 } from "./gConsent";
 
 // Add an API object to the exports to allow explicitly relying on the gConsent-based
@@ -63,6 +62,10 @@ export * as gConsent from "./gConsent";
  * @from unreleased
  */
 export * as odrl from "./odrl";
+
+export { isValidAccessGrant } from "./common/verify";
+
+export * as common from "./common";
 
 export { fetchWithVc } from "./fetch";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export type {
 
 export type { FetchOptions } from "./type/FetchOptions";
 export type { RedirectOptions } from "./type/RedirectOptions";
-export type { AccessModes } from "./type/AccessModes";
+export type { AccessModes, SerializedAccessModes } from "./type/AccessModes";
 export type { AccessGrantAny } from "./type/AccessGrant";
 
 export {

--- a/src/odrl/index.test.ts
+++ b/src/odrl/index.test.ts
@@ -19,11 +19,11 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export type {
-  AccessGrantOdrl,
-  CredentialSubjectOdrl,
-  OdrlConstraint,
-  OdrlPermission,
-} from "./type/AccessGrant";
+import { describe, it, expect } from "@jest/globals";
+import { isCredentialAccessGrantOdrl } from "./index";
 
-export { isCredentialAccessGrantOdrl } from "./type/AccessGrant";
+describe("Index exports", () => {
+  it("exposes expected things", () => {
+    expect(isCredentialAccessGrantOdrl).toBeDefined();
+  });
+});

--- a/src/odrl/index.ts
+++ b/src/odrl/index.ts
@@ -19,5 +19,9 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// TODO Remove when actually exporting functions from the odrl module.
-export const DUMMY_CONSTANT = 0;
+export type {
+  AccessGrantOdrl,
+  CredentialSubjectOdrl,
+  OdrlConstraint,
+  OdrlPermission,
+} from "./type/AccessGrant";

--- a/src/odrl/type/AccessGrant.test.ts
+++ b/src/odrl/type/AccessGrant.test.ts
@@ -22,7 +22,6 @@
 import { it, describe, expect } from "@jest/globals";
 import {
   AccessGrantOdrl,
-  CredentialSubjectOdrl,
   isCredentialAccessGrantOdrl,
   OdrlConstraint,
   OdrlPermission,

--- a/src/odrl/type/AccessGrant.test.ts
+++ b/src/odrl/type/AccessGrant.test.ts
@@ -1,0 +1,400 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { it, describe, expect } from "@jest/globals";
+import {
+  AccessGrantOdrl,
+  CredentialSubjectOdrl,
+  isCredentialAccessGrantOdrl,
+  OdrlConstraint,
+  OdrlPermission,
+} from "./AccessGrant";
+
+const mockAccessGrantOdrl: AccessGrantOdrl = {
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/security/suites/ed25519-2020/v1",
+    "https://www.w3.org/ns/odrl.jsonld",
+    "https://www.w3.org/ns/dpv.jsonld",
+    "https://www.w3.org/ns/solid/access.jsonld",
+  ],
+  id: "https://vc.inrupt.com/credentials/{UUID}",
+  type: ["VerifiableCredential", "SolidAccessGrant"],
+  issuer: "https://vc.inrupt.com",
+  holder: "{WebID-friend}",
+  issuanceDate: "2022-06-15T00:00:00Z",
+  expirationDate: "2022-06-30T00:00:00Z",
+  credentialSubject: {
+    id: "{WebID-owner}",
+    type: "Agreement",
+    profile: "https://www.w3.org/ns/solid/odrl/access",
+    assigner: "{WebID-owner}",
+    assignee: "{WebID-friend}",
+    permission: [
+      {
+        target: "https://storage.inrupt.com/{UUID}/data/",
+        action: ["read", "write"],
+        constraint: [
+          {
+            leftOperand: "purpose",
+            operator: "eq",
+            rightOperand: "InnovativeUseOfNewTechnologies",
+          },
+          {
+            leftOperand: "application",
+            operator: "eq",
+            rightOperand: "https://app.example/id",
+          },
+        ],
+      },
+    ],
+    prohibition: [
+      {
+        target: "https://storage.inrupt.com/{UUID}/data/private/",
+        action: ["read", "write"],
+      },
+    ],
+  },
+  proof: {
+    type: "Ed25519Signature2020",
+    created: "2022-06-15T00:00:00Z",
+    proofValue: "z5SpZtDGGz5a89PJbQT2sg...zmw1jMAR9PJU9mowshQFFdGmDN14D",
+    proofPurpose: "assertionMethod",
+    verificationMethod: "https://issuer.example/key-1",
+  },
+};
+
+const mockConstraint = (
+  mockAccessGrantOdrl.credentialSubject.permission[0]
+    .constraint as OdrlConstraint[]
+)[0];
+
+describe("Valid Access Grants are recognized", () => {
+  it("Validates a full ODRL-based Access Grant VC", () => {
+    expect(isCredentialAccessGrantOdrl(mockAccessGrantOdrl)).toBe(true);
+  });
+
+  it("Validates an ODRL-based Access Grant VC without a prohibition.", () => {
+    expect(
+      isCredentialAccessGrantOdrl({
+        ...mockAccessGrantOdrl,
+        credentialSubject: {
+          ...mockAccessGrantOdrl.credentialSubject,
+          prohibition: undefined,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("Validates an ODRL-based Access Grant VC without a constraint.", () => {
+    expect(
+      isCredentialAccessGrantOdrl({
+        ...mockAccessGrantOdrl,
+        credentialSubject: {
+          ...mockAccessGrantOdrl.credentialSubject,
+          permission: [
+            {
+              ...mockAccessGrantOdrl.credentialSubject.permission[0],
+              constraint: undefined,
+            },
+          ],
+        },
+      })
+    ).toBe(true);
+  });
+});
+
+describe("Invalid Access Grants are rejected", () => {
+  it("Rejects an ODRL-based Access Grant missing the SolidAccessGrant type", () => {
+    expect(
+      isCredentialAccessGrantOdrl({
+        ...mockAccessGrantOdrl,
+        type: [],
+      })
+    ).toBe(false);
+  });
+
+  describe("Rejects ODRL-based Access Grant with an invalid credentialSubject", () => {
+    it("Rejects an ODRL-based Access Grant subject missing the SolidAccessGrant type", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            type: "InvalidType",
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("Rejects an ODRL-based Access Grant subject without the Agreement type", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            type: "InvalidType",
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("Rejects an ODRL-based Access Grant subject without the odrl:access profile", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            profile: "https://some.invalid/profile",
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("Rejects an ODRL-based Access Grant subject without an assigner", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            assigner: undefined,
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("Rejects an ODRL-based Access Grant subject without an assignee", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            assignee: undefined,
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("Rejects an ODRL-based Access Grant subject without a permission array", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            permission: undefined,
+          },
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("Rejects ODRL-based Access Grant with invalid permissions", () => {
+    it("Rejects an ODRL-based Access Grant permission without a target", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            permission: [
+              {
+                ...mockAccessGrantOdrl.credentialSubject.permission[0],
+                target: undefined,
+              },
+            ],
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("Rejects an ODRL-based Access Grant permission without an action array", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            permission: [
+              {
+                ...mockAccessGrantOdrl.credentialSubject.permission[0],
+                action: undefined,
+              },
+            ],
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("Rejects an ODRL-based Access Grant permission with unknown actions", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            permission: [
+              {
+                ...mockAccessGrantOdrl.credentialSubject.permission[0],
+                action: ["some invalid action"],
+              },
+            ],
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("Rejects an ODRL-based Access Grant permission with unknown constraints", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            permission: [
+              {
+                ...mockAccessGrantOdrl.credentialSubject.permission[0],
+                constraint: "some invalid constraint",
+              },
+            ],
+          },
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("Rejects ODRL-based Access Grant with invalid constraints", () => {
+    it("Rejects an ODRL-based Access Grant permission with an unknown left operand", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            permission: [
+              {
+                ...mockAccessGrantOdrl.credentialSubject.permission[0],
+                constraint: [
+                  {
+                    ...mockConstraint,
+                    leftOperand: "Some unknown operand",
+                  },
+                ],
+              },
+            ],
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("Rejects an ODRL-based Access Grant permission with an unknown operator", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            permission: [
+              {
+                ...mockAccessGrantOdrl.credentialSubject.permission[0],
+                constraint: [
+                  {
+                    ...mockConstraint,
+                    operator: "Some unknown operator",
+                  },
+                ],
+              },
+            ],
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("Rejects an ODRL-based Access Grant permission without a right operand", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            permission: [
+              {
+                ...mockAccessGrantOdrl.credentialSubject.permission[0],
+                constraint: [
+                  {
+                    ...mockConstraint,
+                    rightOperand: undefined,
+                  },
+                ],
+              },
+            ],
+          },
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("Rejects ODRL-based Access Grant with invalid prohibitions", () => {
+    it("Rejects an ODRL-based Access Grant prohibitions with a malformed prohibition", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            prohibition: "some invalid prohibition",
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("Rejects an ODRL-based Access Grant prohibitions without a target", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            prohibition: [
+              {
+                ...(
+                  mockAccessGrantOdrl.credentialSubject
+                    .prohibition as OdrlPermission[]
+                )[0],
+                target: undefined,
+              },
+            ],
+          },
+        })
+      ).toBe(false);
+    });
+
+    it("Rejects an ODRL-based Access Grant permission without an action array", () => {
+      expect(
+        isCredentialAccessGrantOdrl({
+          ...mockAccessGrantOdrl,
+          credentialSubject: {
+            ...mockAccessGrantOdrl.credentialSubject,
+            prohibition: [
+              {
+                ...(
+                  mockAccessGrantOdrl.credentialSubject
+                    .prohibition as OdrlPermission[]
+                )[0],
+                action: undefined,
+              },
+            ],
+          },
+        })
+      ).toBe(false);
+    });
+  });
+});

--- a/src/odrl/type/AccessGrant.ts
+++ b/src/odrl/type/AccessGrant.ts
@@ -1,0 +1,174 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import type { Iri, VerifiableCredential } from "@inrupt/solid-client-vc";
+import {
+  SerializedAccessModes,
+  SERIALIZED_ACCESS_MODES,
+} from "../../type/AccessModes";
+
+const ODRL_ACCESS = "https://www.w3.org/ns/solid/odrl/access";
+
+const ODRL_CONSTRAINTS = ["purpose" as const, "application" as const];
+type OdrlConstraintTypes = typeof ODRL_CONSTRAINTS extends Array<infer E>
+  ? E
+  : never;
+
+const ODRL_OPERATORS = ["eq" as const];
+type OdrlOperatorTypes = typeof ODRL_OPERATORS extends Array<infer E>
+  ? E
+  : never;
+
+export type OdrlConstraint = {
+  leftOperand: OdrlConstraintTypes;
+  operator: OdrlOperatorTypes;
+  rightOperand: string | Iri;
+};
+
+export type OdrlPermission = {
+  target: Iri;
+  action: SerializedAccessModes[];
+  constraint?: OdrlConstraint[];
+};
+
+export type CredentialSubjectOdrl =
+  VerifiableCredential["credentialSubject"] & {
+    type: "Agreement";
+    profile: typeof ODRL_ACCESS;
+    assigner: Iri;
+    assignee: Iri;
+    permission: OdrlPermission[];
+    prohibition?: OdrlPermission[];
+  };
+
+export type AccessGrantOdrl = VerifiableCredential & {
+  // The type array must contain SolidAccessGrant
+  type: string[];
+  credentialSubject: CredentialSubjectOdrl;
+};
+
+function isOdrlConstraint(constraint: unknown): constraint is OdrlConstraint {
+  if (
+    typeof (constraint as OdrlConstraint).leftOperand !== "string" ||
+    !ODRL_CONSTRAINTS.includes((constraint as OdrlConstraint).leftOperand)
+  ) {
+    return false;
+  }
+  if (
+    typeof (constraint as OdrlConstraint).operator !== "string" ||
+    !ODRL_OPERATORS.includes((constraint as OdrlConstraint).operator)
+  ) {
+    return false;
+  }
+  if (typeof (constraint as OdrlConstraint).rightOperand !== "string") {
+    return false;
+  }
+  return true;
+}
+
+function isOdrlPermission(permission: unknown): permission is OdrlPermission {
+  if (typeof (permission as OdrlPermission).target !== "string") {
+    return false;
+  }
+  if (
+    !Array.isArray((permission as OdrlPermission).action) ||
+    (permission as OdrlPermission).action.some(
+      (mode) => !SERIALIZED_ACCESS_MODES.includes(mode)
+    )
+  ) {
+    return false;
+  }
+
+  // permission.constraint is either undefined or a constraint array.
+  if (
+    typeof (permission as OdrlPermission).constraint !== "undefined" &&
+    !Array.isArray((permission as OdrlPermission).constraint)
+  ) {
+    return false;
+  }
+  if (
+    (permission as OdrlPermission).constraint?.some(
+      (constraint) => !isOdrlConstraint(constraint)
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export function isCredentialAccessGrantOdrl(
+  vc: VerifiableCredential
+): vc is AccessGrantOdrl {
+  if (!vc.type.includes("SolidAccessGrant")) {
+    return false;
+  }
+  if (
+    typeof vc.credentialSubject.type !== "string" ||
+    vc.credentialSubject.type !== "Agreement"
+  ) {
+    return false;
+  }
+  if (
+    typeof vc.credentialSubject.profile !== "string" ||
+    vc.credentialSubject.profile !== ODRL_ACCESS
+  ) {
+    return false;
+  }
+  if (typeof vc.credentialSubject.assigner !== "string") {
+    return false;
+  }
+
+  if (typeof vc.credentialSubject.assignee !== "string") {
+    return false;
+  }
+
+  if (
+    !Array.isArray(
+      (vc.credentialSubject as CredentialSubjectOdrl).permission
+    ) ||
+    (vc.credentialSubject as CredentialSubjectOdrl).permission.some(
+      (permission) => !isOdrlPermission(permission)
+    )
+  ) {
+    return false;
+  }
+
+  // vc.credentialSubject.prohibition is either undefined or an array of prohibitions.
+  if (
+    !Array.isArray(
+      (vc.credentialSubject as CredentialSubjectOdrl).prohibition
+    ) &&
+    typeof (vc.credentialSubject as CredentialSubjectOdrl).prohibition !==
+      "undefined"
+  ) {
+    return false;
+  }
+
+  if (
+    (vc.credentialSubject as CredentialSubjectOdrl).prohibition?.some(
+      (permission) => !isOdrlPermission(permission)
+    )
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/src/odrl/type/AccessGrant.ts
+++ b/src/odrl/type/AccessGrant.ts
@@ -115,6 +115,15 @@ function isOdrlPermission(permission: unknown): permission is OdrlPermission {
   return true;
 }
 
+/**
+ * Verify that the provided Verifiable Credential has the shape of an ODRL-based
+ * Access Grant. This function only performs type validation, it does not verify
+ * that the provided Credential is valid.
+ *
+ * @param vc A Verifiable Credential
+ * @returns true if the VC is a valid ODRL-based Access Grant
+ * @since unreleased
+ */
 export function isCredentialAccessGrantOdrl(
   vc: VerifiableCredential
 ): vc is AccessGrantOdrl {

--- a/src/odrl/type/AccessGrant.ts
+++ b/src/odrl/type/AccessGrant.ts
@@ -120,6 +120,24 @@ function isOdrlPermission(permission: unknown): permission is OdrlPermission {
  * Access Grant. This function only performs type validation, it does not verify
  * that the provided Credential is valid.
  *
+ * Example usage:
+ *
+ * ```
+ * // Get a JSON object that may be an Access Grant
+ * const candidateCredential = await fetchCredentialFromElsewhere();
+ *
+ * // Validate the Access Grant payload
+ * if (!isCredentialAccessGrantOdrl(candidateCredential)) {
+ *  throw new Error("Invalid ODRL Access Grant");
+ * }
+ *
+ * // Verify the credential
+ * const validationResult = await isValidAccessGrant(candidateCredential, {
+ *  verificationEndpoint: "https://some.verifier",
+ *  fetch: someAuthenticatedFetch
+ * });
+ * ```
+ *
  * @param vc A Verifiable Credential
  * @returns true if the VC is a valid ODRL-based Access Grant
  * @since unreleased

--- a/src/type/AccessGrant.ts
+++ b/src/type/AccessGrant.ts
@@ -19,10 +19,14 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import type { VerifiableCredential } from "@inrupt/solid-client-vc";
-import type { AccessGrantBody } from "./AccessVerifiableCredential";
+import { AccessGrantOdrl, isCredentialAccessGrantOdrl } from "../odrl/type/AccessGrant";
+import { AccessGrantGConsent } from "../gConsent/type/AccessGrant";
+import { CredentialIsAccessGrantGConsent } from "../gConsent/guard/isAccessGrant";
+import { isBaseAccessVcBody } from "../gConsent/guard/isBaseAccessVcBody";
+import { VerifiableCredential } from "@inrupt/solid-client-vc";
 
-export type AccessGrant = VerifiableCredential & AccessGrantBody;
-// Alias with the explicit GConsent suffix, to be used in functions accepting both
-// gConsent-based and ODRL-based grants.
-export type AccessGrantGConsent = AccessGrant;
+export type AccessGrantAny = AccessGrantOdrl | AccessGrantGConsent;
+
+export function CredentialIsAccessGrantAny(vc: VerifiableCredential): vc is AccessGrantAny {
+  return isCredentialAccessGrantOdrl(vc) || (isBaseAccessVcBody(vc) && CredentialIsAccessGrantGConsent(vc))
+}

--- a/src/type/AccessGrant.ts
+++ b/src/type/AccessGrant.ts
@@ -19,14 +19,22 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { AccessGrantOdrl, isCredentialAccessGrantOdrl } from "../odrl/type/AccessGrant";
+import { VerifiableCredential } from "@inrupt/solid-client-vc";
+import {
+  AccessGrantOdrl,
+  isCredentialAccessGrantOdrl,
+} from "../odrl/type/AccessGrant";
 import { AccessGrantGConsent } from "../gConsent/type/AccessGrant";
 import { CredentialIsAccessGrantGConsent } from "../gConsent/guard/isAccessGrant";
 import { isBaseAccessVcBody } from "../gConsent/guard/isBaseAccessVcBody";
-import { VerifiableCredential } from "@inrupt/solid-client-vc";
 
 export type AccessGrantAny = AccessGrantOdrl | AccessGrantGConsent;
 
-export function CredentialIsAccessGrantAny(vc: VerifiableCredential): vc is AccessGrantAny {
-  return isCredentialAccessGrantOdrl(vc) || (isBaseAccessVcBody(vc) && CredentialIsAccessGrantGConsent(vc))
+export function CredentialIsAccessGrantAny(
+  vc: VerifiableCredential
+): vc is AccessGrantAny {
+  return (
+    isCredentialAccessGrantOdrl(vc) ||
+    (isBaseAccessVcBody(vc) && CredentialIsAccessGrantGConsent(vc))
+  );
 }

--- a/src/type/AccessModes.ts
+++ b/src/type/AccessModes.ts
@@ -34,3 +34,11 @@ export interface AccessModes {
   write?: boolean;
   append?: boolean;
 }
+
+export const SERIALIZED_ACCESS_MODES = [
+  "read" as const,
+  "write" as const,
+  "append" as const,
+];
+export type SerializedAccessModes =
+  typeof SERIALIZED_ACCESS_MODES extends Array<infer E> ? E : never;

--- a/src/type/AccessModes.ts
+++ b/src/type/AccessModes.ts
@@ -40,5 +40,9 @@ export const SERIALIZED_ACCESS_MODES = [
   "write" as const,
   "append" as const,
 ];
+
+/**
+ * Acceptable values for Access being granted.
+ */
 export type SerializedAccessModes =
   typeof SERIALIZED_ACCESS_MODES extends Array<infer E> ? E : never;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,10 +34,12 @@
       "src/type/RedirectOptions.ts",
       "src/type/FetchOptions.ts",
       "src/type/UmaConfiguration.ts",
+      "src/type/AccessGrant.ts",
       "src/gConsent/type/AccessModes.ts",
       "src/gConsent/type/AccessBaseOptions.ts",
       "src/gConsent/type/IssueAccessRequestParameters.ts",
-      "src/gConsent/type/Parameter.ts"
+      "src/gConsent/type/Parameter.ts",
+      "src/odrl/type/AccessGrant.ts"
     ],
     "exclude": [
       "node_modules/**",


### PR DESCRIPTION
This adds an explicit type and type guard for ODRL-based Access Grants. This type guard only does payload validation, and doesn't do anything to check the VC signature: that is done using `isValidAccessGrant`. Looking into this made me realize `isValidAccessGrant` didn't have anything gConsent-specific (it doesn't have any type validation at all, which is actually called out as a TODO), so I moved it to the common module and re-exported it from the gConsent module for backwards compatibility.
A bit of churn comes in this PR from the fact that the session fetcher is also moved to the common module, and that is referenced from everywhere.

Note that #378 should be reviewed first.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).