### PR TITLE
Fix AccessMode typedoc entrypoint

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,7 @@
       "src/type/FetchOptions.ts",
       "src/type/UmaConfiguration.ts",
       "src/type/AccessGrant.ts",
-      "src/gConsent/type/AccessModes.ts",
+      "src/type/AccessModes.ts",
       "src/gConsent/type/AccessBaseOptions.ts",
       "src/gConsent/type/IssueAccessRequestParameters.ts",
       "src/gConsent/type/Parameter.ts",


### PR DESCRIPTION
The AccessMode module moved location, but the entrypoint wasn't updated.
