### PR TITLE
feat: Add createContainerInContainer method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+- Added the `createContainerInContainer` method.
+
 ### Minor changes
 
 - The `getters` module contains functions and a class to interact with Verifiable

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -524,7 +524,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       expect(updatedDatasetTtl).toBe(updatedDatasetAsOwnerTtl);
     });
 
-  it("can use the createContainerInContainer API to create a new container", async () => {
+    it("can use the createContainerInContainer API to create a new container", async () => {
       const containerNameSuggestion = "newTestContainer";
       const newChildContainer = await createContainerInContainer(
         testContainerIri,
@@ -551,7 +551,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
       expect(match).toHaveLength(1);
     });
-    
+
     it("can use the saveSolidDatasetInContainer API for an existing dataset", async () => {
       // Need to delete dataset that was already created in test setup,
       // such that our test can create an empty dataset at `testFileIri`.

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -530,18 +530,20 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         }
       );
 
-      const parentContainer = await solidClient.getSolidDataset(
-        testContainerIri,
-        {
-          fetch: resourceOwnerSession.fetch,
-        }
+      const parentContainer = await sc.getSolidDataset(testContainerIri, {
+        fetch: resourceOwnerSession.fetch,
+      });
+      const parentContainerContainsAll = sc.getUrlAll(
+        sc.getThing(
+          parentContainer,
+          sc.getSourceUrl(parentContainer)
+        ) as sc.Thing,
+        "http://www.w3.org/ns/ldp#member"
       );
-      const parentContainerContainsAll =
-        solidClient.getThingAll(parentContainer);
-      testContainerIriChild = solidClient.getSourceUrl(newChildContainer);
+      testContainerIriChild = sc.getSourceUrl(newChildContainer);
 
-      const match = parentContainerContainsAll.filter((thing) => {
-        return thing.url === testContainerIriChild;
+      const match = parentContainerContainsAll.filter((childUrl) => {
+        return childUrl === testContainerIriChild;
       });
 
       expect(match).toHaveLength(1);

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -538,7 +538,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           parentContainer,
           sc.getSourceUrl(parentContainer)
         ) as sc.Thing,
-        "http://www.w3.org/ns/ldp#member"
+        "http://www.w3.org/ns/ldp#contains"
       );
       testContainerIriChild = sc.getSourceUrl(newChildContainer);
 

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -525,7 +525,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
     it("can use the createContainerInContainer API to create a new container", async () => {
       const containerNameSuggestion = "newTestContainer";
-
       const newChildContainer = await createContainerInContainer(
         testContainerIri,
         accessGrant,
@@ -541,15 +540,12 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           fetch: resourceOwnerSession.fetch,
         }
       );
-
-      const parentContainerContainsAll = solidClient.getUrlAll(
-        parentContainer,
-        "http://www.w3.org/ns/ldp#member"
-      );
+      const parentContainerContainsAll =
+        solidClient.getThingAll(parentContainer);
       testContainerIriChild = solidClient.getSourceUrl(newChildContainer);
 
       const match = parentContainerContainsAll.filter((thing) => {
-        return thing === testContainerIriChild;
+        return thing.url === testContainerIriChild;
       });
 
       expect(match).toHaveLength(1);

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -444,9 +444,14 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         fetch: resourceOwnerSession.fetch,
       });
 
-      await solidClient.deleteContainer(testContainerIriChild, {
-        fetch: resourceOwnerSession.fetch,
-      });
+      if (testContainerIriChild !== undefined) {
+        // This resource is only created in some tests, but cleaning it up here
+        // rather than in the test ensures it is properly removed even on test
+        // failure.
+        await solidClient.deleteContainer(testContainerIriChild, {
+          fetch: resourceOwnerSession.fetch,
+        });
+      }
 
       await solidClient.deleteContainer(testContainerIri, {
         fetch: resourceOwnerSession.fetch,

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -29,7 +29,6 @@ import {
   beforeEach,
   afterEach,
 } from "@jest/globals";
-
 import * as solidClient from "@inrupt/solid-client";
 import { Session } from "@inrupt/solid-client-authn-node";
 import { isVerifiableCredential } from "@inrupt/solid-client-vc";
@@ -526,11 +525,16 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
     it("can use the createContainerInContainer API to create a new container", async () => {
       const containerNameSuggestion = "newTestContainer";
-      testContainerIriChild = `${testContainerIri}${containerNameSuggestion}/`;
-      await createContainerInContainer(testContainerIri, accessGrant, {
-        fetch: requestorSession.fetch,
-        slugSuggestion: containerNameSuggestion,
-      });
+
+      const newChildContainer = await createContainerInContainer(
+        testContainerIri,
+        accessGrant,
+        {
+          fetch: requestorSession.fetch,
+          slugSuggestion: containerNameSuggestion,
+        }
+      );
+
       const parentContainer = await solidClient.getSolidDataset(
         testContainerIri,
         {
@@ -538,11 +542,14 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         }
       );
 
-      const parentContainerContainsAll =
-        solidClient.getThingAll(parentContainer);
+      const parentContainerContainsAll = solidClient.getUrlAll(
+        parentContainer,
+        "http://www.w3.org/ns/ldp#member"
+      );
+      testContainerIriChild = solidClient.getSourceUrl(newChildContainer);
 
       const match = parentContainerContainsAll.filter((thing) => {
-        return thing.url === testContainerIriChild;
+        return thing === testContainerIriChild;
       });
 
       expect(match).toHaveLength(1);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -21,45 +21,47 @@
 
 import { describe, it, expect } from "@jest/globals";
 import {
+  AccessGrantWrapper,
   approveAccessRequest,
   cancelAccessRequest,
+  createContainerInContainer,
   denyAccessRequest,
+  fetchWithVc,
+  gConsent,
+  getAccessApiEndpoint,
   getAccessGrant,
   getAccessGrantAll,
-  getAccessApiEndpoint,
   getAccessGrantFromRedirectUrl,
   getAccessManagementUi,
-  getAccessRequestFromRedirectUrl,
-  isValidAccessGrant,
-  issueAccessRequest,
-  redirectToAccessManagementUi,
-  redirectToRequestor,
-  revokeAccessGrant,
-  fetchWithVc,
-  getFile,
-  saveFileInContainer,
-  overwriteFile,
-  getSolidDataset,
-  saveSolidDatasetAt,
-  GRANT_VC_URL_PARAM_NAME,
-  gConsent,
-  odrl,
-  AccessGrantWrapper,
   getAccessModes,
+  getAccessRequestFromRedirectUrl,
   getExpirationDate,
+  getFile,
   getId,
   getIssuanceDate,
   getIssuer,
   getRequestor,
   getResourceOwner,
   getResources,
+  getSolidDataset,
   getTypes,
+  GRANT_VC_URL_PARAM_NAME,
+  issueAccessRequest,
+  isValidAccessGrant,
+  odrl,
+  overwriteFile,
+  redirectToAccessManagementUi,
+  redirectToRequestor,
+  revokeAccessGrant,
+  saveFileInContainer,
+  saveSolidDatasetAt,
 } from "./index";
 
 describe("Index exports", () => {
   it("exposes expected things", () => {
     expect(approveAccessRequest).toBeDefined();
     expect(cancelAccessRequest).toBeDefined();
+    expect(createContainerInContainer).toBeDefined();
     expect(denyAccessRequest).toBeDefined();
     expect(getAccessGrant).toBeDefined();
     expect(getAccessGrantAll).toBeDefined();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -21,47 +21,46 @@
 
 import { describe, it, expect } from "@jest/globals";
 import {
-  AccessGrantWrapper,
   approveAccessRequest,
   cancelAccessRequest,
-  createContainerInContainer,
   denyAccessRequest,
-  fetchWithVc,
-  gConsent,
-  getAccessApiEndpoint,
   getAccessGrant,
   getAccessGrantAll,
+  getAccessApiEndpoint,
   getAccessGrantFromRedirectUrl,
   getAccessManagementUi,
-  getAccessModes,
   getAccessRequestFromRedirectUrl,
-  getExpirationDate,
+  isValidAccessGrant,
+  issueAccessRequest,
+  redirectToAccessManagementUi,
+  redirectToRequestor,
+  revokeAccessGrant,
+  fetchWithVc,
   getFile,
+  saveFileInContainer,
+  overwriteFile,
+  getSolidDataset,
+  createContainerInContainer,
+  saveSolidDatasetAt,
+  GRANT_VC_URL_PARAM_NAME,
+  gConsent,
+  odrl,
+  AccessGrantWrapper,
+  getAccessModes,
+  getExpirationDate,
   getId,
   getIssuanceDate,
   getIssuer,
   getRequestor,
   getResourceOwner,
   getResources,
-  getSolidDataset,
   getTypes,
-  GRANT_VC_URL_PARAM_NAME,
-  issueAccessRequest,
-  isValidAccessGrant,
-  odrl,
-  overwriteFile,
-  redirectToAccessManagementUi,
-  redirectToRequestor,
-  revokeAccessGrant,
-  saveFileInContainer,
-  saveSolidDatasetAt,
 } from "./index";
 
 describe("Index exports", () => {
   it("exposes expected things", () => {
     expect(approveAccessRequest).toBeDefined();
     expect(cancelAccessRequest).toBeDefined();
-    expect(createContainerInContainer).toBeDefined();
     expect(denyAccessRequest).toBeDefined();
     expect(getAccessGrant).toBeDefined();
     expect(getAccessGrantAll).toBeDefined();
@@ -78,6 +77,7 @@ describe("Index exports", () => {
     expect(getFile).toBeDefined();
     expect(overwriteFile).toBeDefined();
     expect(saveFileInContainer).toBeDefined();
+    expect(createContainerInContainer).toBeDefined();
     expect(getSolidDataset).toBeDefined();
     expect(saveSolidDatasetAt).toBeDefined();
     expect(GRANT_VC_URL_PARAM_NAME).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,9 @@
 //
 
 export type {
-  AccessGrant,
   AccessBaseOptions,
   AccessCredentialType,
+  AccessGrant,
   AccessGrantContext,
   AccessRequest,
   ApproveAccessRequestOverrides,
@@ -36,17 +36,17 @@ export type { AccessModes } from "./type/AccessModes";
 export type { AccessGrantAny } from "./type/AccessGrant";
 
 export {
-  getAccessApiEndpoint,
-  getAccessManagementUi,
-  redirectToAccessManagementUi,
-  issueAccessRequest,
-  cancelAccessRequest,
-  getAccessGrantFromRedirectUrl,
   approveAccessRequest,
+  cancelAccessRequest,
   denyAccessRequest,
+  getAccessApiEndpoint,
   getAccessGrant,
   getAccessGrantAll,
+  getAccessGrantFromRedirectUrl,
+  getAccessManagementUi,
   getAccessRequestFromRedirectUrl,
+  issueAccessRequest,
+  redirectToAccessManagementUi,
   redirectToRequestor,
   revokeAccessGrant,
   GRANT_VC_URL_PARAM_NAME,
@@ -71,8 +71,9 @@ export * as common from "./common";
 export { fetchWithVc } from "./fetch";
 
 export {
-  getSolidDataset,
+  createContainerInContainer,
   getFile,
+  getSolidDataset,
   overwriteFile,
   saveFileInContainer,
   saveSolidDatasetAt,

--- a/src/resource/createContainerInContainer.test.ts
+++ b/src/resource/createContainerInContainer.test.ts
@@ -21,6 +21,7 @@
 
 import { it, jest, describe, expect } from "@jest/globals";
 import { mockSolidDatasetFrom, UrlString } from "@inrupt/solid-client";
+import type * as SolidClient from "@inrupt/solid-client";
 import { mockAccessRequestVc } from "../gConsent/util/access.mock";
 import { fetchWithVc } from "../fetch";
 import { createContainerInContainer } from "./createContainerInContainer";
@@ -38,27 +39,31 @@ const TEST_CONTAINER_URL: UrlString =
 
 describe("createContainerInContainer", () => {
   it("authenticates using the provided VC", async () => {
-    const solidClientModule = jest.requireMock("@inrupt/solid-client") as any;
+    const solidClientModule = jest.requireMock(
+      "@inrupt/solid-client"
+    ) as jest.Mocked<typeof SolidClient>;
     const mockedDataset = mockSolidDatasetFrom("https://some.url");
     solidClientModule.createContainerInContainer.mockResolvedValueOnce(
       MOCKED_DATASET
     );
-    const mockedFetch = jest.fn() as typeof fetch;
-    // TODO: change to mockAccessGrantVc when rebasing
+    const mockedFetch = jest.fn<typeof fetch>();
     const resultDataset = await createContainerInContainer(
+      TEST_CONTAINER_URL,
+      mockAccessRequestVc(),
+      { fetch: mockedFetch, slugSuggestion: "NewChildContainer" }
+    );
+
+    expect(fetchWithVc).toHaveBeenCalledWith(
       TEST_CONTAINER_URL,
       mockAccessRequestVc(),
       { fetch: mockedFetch }
     );
-    expect(fetchWithVc).toHaveBeenCalledWith(
-      expect.anything(),
-      mockAccessRequestVc(),
-      { fetch: mockedFetch }
-    );
+
     expect(solidClientModule.createContainerInContainer).toHaveBeenCalledWith(
       TEST_CONTAINER_URL,
       expect.anything()
     );
+
     expect(resultDataset).toStrictEqual(mockedDataset);
   });
 });

--- a/src/resource/createContainerInContainer.test.ts
+++ b/src/resource/createContainerInContainer.test.ts
@@ -59,6 +59,6 @@ describe("createContainerInContainer", () => {
       TEST_CONTAINER_URL,
       expect.anything()
     );
-    expect(resultDataset).toBe(mockedDataset);
+    expect(resultDataset).toStrictEqual(mockedDataset);
   });
 });

--- a/src/resource/createContainerInContainer.test.ts
+++ b/src/resource/createContainerInContainer.test.ts
@@ -1,0 +1,64 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { it, jest, describe, expect } from "@jest/globals";
+import { mockSolidDatasetFrom, UrlString } from "@inrupt/solid-client";
+import { mockAccessRequestVc } from "../gConsent/util/access.mock";
+import { fetchWithVc } from "../fetch";
+import { createContainerInContainer } from "./createContainerInContainer";
+
+jest.mock("../fetch");
+jest.mock("@inrupt/solid-client", () => {
+  const solidClientModule = jest.requireActual("@inrupt/solid-client") as any;
+  solidClientModule.createContainerInContainer = jest.fn();
+  return solidClientModule;
+});
+
+const MOCKED_DATASET = mockSolidDatasetFrom("https://some.url");
+const TEST_CONTAINER_URL: UrlString =
+  "https://example.come/container/anothercontainer";
+
+describe("createContainerInContainer", () => {
+  it("authenticates using the provided VC", async () => {
+    const solidClientModule = jest.requireMock("@inrupt/solid-client") as any;
+    const mockedDataset = mockSolidDatasetFrom("https://some.url");
+    solidClientModule.createContainerInContainer.mockResolvedValueOnce(
+      MOCKED_DATASET
+    );
+    const mockedFetch = jest.fn() as typeof fetch;
+    // TODO: change to mockAccessGrantVc when rebasing
+    const resultDataset = await createContainerInContainer(
+      TEST_CONTAINER_URL,
+      mockAccessRequestVc(),
+      { fetch: mockedFetch }
+    );
+    expect(fetchWithVc).toHaveBeenCalledWith(
+      expect.anything(),
+      mockAccessRequestVc(),
+      { fetch: mockedFetch }
+    );
+    expect(solidClientModule.createContainerInContainer).toHaveBeenCalledWith(
+      TEST_CONTAINER_URL,
+      expect.anything()
+    );
+    expect(resultDataset).toBe(mockedDataset);
+  });
+});

--- a/src/resource/createContainerInContainer.ts
+++ b/src/resource/createContainerInContainer.ts
@@ -22,18 +22,20 @@
 import {
   UrlString,
   createContainerInContainer as coreCreateContainerInContainer,
-  WithResourceInfo,
-  SolidDataset,
 } from "@inrupt/solid-client";
 import { VerifiableCredential } from "@inrupt/solid-client-vc";
 import { fetchWithVc } from "../fetch";
 import { FetchOptions } from "../type/FetchOptions";
 
+interface SaveInContainerOptions extends FetchOptions {
+  slugSuggestion?: string;
+}
+
 /**
  * Create an empty Container inside the Container at the given URL.
  *
  * Throws an error if creating the Container failed, e.g. because the current user does not have
- * permissions to.
+ * permissions to. In particular, the Access Grant being used should at least append access to the target Container.
  *
  * The Container in which to create the new Container should itself already exist.
  *
@@ -47,22 +49,24 @@ import { FetchOptions } from "../type/FetchOptions";
  * If the user does have access to write directly to a given location, [[createContainerAt]]
  * will do the job just fine, and does not require the parent Container to exist in advance.
  *
- * @param containerUrl URL of the Container in which the empty Container is to be created.
- * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters). `options.slugSuggestion` accepts a string for your new Container's name.
- * @returns A promise that resolves to a SolidDataset with ResourceInfo if successful, and that
- * rejects otherwise.
- * @since 0.2.0
+ * @param containerUrl URL of the Container in which the empty Container is to
+ * be created.
+ * @param accessGrant The Access Grant that would allow the Agent/Application to
+ * perform this operation.
+ * @param options Optional parameter `options.fetch`: An alternative `fetch`
+ * function to make the HTTP request, compatible with the browser-native [fetch
+ * API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * `options.slugSuggestion` accepts a string for your new Container's name.
+ * @returns A promise that resolves to a SolidDataset with ResourceInfo if
+ * successful, and that rejects otherwise.
+ * @since unreleased
  */
-
-interface SaveInContainerOptions extends FetchOptions {
-  slugSuggestion?: string;
-}
 
 export async function createContainerInContainer(
   containerUrl: UrlString,
   accessGrant: VerifiableCredential,
   options?: SaveInContainerOptions
-): Promise<SolidDataset & WithResourceInfo> {
+) {
   const fetchOptions: FetchOptions = {};
 
   if (options && options.fetch) {

--- a/src/resource/createContainerInContainer.ts
+++ b/src/resource/createContainerInContainer.ts
@@ -1,0 +1,81 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import {
+  UrlString,
+  createContainerInContainer as coreCreateContainerInContainer,
+  WithResourceInfo,
+} from "@inrupt/solid-client";
+import { VerifiableCredential } from "@inrupt/solid-client-vc";
+import { fetchWithVc } from "../fetch";
+import { FetchOptions } from "../type/FetchOptions";
+
+/**
+ * Create an empty Container inside the Container at the given URL.
+ *
+ * Throws an error if creating the Container failed, e.g. because the current user does not have
+ * permissions to.
+ *
+ * The Container in which to create the new Container should itself already exist.
+ *
+ * This function is primarily useful if the current user does not have access to change existing files in
+ * a Container, but is allowed to add new files; in other words, they have Append, but not Write
+ * access to a Container. This is useful in situations where someone wants to allow others to,
+ * for example, send notifications to their Pod, but not to view or delete existing notifications.
+ * You can pass a suggestion for the new Resource's name, but the server may decide to give it
+ * another name — for example, if a Resource with that name already exists inside the given
+ * Container.
+ * If the user does have access to write directly to a given location, [[createContainerAt]]
+ * will do the job just fine, and does not require the parent Container to exist in advance.
+ *
+ * @param containerUrl URL of the Container in which the empty Container is to be created.
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters). `options.slugSuggestion` accepts a string for your new Container's name.
+ * @returns A promise that resolves to a SolidDataset if successful, and that
+ * rejects otherwise.
+ * @since 0.2.0
+ */
+
+type SaveInContainerOptions = Partial<
+  FetchOptions & {
+    slugSuggestion: string;
+  }
+>;
+export async function createContainerInContainer<SolidDataset>(
+  containerUrl: UrlString,
+  accessGrant: VerifiableCredential,
+  options?: SaveInContainerOptions
+): Promise<SolidDataset & WithResourceInfo> {
+  const fetchOptions: FetchOptions = {};
+  if (options && options.fetch) {
+    fetchOptions.fetch = options.fetch;
+  }
+
+  const authenticatedFetch = await fetchWithVc(
+    containerUrl,
+    accessGrant,
+    fetchOptions
+  );
+
+  return await coreCreateContainerInContainer(containerUrl, {
+    ...options,
+    fetch: authenticatedFetch,
+  });
+}

--- a/src/resource/createContainerInContainer.ts
+++ b/src/resource/createContainerInContainer.ts
@@ -23,6 +23,7 @@ import {
   UrlString,
   createContainerInContainer as coreCreateContainerInContainer,
   WithResourceInfo,
+  SolidDataset,
 } from "@inrupt/solid-client";
 import { VerifiableCredential } from "@inrupt/solid-client-vc";
 import { fetchWithVc } from "../fetch";
@@ -48,22 +49,22 @@ import { FetchOptions } from "../type/FetchOptions";
  *
  * @param containerUrl URL of the Container in which the empty Container is to be created.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters). `options.slugSuggestion` accepts a string for your new Container's name.
- * @returns A promise that resolves to a SolidDataset if successful, and that
+ * @returns A promise that resolves to a SolidDataset with ResourceInfo if successful, and that
  * rejects otherwise.
  * @since 0.2.0
  */
 
-type SaveInContainerOptions = Partial<
-  FetchOptions & {
-    slugSuggestion: string;
-  }
->;
-export async function createContainerInContainer<SolidDataset>(
+interface SaveInContainerOptions extends FetchOptions {
+  slugSuggestion?: string;
+}
+
+export async function createContainerInContainer(
   containerUrl: UrlString,
   accessGrant: VerifiableCredential,
   options?: SaveInContainerOptions
 ): Promise<SolidDataset & WithResourceInfo> {
   const fetchOptions: FetchOptions = {};
+
   if (options && options.fetch) {
     fetchOptions.fetch = options.fetch;
   }

--- a/src/resource/index.ts
+++ b/src/resource/index.ts
@@ -20,5 +20,6 @@
 //
 
 export { getFile, overwriteFile, saveFileInContainer } from "./file";
+export { createContainerInContainer } from "./createContainerInContainer";
 export { getSolidDataset } from "./getSolidDataset";
 export { saveSolidDatasetAt } from "./saveSolidDatasetAt";

--- a/src/resource/saveSolidDatasetInContainer.test.ts
+++ b/src/resource/saveSolidDatasetInContainer.test.ts
@@ -36,7 +36,7 @@ const MOCKED_DATASET = mockSolidDatasetFrom("https://some.url");
 const TEST_CONTAINER_URL: UrlString = "https://example.com/testContainerUrl";
 
 describe("saveSolidDatasetInContainer", () => {
-  it("authenticates using the provided VC", async () => {
+  it("authenticates using the provided VC with a slugSuggestion", async () => {
     const solidClientModule = jest.requireMock("@inrupt/solid-client") as any;
     const mockedDataset = mockSolidDatasetFrom("https://some.url");
     solidClientModule.saveSolidDatasetInContainer.mockResolvedValueOnce(
@@ -49,7 +49,7 @@ describe("saveSolidDatasetInContainer", () => {
       TEST_CONTAINER_URL,
       MOCKED_DATASET,
       mockAccessRequestVc(),
-      { fetch: mockedFetch }
+      { fetch: mockedFetch, slugSuggestion: "test" }
     );
 
     expect(fetchWithVc).toHaveBeenCalledWith(
@@ -61,7 +61,7 @@ describe("saveSolidDatasetInContainer", () => {
     expect(solidClientModule.saveSolidDatasetInContainer).toHaveBeenCalledWith(
       TEST_CONTAINER_URL,
       MOCKED_DATASET,
-      expect.anything()
+      expect.objectContaining({ slugSuggestion: "test" })
     );
 
     expect(resultDataset).toStrictEqual(MOCKED_DATASET);

--- a/src/resource/saveSolidDatasetInContainer.ts
+++ b/src/resource/saveSolidDatasetInContainer.ts
@@ -23,7 +23,6 @@ import {
   UrlString,
   saveSolidDatasetInContainer as coreSaveSolidDatasetInContainer,
   SolidDataset,
-  WithResourceInfo,
 } from "@inrupt/solid-client";
 import { VerifiableCredential } from "@inrupt/solid-client-vc";
 import { fetchWithVc } from "../fetch";


### PR DESCRIPTION
# Add CreateContainerInContainer method
This PR adds the createContainerInContainer function in the Access Grants library. 
The ticket for this is [SDK-2791](https://inrupt.atlassian.net/browse/SDK-2791)

Why create container in container? Here's a little reminder of the use case:

This function is primarily useful if the current user does not have access to change existing files in a Container, but is allowed to add new files; in other words, they have Append, but not Write access to a Container. This is useful in situations where someone wants to allow others to, for example, send notifications to their Pod, but not to view or delete existing notifications.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
