### PR TITLE
Issue recursive Access requests and grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   Additional information is available in [the ESS documentation](https://docs.inrupt.com/ess/latest/security/access-requests-grants/#acp)
 - Added the `inherit` flag to `issueAccessRequest` and `approveAccessRequest` to
   allow controlling whether the issued Access Grant should apply recursively to
-  the target container's contained resources.
+  the target containers' contained resources.
 
 ### Minor changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### New Features
+
 - Added the `createContainerInContainer` method.
 - Added `saveSolidDatasetInContainer` method.
 - Added the `updateAcr` flag to the options that can be included when calling
@@ -11,6 +13,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   this is an advanced feature, and only users having a good understanding of the
   relationship between Access Grants and ACRs should deviate from the default.
   Additional information is available in [the ESS documentation](https://docs.inrupt.com/ess/latest/security/access-requests-grants/#acp)
+- Added the `inherit` flag to `issueAccessRequest` and `approveAccessRequest` to
+  allow controlling whether the issued Access Grant should apply recursively to
+  the target container's contained resources. 
 
 ### Minor changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   Additional information is available in [the ESS documentation](https://docs.inrupt.com/ess/latest/security/access-requests-grants/#acp)
 - Added the `inherit` flag to `issueAccessRequest` and `approveAccessRequest` to
   allow controlling whether the issued Access Grant should apply recursively to
-  the target container's contained resources. 
+  the target container's contained resources.
 
 ### Minor changes
 

--- a/src/gConsent/manage/approveAccessRequest.test.ts
+++ b/src/gConsent/manage/approveAccessRequest.test.ts
@@ -22,8 +22,7 @@
 import { jest, it, describe, expect } from "@jest/globals";
 
 import { mockSolidDatasetFrom } from "@inrupt/solid-client";
-import type { issueVerifiableCredential } from "@inrupt/solid-client-vc";
-
+import type * as VcClient from "@inrupt/solid-client-vc";
 import type * as SolidClient from "@inrupt/solid-client";
 import {
   mockAccessApiEndpoint,
@@ -121,9 +120,7 @@ describe("approveAccessRequest", () => {
 
     const spiedAcrSave = jest.spyOn(mockedClientModule.acp_ess_2, "saveAcrFor");
     const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
+      jest.requireMock("@inrupt/solid-client-vc") as typeof VcClient,
       "issueVerifiableCredential"
     );
     mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
@@ -199,20 +196,14 @@ describe("approveAccessRequest", () => {
 
   it("uses the provided access endpoint, if any", async () => {
     mockAcpClient();
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as typeof VcClient;
     const spiedIssueRequest = jest.spyOn(
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
-      "issueVerifiableCredential"
-    );
-    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+    spiedIssueRequest.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(mockAccessRequestVc(), undefined, {
       accessEndpoint: "https://some.consent-endpoint.override/",
       fetch: jest.fn<typeof fetch>(),
@@ -229,20 +220,14 @@ describe("approveAccessRequest", () => {
     mockAcpClient();
     mockAccessApiEndpoint();
     const mockedFetch = jest.fn(global.fetch);
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as typeof VcClient;
     const spiedIssueRequest = jest.spyOn(
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
-      "issueVerifiableCredential"
-    );
-    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+    spiedIssueRequest.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(mockAccessRequestVc(), undefined, {
       fetch: mockedFetch,
     });
@@ -257,19 +242,14 @@ describe("approveAccessRequest", () => {
   it("issues a proper access grant from a request VC", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as typeof VcClient;
     const spiedIssueRequest = jest.spyOn(
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
-      "issueVerifiableCredential"
-    );
+    const mockedIssue = jest.spyOn(mockedVcModule, "issueVerifiableCredential");
     mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(mockAccessRequestVc(), undefined, {
       fetch: jest.fn(global.fetch),
@@ -298,9 +278,7 @@ describe("approveAccessRequest", () => {
     mockAcpClient();
     mockAccessApiEndpoint();
     const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
+      jest.requireMock("@inrupt/solid-client-vc") as typeof VcClient,
       "issueVerifiableCredential"
     );
     mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
@@ -337,9 +315,7 @@ describe("approveAccessRequest", () => {
     mockAcpClient();
     mockAccessApiEndpoint();
     const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
+      jest.requireMock("@inrupt/solid-client-vc") as typeof VcClient,
       "issueVerifiableCredential"
     );
     mockedIssue.mockResolvedValueOnce(mockAccessRequestVc());
@@ -358,20 +334,14 @@ describe("approveAccessRequest", () => {
   it("issues a proper access grant from a given request VC with purpose", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as typeof VcClient;
     const spiedIssueRequest = jest.spyOn(
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
-      "issueVerifiableCredential"
-    );
-    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+    spiedIssueRequest.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(mockConsentRequestVc(), undefined, {
       fetch: jest.fn(global.fetch),
     });
@@ -401,19 +371,14 @@ describe("approveAccessRequest", () => {
   it("issues a proper access grant from a partially overridden request VC", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as typeof VcClient;
     const spiedIssueRequest = jest.spyOn(
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
-      "issueVerifiableCredential"
-    );
+    const mockedIssue = jest.spyOn(mockedVcModule, "issueVerifiableCredential");
     mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       mockConsentRequestVc(),
@@ -445,23 +410,44 @@ describe("approveAccessRequest", () => {
     );
   });
 
-  it("issues a proper access grant from a totally overridden request VC", async () => {
+  it("allows overriding the 'inherit' parameter of the provided request VC", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as typeof VcClient;
     const spiedIssueRequest = jest.spyOn(
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
+    spiedIssueRequest.mockResolvedValueOnce(mockAccessGrantVc());
+    await approveAccessRequest(
+      mockAccessRequestVc({ inherit: false }),
+      {
+        inherit: true,
       },
+      {
+        fetch: jest.fn(global.fetch),
+      }
+    );
+    expect(spiedIssueRequest.mock.lastCall?.[1]).toMatchObject({
+      providedConsent: {
+        inherit: true,
+      },
+    });
+  });
+
+  it("issues a proper access grant from a totally overridden request VC", async () => {
+    mockAcpClient();
+    mockAccessApiEndpoint();
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as typeof VcClient;
+    const spiedIssueRequest = jest.spyOn(
+      mockedVcModule,
       "issueVerifiableCredential"
     );
-    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+    spiedIssueRequest.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       mockConsentRequestVc(),
       {
@@ -500,20 +486,14 @@ describe("approveAccessRequest", () => {
   it("issues a proper access grant from a request override alone", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as typeof VcClient;
     const spiedIssueRequest = jest.spyOn(
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
-      "issueVerifiableCredential"
-    );
-    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+    spiedIssueRequest.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       undefined,
       {
@@ -552,20 +532,14 @@ describe("approveAccessRequest", () => {
   it("issues a proper access grant overriding only the issuance of the provided VC", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as typeof VcClient;
     const spiedIssueRequest = jest.spyOn(
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
-      "issueVerifiableCredential"
-    );
-    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+    spiedIssueRequest.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       mockConsentRequestVc(),
       {
@@ -603,20 +577,14 @@ describe("approveAccessRequest", () => {
   it("issues a proper access grant overriding only the expiration of the provided VC", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as typeof VcClient;
     const spiedIssueRequest = jest.spyOn(
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
-      "issueVerifiableCredential"
-    );
-    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+    spiedIssueRequest.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       mockConsentRequestVc(),
       {
@@ -653,20 +621,14 @@ describe("approveAccessRequest", () => {
   it("issues a proper access grant nullifying only the expiration of the provided VC", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as typeof VcClient;
     const spiedIssueRequest = jest.spyOn(
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
-      "issueVerifiableCredential"
-    );
-    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+    spiedIssueRequest.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       mockConsentRequestVc(),
       {
@@ -704,20 +666,14 @@ describe("approveAccessRequest", () => {
   it("issues a proper access grant with undefined expiration date", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as typeof VcClient;
     const spiedIssueRequest = jest.spyOn(
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
-      "issueVerifiableCredential"
-    );
-    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+    spiedIssueRequest.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       {
         ...mockConsentRequestVc(),
@@ -754,20 +710,14 @@ describe("approveAccessRequest", () => {
   it("issues a proper access grant from a request VC using the deprecated signature", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
-    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
-      issueVerifiableCredential: () => unknown;
-    };
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc"
+    ) as typeof VcClient;
     const spiedIssueRequest = jest.spyOn(
       mockedVcModule,
       "issueVerifiableCredential"
     );
-    const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
-      "issueVerifiableCredential"
-    );
-    mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
+    spiedIssueRequest.mockResolvedValueOnce(mockAccessGrantVc());
     await approveAccessRequest(
       "https://some.resource.owner",
       mockAccessRequestVc(),
@@ -800,9 +750,7 @@ describe("approveAccessRequest", () => {
     mockAcpClient();
     mockAccessApiEndpoint();
     const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
+      jest.requireMock("@inrupt/solid-client-vc") as typeof VcClient,
       "issueVerifiableCredential"
     );
     mockedIssue.mockResolvedValueOnce(mockAccessRequestVc());
@@ -827,9 +775,7 @@ describe("approveAccessRequest", () => {
 
     const spiedAcrSave = jest.spyOn(mockedClientModule.acp_ess_2, "saveAcrFor");
     const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
+      jest.requireMock("@inrupt/solid-client-vc") as typeof VcClient,
       "issueVerifiableCredential"
     );
     mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());
@@ -871,9 +817,7 @@ describe("approveAccessRequest", () => {
 
     const spiedAcrSave = jest.spyOn(mockedClientModule.acp_ess_2, "saveAcrFor");
     const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
+      jest.requireMock("@inrupt/solid-client-vc") as typeof VcClient,
       "issueVerifiableCredential"
     );
 
@@ -919,9 +863,7 @@ describe("approveAccessRequest", () => {
 
     const spiedAcrSave = jest.spyOn(mockedClientModule.acp_ess_2, "saveAcrFor");
     const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as {
-        issueVerifiableCredential: typeof issueVerifiableCredential;
-      },
+      jest.requireMock("@inrupt/solid-client-vc") as typeof VcClient,
       "issueVerifiableCredential"
     );
     mockedIssue.mockResolvedValueOnce(mockAccessGrantVc());

--- a/src/gConsent/manage/approveAccessRequest.ts
+++ b/src/gConsent/manage/approveAccessRequest.ts
@@ -138,6 +138,7 @@ async function internal_approveAccessRequest(
     issuanceDate: internalGrantOptions.issuanceDate,
     expirationDate: internalGrantOptions.expirationDate ?? undefined,
     status: GC_CONSENT_STATUS_EXPLICITLY_GIVEN,
+    inherit: internalGrantOptions.inherit,
   });
 
   const grantedAccess = getAccessModesFromAccessGrant(grantBody);

--- a/src/gConsent/request/issueAccessRequest.ts
+++ b/src/gConsent/request/issueAccessRequest.ts
@@ -34,7 +34,7 @@ import { isAccessRequest } from "../guard/isAccessRequest";
  * Request access to a given Resource.
  *
  * @param params Access to request.
- * @param options Optional properties to customise the access request behaviour.
+ * @param options Optional properties to customize the access request behavior.
  * @returns A signed Verifiable Credential representing the access request.
  * @since 0.4.0
  */

--- a/src/gConsent/request/issueAccessRequest.ts
+++ b/src/gConsent/request/issueAccessRequest.ts
@@ -57,9 +57,7 @@ async function issueAccessRequest(
     ...params,
     status: GC_CONSENT_STATUS_REQUESTED,
   });
-
   const accessRequest = await issueAccessVc(requestBody, options);
-
   if (!isAccessRequest(accessRequest)) {
     throw new Error(
       `${JSON.stringify(accessRequest)} is not an Access Request`

--- a/src/gConsent/type/AccessBaseOptions.ts
+++ b/src/gConsent/type/AccessBaseOptions.ts
@@ -55,6 +55,7 @@ export interface AccessBaseOptions {
    * @since 0.4.0
    */
   accessEndpoint?: URL | UrlString;
+  recursive?: boolean;
 
   // TODO: Verify whether we need to support the podHost parameter and implement
   //

--- a/src/gConsent/type/AccessBaseOptions.ts
+++ b/src/gConsent/type/AccessBaseOptions.ts
@@ -55,7 +55,6 @@ export interface AccessBaseOptions {
    * @since 0.4.0
    */
   accessEndpoint?: URL | UrlString;
-  recursive?: boolean;
 
   // TODO: Verify whether we need to support the podHost parameter and implement
   //

--- a/src/gConsent/type/AccessVerifiableCredential.ts
+++ b/src/gConsent/type/AccessVerifiableCredential.ts
@@ -35,6 +35,7 @@ export type GConsentAttributes = {
   hasStatus: GConsentStatus;
   forPersonalData: UrlString[];
   forPurpose?: UrlString[];
+  inherit?: boolean;
 };
 
 export type GConsentGrantAttributes = GConsentAttributes & {
@@ -77,7 +78,6 @@ export type BaseAccessVcBody = {
     | Omit<GrantCredentialSubject, "id">;
   issuanceDate?: string;
   expirationDate?: string;
-  inherit?: boolean;
 };
 
 export type BaseRequestBody = BaseAccessVcBody & {

--- a/src/gConsent/type/AccessVerifiableCredential.ts
+++ b/src/gConsent/type/AccessVerifiableCredential.ts
@@ -77,6 +77,7 @@ export type BaseAccessVcBody = {
     | Omit<GrantCredentialSubject, "id">;
   issuanceDate?: string;
   expirationDate?: string;
+  inherit?: boolean;
 };
 
 export type BaseRequestBody = BaseAccessVcBody & {

--- a/src/gConsent/type/IssueAccessRequestParameters.ts
+++ b/src/gConsent/type/IssueAccessRequestParameters.ts
@@ -38,6 +38,9 @@ import { InputAccessRequestParameters } from "./Parameter";
  * - `purpose`: (Optional.) URL representing what the requested access will be used for.
  * - `issuanceDate`: (Optional, set to the current time if left out.) Point in time from which the access should be granted.
  * - `expirationDate`: (Optional.) Point in time until when the access is needed.
+ * - `inherit`: (Optional.) If Access is targeted at a container, it will **not** apply
+ *              recursively to contained resources if this is set to false. Defaults to
+ *              `true`.
  *
  * @since 0.4.0
  */

--- a/src/gConsent/type/Parameter.ts
+++ b/src/gConsent/type/Parameter.ts
@@ -38,6 +38,7 @@ export interface BaseRequestParameters {
   purpose?: Array<UrlString>;
   issuanceDate?: Date;
   expirationDate?: Date;
+  inherit?: boolean;
 }
 
 export interface InputAccessRequestParameters extends BaseRequestParameters {

--- a/src/gConsent/util/access.mock.ts
+++ b/src/gConsent/util/access.mock.ts
@@ -41,6 +41,7 @@ export const mockAccessRequestVc = (
     resources: UrlString[];
     modes: ResourceAccessMode[];
     resourceOwner: string | null;
+    inherit?: boolean;
   }>
 ): AccessRequest => {
   return {
@@ -69,6 +70,7 @@ export const mockAccessRequestVc = (
       verificationMethod: "some method",
     },
     type: [CREDENTIAL_TYPE_ACCESS_REQUEST],
+    inherit: options?.inherit,
   };
 };
 

--- a/src/gConsent/util/initializeGrantParameters.ts
+++ b/src/gConsent/util/initializeGrantParameters.ts
@@ -80,6 +80,12 @@ function getExpirationFromRequest(
     : undefined;
 }
 
+function getInheritFromRequest(
+  requestVc: AccessRequestBody
+): boolean | undefined {
+  return requestVc.credentialSubject.hasConsent.inherit;
+}
+
 export function initializeGrantParameters(
   requestVc: (AccessRequestBody & { issuanceDate: string }) | undefined,
   requestOverride?: Partial<ApproveAccessRequestOverrides>
@@ -104,6 +110,7 @@ export function initializeGrantParameters(
           expirationDate:
             requestOverride?.expirationDate ??
             getExpirationFromRequest(requestVc),
+          inherit: requestOverride?.inherit ?? getInheritFromRequest(requestVc),
         };
   if (requestOverride?.expirationDate === null) {
     resultGrant.expirationDate = undefined;

--- a/src/gConsent/util/issueAccessVc.ts
+++ b/src/gConsent/util/issueAccessVc.ts
@@ -72,6 +72,9 @@ function getGConsentAttributes(
   if (params.purpose !== undefined) {
     consentAttributes.forPurpose = params.purpose;
   }
+  if (params.inherit !== undefined) {
+    consentAttributes.inherit = params.inherit;
+  }
 
   if (type === "BaseGrantBody") {
     return {
@@ -108,9 +111,6 @@ function getBaseBody(
       inbox: params.requestorInboxUrl,
     },
   };
-  if (params.inherit !== undefined) {
-    (body as BaseAccessVcBody).inherit = params.inherit;
-  }
   if (params.issuanceDate !== undefined) {
     (body as BaseAccessVcBody).issuanceDate = params.issuanceDate.toISOString();
   }
@@ -178,7 +178,6 @@ export async function issueAccessVc(
         accessIssuerEndpoint.hostname
       ),
       ...vcBody.credentialSubject,
-      inherit: options.recursive,
     },
     {
       // All the required context is provided by instanciateEssAccessGrantContext,
@@ -188,7 +187,6 @@ export async function issueAccessVc(
       type: vcBody.type,
       issuanceDate: vcBody.issuanceDate,
       expirationDate: vcBody.expirationDate,
-      inherit: options.recursive,
     },
     {
       fetch: fetcher,

--- a/src/gConsent/util/issueAccessVc.ts
+++ b/src/gConsent/util/issueAccessVc.ts
@@ -108,6 +108,9 @@ function getBaseBody(
       inbox: params.requestorInboxUrl,
     },
   };
+  if (params.inherit !== undefined) {
+    (body as BaseAccessVcBody).inherit = params.inherit;
+  }
   if (params.issuanceDate !== undefined) {
     (body as BaseAccessVcBody).issuanceDate = params.issuanceDate.toISOString();
   }
@@ -175,6 +178,7 @@ export async function issueAccessVc(
         accessIssuerEndpoint.hostname
       ),
       ...vcBody.credentialSubject,
+      inherit: options.recursive,
     },
     {
       // All the required context is provided by instanciateEssAccessGrantContext,
@@ -184,6 +188,7 @@ export async function issueAccessVc(
       type: vcBody.type,
       issuanceDate: vcBody.issuanceDate,
       expirationDate: vcBody.expirationDate,
+      inherit: options.recursive,
     },
     {
       fetch: fetcher,


### PR DESCRIPTION
When requesting access to a resource, and when approving the request, it is now possible to specify an "inherit" flag. If set to true, the resulting access grant will apply not only to the target container, but also recursively to the contained resources. If left undefined, the Access Grant will not contain an `inherit` flag, and the authorization server will default to considering it recursive.

# Checklist

- [X] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).