### PR TITLE
No longer rely on NPM link for demos

### DIFF
--- a/examples/solid-client-access-grants-demo/package.json
+++ b/examples/solid-client-access-grants-demo/package.json
@@ -14,7 +14,6 @@
     "build": "npm run build:backend && npm run build:frontend",
     "build:backend": "tsc",
     "build:frontend": "rollup --config rollup.config.js",
-    "build:local": "npm link ../../ && npm run build",
     "start": "node ."
   },
   "dependencies": {


### PR DESCRIPTION
The `file:` dependency achieves what the npm link intends to do in a more predictable manner.