### PR TITLE
feat: SaveSolidDatasetInContainer in Access Grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+- Added `saveSolidDatasetInContainer` method.
+
 ### Minor changes
 
 - The `getters` module contains functions and a class to interact with Verifiable

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -521,12 +521,11 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
     });
 
     it("can use the saveSolidDatasetInContainer API for an existing dataset", async () => {
-      // ARANGE
+      // Need to delete file already created in test setup to start with empty container.
       await solidClient.deleteFile(testFileIri, {
         fetch: resourceOwnerSession.fetch,
       });
 
-      // ACT
       const testDataset = await solidClient.createSolidDataset();
       const savedDataset = await saveSolidDatasetInContainer(
         testContainerIri,
@@ -539,7 +538,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         }
       );
 
-      // ASSERT
       const datasetInPodAsResourceOwner = await solidClient.getSolidDataset(
         testFileIri,
         {
@@ -564,7 +562,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         savedDataset
       );
       expect(savedDatasetTtl).toBe(updatedDatasetAsOwnerTtl);
-      // CLEANUP
     });
 
     it.skip("can use the saveSolidDatasetAt API for a new dataset", async () => {

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -29,7 +29,6 @@ import {
   beforeEach,
   afterEach,
 } from "@jest/globals";
-
 import * as solidClient from "@inrupt/solid-client";
 import { Session } from "@inrupt/solid-client-authn-node";
 import { isVerifiableCredential } from "@inrupt/solid-client-vc";
@@ -539,7 +538,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       );
 
       const datasetInPodAsResourceOwner = await solidClient.getSolidDataset(
-        testFileIri,
+        solidClient.getSourceIri(savedDataset),
         {
           fetch: resourceOwnerSession.fetch,
         }

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -531,7 +531,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         testContainerIri,
         testDataset,
         accessGrant,
-
         {
           fetch: requestorSession.fetch,
           slugSuggestion: testFileName,

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -521,7 +521,8 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
     });
 
     it("can use the saveSolidDatasetInContainer API for an existing dataset", async () => {
-      // Need to delete file already created in test setup to start with empty container.
+      // Need to delete dataset that was already created in test setup,
+      // such that our test can create an empty dataset at `testFileIri`.
       await solidClient.deleteFile(testFileIri, {
         fetch: resourceOwnerSession.fetch,
       });

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -546,7 +546,9 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       );
 
       // We cannot request the newly created dataset using our existing Access
-      // Grant because of ACR inheritance.
+      // Grant because of ACR inheritance. When we delete the file containing
+      // the dataset at the start of this testcase it also deletes the datasets'
+      // ACRs, so this test case will fail (SDK-2792).
 
       // const datasetInPodAsRequestor = await
       // getSolidDataset( testFileIri, accessGrant,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@inrupt/solid-client": "^1.23.1",
+        "@inrupt/solid-client": "^1.23.3",
         "@inrupt/solid-client-vc": "^0.5.0",
         "auth-header": "^1.0.0",
         "base64url": "^3.0.1",
@@ -836,7 +836,8 @@
     },
     "node_modules/@inrupt/solid-client": {
       "version": "1.23.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.23.3.tgz",
+      "integrity": "sha512-+qzlqtXkM1V2wdZcIWpq6mS+NAfJIeAyWghQBHHLz1hmHiKaE+H0UljOt2B4oSrRYuQq/PYvD/a6N4vfMU+vWg==",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
         "@rdfjs/types": "^1.1.0",
@@ -8012,6 +8013,8 @@
     },
     "@inrupt/solid-client": {
       "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.23.3.tgz",
+      "integrity": "sha512-+qzlqtXkM1V2wdZcIWpq6mS+NAfJIeAyWghQBHHLz1hmHiKaE+H0UljOt2B4oSrRYuQq/PYvD/a6N4vfMU+vWg==",
       "requires": {
         "@rdfjs/dataset": "^1.1.0",
         "@rdfjs/types": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@inrupt/solid-client": "^1.23.1",
+    "@inrupt/solid-client": "^1.23.3",
     "@inrupt/solid-client-vc": "^0.5.0",
     "auth-header": "^1.0.0",
     "base64url": "^3.0.1",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -41,6 +41,7 @@ import {
   overwriteFile,
   getSolidDataset,
   saveSolidDatasetAt,
+  saveSolidDatasetInContainer,
   GRANT_VC_URL_PARAM_NAME,
   gConsent,
   odrl,
@@ -78,6 +79,7 @@ describe("Index exports", () => {
     expect(saveFileInContainer).toBeDefined();
     expect(getSolidDataset).toBeDefined();
     expect(saveSolidDatasetAt).toBeDefined();
+    expect(saveSolidDatasetInContainer).toBeDefined();
     expect(GRANT_VC_URL_PARAM_NAME).toBeDefined();
     expect(gConsent).toBeDefined();
     expect(odrl).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ export {
   overwriteFile,
   saveFileInContainer,
   saveSolidDatasetAt,
+  saveSolidDatasetInContainer,
 } from "./resource";
 
 export {

--- a/src/resource/index.ts
+++ b/src/resource/index.ts
@@ -22,3 +22,4 @@
 export { getFile, overwriteFile, saveFileInContainer } from "./file";
 export { getSolidDataset } from "./getSolidDataset";
 export { saveSolidDatasetAt } from "./saveSolidDatasetAt";
+export { saveSolidDatasetInContainer } from "./saveSolidDatasetInContainer";

--- a/src/resource/saveSolidDatasetInContainer.test.ts
+++ b/src/resource/saveSolidDatasetInContainer.test.ts
@@ -53,7 +53,7 @@ describe("saveSolidDatasetInContainer", () => {
     );
 
     expect(fetchWithVc).toHaveBeenCalledWith(
-      expect.anything(),
+      TEST_CONTAINER_URL,
       mockAccessRequestVc(),
       { fetch: mockedFetch }
     );

--- a/src/resource/saveSolidDatasetInContainer.test.ts
+++ b/src/resource/saveSolidDatasetInContainer.test.ts
@@ -1,0 +1,69 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { it, jest, describe, expect } from "@jest/globals";
+import { mockSolidDatasetFrom, UrlString, Url } from "@inrupt/solid-client";
+import { mockAccessRequestVc } from "../gConsent/util/access.mock";
+import { saveSolidDatasetInContainer } from "./saveSolidDatasetInContainer";
+import { fetchWithVc } from "../fetch";
+
+jest.mock("../fetch");
+jest.mock("@inrupt/solid-client", () => {
+  const solidClientModule = jest.requireActual("@inrupt/solid-client") as any;
+  solidClientModule.saveSolidDatasetInContainer = jest.fn();
+  return solidClientModule;
+});
+
+const MOCKED_DATASET = mockSolidDatasetFrom("https://some.url");
+const TEST_CONTAINER_URL: UrlString = "https://example.com/testContainerUrl";
+
+describe("saveSolidDatasetInContainer", () => {
+  it("authenticates using the provided VC", async () => {
+    const solidClientModule = jest.requireMock("@inrupt/solid-client") as any;
+    const mockedDataset = mockSolidDatasetFrom("https://some.url");
+    solidClientModule.saveSolidDatasetInContainer.mockResolvedValueOnce(
+      mockedDataset
+    );
+    const mockedFetch = jest.fn() as typeof fetch;
+
+    // TODO: change to mockAccessGrantVc when rebasing
+    const resultDataset = await saveSolidDatasetInContainer(
+      TEST_CONTAINER_URL,
+      MOCKED_DATASET,
+      mockAccessRequestVc(),
+      { fetch: mockedFetch }
+    );
+
+    expect(fetchWithVc).toHaveBeenCalledWith(
+      expect.anything(),
+      mockAccessRequestVc(),
+      { fetch: mockedFetch }
+    );
+
+    expect(solidClientModule.saveSolidDatasetInContainer).toHaveBeenCalledWith(
+      TEST_CONTAINER_URL,
+      MOCKED_DATASET,
+      expect.anything()
+    );
+
+    expect(resultDataset).toStrictEqual(MOCKED_DATASET);
+  });
+});

--- a/src/resource/saveSolidDatasetInContainer.test.ts
+++ b/src/resource/saveSolidDatasetInContainer.test.ts
@@ -20,7 +20,7 @@
 //
 
 import { it, jest, describe, expect } from "@jest/globals";
-import { mockSolidDatasetFrom, UrlString, Url } from "@inrupt/solid-client";
+import { mockSolidDatasetFrom, UrlString } from "@inrupt/solid-client";
 import { mockAccessRequestVc } from "../gConsent/util/access.mock";
 import { saveSolidDatasetInContainer } from "./saveSolidDatasetInContainer";
 import { fetchWithVc } from "../fetch";

--- a/src/resource/saveSolidDatasetInContainer.ts
+++ b/src/resource/saveSolidDatasetInContainer.ts
@@ -62,6 +62,7 @@ interface SaveInContainerOptions extends FetchOptions {
  * @param accessGrant The Access Grant that would allow the Agent/Application to perform this operation.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns A Promise resolving to a [[SolidDataset]] containing the saved data. The Promise rejects if the save failed.
+ * @since unreleased
  */
 
 export async function saveSolidDatasetInContainer(

--- a/src/resource/saveSolidDatasetInContainer.ts
+++ b/src/resource/saveSolidDatasetInContainer.ts
@@ -41,15 +41,17 @@ interface SaveInContainerOptions extends FetchOptions {
  * using [[createContainerAt]], or directly save the SolidDataset at the desired location using
  * [[saveSolidDatasetAt]].
  *
- * This function is primarily useful if the current user does not have access to change existing files in
- * a Container, but is allowed to add new files; in other words, they have Append, but not Write
- * access to a Container. This is useful in situations where someone wants to allow others to,
- * for example, send notifications to their Pod, but not to view or delete existing notifications.
- * You can pass a suggestion for the new Resource's name, but the server may decide to give it
- * another name — for example, if a Resource with that name already exists inside the given
- * Container.
- * If the user does have access to write directly to a given location, [[saveSolidDatasetAt]]
- * will do the job just fine, and does not require the parent Container to exist in advance.
+ * This function is primarily useful if the current user has not been granted
+ * access to change existing files in a Container, but is allowed to add new
+ * files; in other words, they have been granted Append, but not Write access to
+ * a Container. This is useful in situations where someone wants to allow others
+ * to, for example, send notifications to their Pod, but not to view or delete
+ * existing notifications. You can pass a suggestion for the new Resource's
+ * name, but the server may decide to give it another name — for example, if a
+ * Resource with that name already exists inside the given Container. If the
+ * user does have access to write directly to a given location,
+ * [[saveSolidDatasetAt]] will do the job just fine, and does not require the
+ * parent Container to exist in advance.
  *
  * @see [@inrupt/solid-client's
  * saveSolidDatasetInContainer](https://docs.inrupt.com/developer-tools/api/javascript/solid-client/modules/resource_solidDataset.html#savesoliddatasetincontainer)

--- a/src/resource/saveSolidDatasetInContainer.ts
+++ b/src/resource/saveSolidDatasetInContainer.ts
@@ -69,7 +69,7 @@ export async function saveSolidDatasetInContainer(
   solidDataset: SolidDataset,
   accessGrant: VerifiableCredential,
   options: SaveInContainerOptions
-): Promise<SolidDataset & WithResourceInfo> {
+) {
   const fetchOptions: FetchOptions = {};
 
   if (options && options.fetch) {

--- a/src/resource/saveSolidDatasetInContainer.ts
+++ b/src/resource/saveSolidDatasetInContainer.ts
@@ -29,6 +29,11 @@ import { VerifiableCredential } from "@inrupt/solid-client-vc";
 import { fetchWithVc } from "../fetch";
 import { FetchOptions } from "../type/FetchOptions";
 
+type SaveInContainerOptions = Partial<
+  FetchOptions & {
+    slugSuggestion: string;
+  }
+>;
 /**
  * Given a SolidDataset, store it in a Solid Pod as a new Resource inside a Container.
  *
@@ -60,9 +65,10 @@ export async function saveSolidDatasetInContainer(
   containerUrl: UrlString,
   solidDataset: SolidDataset,
   accessGrant: VerifiableCredential,
-  options: FetchOptions
+  options: SaveInContainerOptions
 ): Promise<SolidDataset & WithResourceInfo> {
   const fetchOptions: FetchOptions = {};
+
   if (options && options.fetch) {
     fetchOptions.fetch = options.fetch;
   }

--- a/src/resource/saveSolidDatasetInContainer.ts
+++ b/src/resource/saveSolidDatasetInContainer.ts
@@ -30,7 +30,7 @@ import { fetchWithVc } from "../fetch";
 import { FetchOptions } from "../type/FetchOptions";
 
 /**
- * Given a SolidDataset, store it in a Solid Pod in a new Resource inside a Container.
+ * Given a SolidDataset, store it in a Solid Pod as a new Resource inside a Container.
  *
  * The Container at the given URL should already exist; if it does not, you can initialise it first
  * using [[createContainerAt]], or directly save the SolidDataset at the desired location using

--- a/src/resource/saveSolidDatasetInContainer.ts
+++ b/src/resource/saveSolidDatasetInContainer.ts
@@ -29,6 +29,7 @@ import { VerifiableCredential } from "@inrupt/solid-client-vc";
 import { fetchWithVc } from "../fetch";
 import { FetchOptions } from "../type/FetchOptions";
 
+// TODO: This should come from @inrupt/solid-client
 interface SaveInContainerOptions extends FetchOptions {
   slugSuggestion?: string;
 }

--- a/src/resource/saveSolidDatasetInContainer.ts
+++ b/src/resource/saveSolidDatasetInContainer.ts
@@ -29,11 +29,10 @@ import { VerifiableCredential } from "@inrupt/solid-client-vc";
 import { fetchWithVc } from "../fetch";
 import { FetchOptions } from "../type/FetchOptions";
 
-type SaveInContainerOptions = Partial<
-  FetchOptions & {
-    slugSuggestion: string;
-  }
->;
+type SaveInContainerOptions = FetchOptions & {
+  slugSuggestion?: string;
+};
+
 /**
  * Given a SolidDataset, store it in a Solid Pod as a new Resource inside a Container.
  *

--- a/src/resource/saveSolidDatasetInContainer.ts
+++ b/src/resource/saveSolidDatasetInContainer.ts
@@ -1,0 +1,81 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import {
+  UrlString,
+  Url,
+  saveSolidDatasetInContainer as coreSaveSolidDatasetInContainer,
+  SolidDataset,
+  WithResourceInfo,
+} from "@inrupt/solid-client";
+import { VerifiableCredential } from "@inrupt/solid-client-vc";
+import { fetchWithVc } from "../fetch";
+import { FetchOptions } from "../type/FetchOptions";
+
+/**
+ * Given a SolidDataset, store it in a Solid Pod in a new Resource inside a Container.
+ *
+ * The Container at the given URL should already exist; if it does not, you can initialise it first
+ * using [[createContainerAt]], or directly save the SolidDataset at the desired location using
+ * [[saveSolidDatasetAt]].
+ *
+ * This function is primarily useful if the current user does not have access to change existing files in
+ * a Container, but is allowed to add new files; in other words, they have Append, but not Write
+ * access to a Container. This is useful in situations where someone wants to allow others to,
+ * for example, send notifications to their Pod, but not to view or delete existing notifications.
+ * You can pass a suggestion for the new Resource's name, but the server may decide to give it
+ * another name — for example, if a Resource with that name already exists inside the given
+ * Container.
+ * If the user does have access to write directly to a given location, [[saveSolidDatasetAt]]
+ * will do the job just fine, and does not require the parent Container to exist in advance.
+ *
+ * @see [@inrupt/solid-client's
+ * saveSolidDatasetInContainer](https://docs.inrupt.com/developer-tools/api/javascript/solid-client/modules/resource_solidDataset.html#savesoliddatasetincontainer)
+ *
+ *
+ * @param containerUrl URL of the Container in which to create a new Resource.
+ * @param solidDataset The [[SolidDataset]] to save to a new Resource in the given Container.
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns A Promise resolving to a [[SolidDataset]] containing the saved data. The Promise rejects if the save failed.
+ */
+
+export async function saveSolidDatasetInContainer(
+  containerUrl: UrlString,
+  solidDataset: SolidDataset,
+  accessGrant: VerifiableCredential,
+  options: FetchOptions
+): Promise<SolidDataset & WithResourceInfo> {
+  const fetchOptions: FetchOptions = {};
+  if (options && options.fetch) {
+    fetchOptions.fetch = options.fetch;
+  }
+
+  const authenticatedFetch = await fetchWithVc(
+    containerUrl,
+    accessGrant,
+    fetchOptions
+  );
+
+  return await coreSaveSolidDatasetInContainer(containerUrl, solidDataset, {
+    ...options,
+    fetch: authenticatedFetch,
+  });
+}

--- a/src/resource/saveSolidDatasetInContainer.ts
+++ b/src/resource/saveSolidDatasetInContainer.ts
@@ -57,6 +57,7 @@ interface SaveInContainerOptions extends FetchOptions {
  *
  * @param containerUrl URL of the Container in which to create a new Resource.
  * @param solidDataset The [[SolidDataset]] to save to a new Resource in the given Container.
+ * @param accessGrant The Access Grant that would allow the Agent/Application to perform this operation.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns A Promise resolving to a [[SolidDataset]] containing the saved data. The Promise rejects if the save failed.
  */

--- a/src/resource/saveSolidDatasetInContainer.ts
+++ b/src/resource/saveSolidDatasetInContainer.ts
@@ -21,7 +21,6 @@
 
 import {
   UrlString,
-  Url,
   saveSolidDatasetInContainer as coreSaveSolidDatasetInContainer,
   SolidDataset,
   WithResourceInfo,

--- a/src/resource/saveSolidDatasetInContainer.ts
+++ b/src/resource/saveSolidDatasetInContainer.ts
@@ -29,9 +29,9 @@ import { VerifiableCredential } from "@inrupt/solid-client-vc";
 import { fetchWithVc } from "../fetch";
 import { FetchOptions } from "../type/FetchOptions";
 
-type SaveInContainerOptions = FetchOptions & {
+interface SaveInContainerOptions extends FetchOptions {
   slugSuggestion?: string;
-};
+}
 
 /**
  * Given a SolidDataset, store it in a Solid Pod as a new Resource inside a Container.

--- a/src/resource/saveSolidDatasetInContainer.ts
+++ b/src/resource/saveSolidDatasetInContainer.ts
@@ -78,8 +78,14 @@ export async function saveSolidDatasetInContainer(
     fetchOptions
   );
 
+  const containerOptions: { slugSuggestion?: string } = {};
+
+  if (options && options.slugSuggestion) {
+    containerOptions.slugSuggestion = options.slugSuggestion;
+  }
+
   return await coreSaveSolidDatasetInContainer(containerUrl, solidDataset, {
-    ...options,
+    ...containerOptions,
     fetch: authenticatedFetch,
   });
 }


### PR DESCRIPTION
# Adding saveSolidDatasetInContainer Method
This PR adds the `saveSolidDatasetInContainer` method to our access grants library. 
Also updates our solid-client library as this was necessary for this function to be added. 
# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


