### PR TITLE
Lookup recursive access grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Added the `inherit` flag to `issueAccessRequest` and `approveAccessRequest` to
   allow controlling whether the issued Access Grant should apply recursively to
   the target containers' contained resources.
+- The `getAccessGrantAll` method now allows discovering recursive Access Grants
+  issued for an ancestor container.
 
 ### Minor changes
 

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -30,6 +30,7 @@ import {
   getAccessModes,
   getExpirationDate,
   getId,
+  getInherit,
   getIssuanceDate,
   getIssuer,
   getRequestor,
@@ -283,6 +284,47 @@ describe("getIssuer", () => {
     });
   });
 });
+
+describe("getInherit", () => {
+  describe("gConsent data model", () => {
+    it("gets the gConsent access grant issuer", () => {
+      const gConsentGrant = mockGConsentGrant(
+        "https://some.issuer",
+        "https://some.resource.owner",
+        false
+      );
+      expect(getIssuer(gConsentGrant)).toStrictEqual(gConsentGrant.issuer);
+    });
+
+    it("defaults the recursive nature from a gConsent access grant to true", () => {
+      const gConsentGrant = mockGConsentGrant(
+        "https://some.issuer",
+        "https://some.resource.owner",
+        undefined
+      );
+      expect(getInherit(gConsentGrant)).toBe(true);
+    });
+
+    it("gets the recursive nature from a gConsent access request", () => {
+      const gConsentRequest = mockGConsentRequest({ inherit: false });
+      expect(getInherit(gConsentRequest)).toBe(false);
+    });
+
+    it("defaults the recursive nature from a gConsent access request to true", () => {
+      const gConsentRequest = mockGConsentRequest({ inherit: undefined });
+      expect(getInherit(gConsentRequest)).toBe(true);
+    });
+  });
+
+  describe("ODRL data model", () => {
+    it("gets the recursive nature of an ODRL access grant", () => {
+      const odrlGrant = mockOdrlGrant();
+      expect(getInherit(odrlGrant)).toBe(true);
+    });
+  });
+});
+
+
 
 describe("AccessGrant", () => {
   it("wraps calls to the underlying functions", () => {

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -288,20 +288,12 @@ describe("getIssuer", () => {
 describe("getInherit", () => {
   describe("gConsent data model", () => {
     it("gets the gConsent access grant issuer", () => {
-      const gConsentGrant = mockGConsentGrant(
-        "https://some.issuer",
-        "https://some.resource.owner",
-        false
-      );
+      const gConsentGrant = mockGConsentGrant({ inherit: false });
       expect(getIssuer(gConsentGrant)).toStrictEqual(gConsentGrant.issuer);
     });
 
     it("defaults the recursive nature from a gConsent access grant to true", () => {
-      const gConsentGrant = mockGConsentGrant(
-        "https://some.issuer",
-        "https://some.resource.owner",
-        undefined
-      );
+      const gConsentGrant = mockGConsentGrant({ inherit: undefined });
       expect(getInherit(gConsentGrant)).toBe(true);
     });
 
@@ -323,8 +315,6 @@ describe("getInherit", () => {
     });
   });
 });
-
-
 
 describe("AccessGrant", () => {
   it("wraps calls to the underlying functions", () => {

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -223,6 +223,31 @@ export function getIssuer(
 }
 
 /**
+ * Check whether a given Access Grant applies recursively to child resources or not.
+ *
+ * @example
+ *
+ * ```
+ * const isInherited = getInherit(accessGrant);
+ * ```
+ *
+ * @param vc The Access Grant/Request
+ * @returns true if the Grant applies to contained resources, false otherwise.
+ */
+export function getInherit(
+  vc: AccessGrantGConsent | AccessRequestGConsent | AccessGrantOdrl
+): boolean {
+  if (isCredentialAccessGrantOdrl(vc)) {
+    return true;
+  }
+  if (isGConsentAccessGrant(vc)) {
+    // Inherit defaults to true.
+    return vc.credentialSubject.providedConsent.inherit ?? true;
+  }
+  return vc.credentialSubject.hasConsent.inherit ?? true;
+}
+
+/**
  * This class wraps all the accessor functions on a raw Access Grant JSON object.
  * It wraps all the supported Access Grants data models, namely GConsent and
  * ODRL.
@@ -276,5 +301,9 @@ export class AccessGrantWrapper {
 
   getIssuer(): ReturnType<typeof getIssuer> {
     return getIssuer(this.vc);
+  }
+
+  getInherit(): ReturnType<typeof getInherit> {
+    return getInherit(this.vc);
   }
 }

--- a/src/gConsent/manage/getAccessGrantAll.test.ts
+++ b/src/gConsent/manage/getAccessGrantAll.test.ts
@@ -21,19 +21,17 @@
 
 import { jest, it, describe, expect } from "@jest/globals";
 import { getVerifiableCredentialAllFromShape } from "@inrupt/solid-client-vc";
+import type * as VcModule from "@inrupt/solid-client-vc";
 import {
   getAccessGrantAll,
   IssueAccessRequestParameters,
 } from "./getAccessGrantAll";
 import { getAccessApiEndpoint } from "../discover/getAccessApiEndpoint";
+import { mockAccessGrantVc } from "../util/access.mock";
 
 const otherFetch = jest.fn(global.fetch);
 
-jest.mock("@inrupt/solid-client-vc", () => {
-  return {
-    getVerifiableCredentialAllFromShape: jest.fn(() => ""),
-  };
-});
+jest.mock("@inrupt/solid-client-vc");
 
 jest.mock("../discover/getAccessApiEndpoint", () => {
   return {
@@ -45,6 +43,11 @@ describe("getAccessGrantAll", () => {
   const resource = new URL(
     "https://pod.example/container-1/container-2/some-resource"
   );
+  const resourceAncestors = [
+    "https://pod.example/container-1/container-2/",
+    "https://pod.example/container-1/",
+    "https://pod.example/",
+  ];
 
   it("Calls @inrupt/solid-client-vc/getVerifiableCredentialAllFromShape with the right default parameters", async () => {
     const expectedDefaultVcShape = {
@@ -188,16 +191,12 @@ describe("getAccessGrantAll", () => {
   it("issues requests for recursive access grants of ancestor containers", async () => {
     // These are all the URLs for which a recursive Access Grant would grant access
     // to the target resource.
-    const matchingUrls = [
-      resource.href,
-      "https://pod.example/container-1/container-2/",
-      "https://pod.example/container-1/",
-      "https://pod.example/",
-    ];
+    const matchingUrls = [resource.href, ...resourceAncestors];
     const expectedVcShape = matchingUrls.map((url) => ({
       credentialSubject: {
         providedConsent: {
           forPersonalData: [url],
+          hasStatus: "https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
         },
       },
     }));
@@ -209,23 +208,53 @@ describe("getAccessGrantAll", () => {
     // A call should have been made for each level of the hierarchy.
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
       expect.anything(),
-      expectedVcShape[0],
+      expect.objectContaining(expectedVcShape[0]),
       expect.anything()
     );
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
       expect.anything(),
-      expectedVcShape[1],
+      expect.objectContaining(expectedVcShape[1]),
       expect.anything()
     );
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
       expect.anything(),
-      expectedVcShape[2],
+      expect.objectContaining(expectedVcShape[2]),
       expect.anything()
     );
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
       expect.anything(),
-      expectedVcShape[3],
+      expect.objectContaining(expectedVcShape[3]),
       expect.anything()
     );
+  });
+
+  it("filters out non-recursive grants for ancestors", async () => {
+    const mockedVcResponse = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as jest.Mocked<typeof VcModule>;
+    const mockedGrant = mockAccessGrantVc({
+      inherit: false,
+      resources: [resourceAncestors[0]],
+    });
+    mockedVcResponse.getVerifiableCredentialAllFromShape.mockResolvedValueOnce([
+      mockedGrant,
+    ]);
+    await expect(getAccessGrantAll(resource.href)).resolves.toStrictEqual([]);
+  });
+
+  it("accepts explicitly non-recursive grants for target resource", async () => {
+    const mockedVcResponse = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as jest.Mocked<typeof VcModule>;
+    const mockedGrant = mockAccessGrantVc({
+      inherit: false,
+      resources: [resource.href],
+    });
+    mockedVcResponse.getVerifiableCredentialAllFromShape.mockResolvedValueOnce([
+      mockedGrant,
+    ]);
+    await expect(getAccessGrantAll(resource.href)).resolves.toStrictEqual([
+      mockedGrant,
+    ]);
   });
 });

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -57,8 +57,10 @@ const getAncestorUrls = (resourceUrl: URL) => {
 };
 
 /**
- * Retrieve Access Grants issued over a resource.
- * Can be filtered by requestor, access and purpose.
+ * Retrieve Access Grants issued over a resource. The Access Grants may be filtered
+ * by requestor, access modes and purpose. In order to discover all applicable Access
+ * Grants for the target resource, including recursive Access Grants issued over
+ * an ancestor container, the resources hierarchy is walked up to the storage root.
  *
  * @param resource The URL of a resource to which access grants might have been issued.
  * @param grantShape The properties of grants to filter results.

--- a/src/gConsent/manage/revokeAccessGrant.test.ts
+++ b/src/gConsent/manage/revokeAccessGrant.test.ts
@@ -38,13 +38,7 @@ describe("revokeAccessGrant", () => {
     );
     const mockedFetch = jest
       .fn(global.fetch)
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify(
-            mockAccessGrantVc("https://some.issuer", "https://some.subject")
-          )
-        )
-      );
+      .mockResolvedValueOnce(new Response(JSON.stringify(mockAccessGrantVc())));
     await revokeAccessGrant("https://some.credential", {
       fetch: mockedFetch,
     });
@@ -65,13 +59,9 @@ describe("revokeAccessGrant", () => {
       mockedVcModule,
       "revokeVerifiableCredential"
     );
-    const mockedVc = mockAccessGrantVc(
-      "https://some.issuer",
-      "https://some.subject"
-    );
     const mockedFetch = jest
       .fn(global.fetch)
-      .mockResolvedValue(new Response(JSON.stringify(mockedVc)));
+      .mockResolvedValue(new Response(JSON.stringify(mockAccessGrantVc())));
     await revokeAccessGrant(MOCKED_CREDENTIAL_ID, {
       fetch: mockedFetch,
     });
@@ -111,7 +101,7 @@ describe("revokeAccessGrant", () => {
     );
     const mockedFetch = jest.fn(global.fetch);
     await revokeAccessGrant(
-      mockAccessGrantVc("https://some.issuer", "https://some.subject"),
+      mockAccessGrantVc({ issuer: "https://some.issuer/" }),
       {
         fetch: mockedFetch,
       }

--- a/src/gConsent/request/cancelAccessRequest.test.ts
+++ b/src/gConsent/request/cancelAccessRequest.test.ts
@@ -46,13 +46,7 @@ describe("cancelAccessRequest", () => {
     );
     const mockedFetch = jest
       .fn(global.fetch)
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify(
-            mockAccessGrantVc("https://some.issuer", "https://some.subject")
-          )
-        )
-      );
+      .mockResolvedValueOnce(new Response(JSON.stringify(mockAccessGrantVc())));
     await cancelAccessRequest("https://some.credential", {
       fetch: mockedFetch,
     });
@@ -73,13 +67,9 @@ describe("cancelAccessRequest", () => {
       mockedVcModule,
       "revokeVerifiableCredential"
     );
-    const mockedVc = mockAccessGrantVc(
-      "https://some.issuer",
-      "https://some.subject"
-    );
     const mockedFetch = jest
       .fn(global.fetch)
-      .mockResolvedValue(new Response(JSON.stringify(mockedVc)));
+      .mockResolvedValue(new Response(JSON.stringify(mockAccessGrantVc())));
     await cancelAccessRequest(MOCKED_CREDENTIAL_ID, {
       fetch: mockedFetch,
     });
@@ -113,7 +103,7 @@ describe("cancelAccessRequest", () => {
     );
     const mockedFetch = jest.fn(global.fetch);
     await cancelAccessRequest(
-      mockAccessGrantVc("https://some.issuer", "https://some.subject"),
+      mockAccessGrantVc({ issuer: "https://some.issuer" }),
       {
         fetch: mockedFetch,
       }

--- a/src/gConsent/util/access.mock.ts
+++ b/src/gConsent/util/access.mock.ts
@@ -41,7 +41,7 @@ export const mockAccessRequestVc = (
     resources: UrlString[];
     modes: ResourceAccessMode[];
     resourceOwner: string | null;
-    inherit?: boolean;
+    inherit: boolean;
   }>
 ): AccessRequest => {
   return {
@@ -57,6 +57,7 @@ export const mockAccessRequestVc = (
           options?.resourceOwner === null
             ? undefined
             : "https://some.pod/profile#you",
+        inherit: options?.inherit,
       },
       inbox: "https://some.inbox",
     },
@@ -75,24 +76,29 @@ export const mockAccessRequestVc = (
 };
 
 export const mockAccessGrantVc = (
-  issuer = "https://some.issuer",
-  subjectId = "https://some.resource.owner"
+  options?: Partial<{
+    issuer: string;
+    subjectId: string;
+    inherit: boolean;
+    resources: string[];
+  }>
 ): AccessGrant => {
   return {
     "@context": ACCESS_GRANT_CONTEXT_DEFAULT,
     id: "https://some.credential",
     credentialSubject: {
-      id: subjectId,
+      id: options?.subjectId ?? "https://some.resource.owner",
       providedConsent: {
-        forPersonalData: ["https://some.resource"],
+        forPersonalData: options?.resources ?? ["https://some.resource"],
         hasStatus: GC_CONSENT_STATUS_EXPLICITLY_GIVEN,
         mode: ["http://www.w3.org/ns/auth/acl#Read"],
         isProvidedTo: "https://some.requestor",
+        inherit: options?.inherit ?? true,
       },
       inbox: "https://some.inbox",
     },
     issuanceDate: "1965-08-28",
-    issuer,
+    issuer: options?.issuer ?? "https://some.issuer",
     proof: {
       created: "2021-10-05",
       proofPurpose: "some proof purpose",


### PR DESCRIPTION
The issue this intends to solve is the following: when recursive access grants are supported, looking up an access grant applicable to a given resource may not include said resource, and instead include one of its ancestor containers. To solve this, when looking up access grants for a target resource, requests for recursive access grants are sent to each ancestor container of the resource. The result set is then filtered to remove non-recursive grants on ancestor resources.

Grants are assumed to be implicitly recursive, so only explicitly non-recursive grants are filtered out. Explicitly non-recursive grants targetting the target resource are not filtered out.

This PR also has some refactor of access grant mocks to make unit tests easier. It also has some changes in the getters and the AccessCredentials type to add the `inherit` flag that may conflict with another PR, so these could be removed when rebasing.

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).