### PR TITLE
Fix misalignments between JSON-LD input and plain JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Bugfixes
 
-- The Access Grants and Access Requests status is now accepted in its abbreviated
+- JSON-LD/JSON alignment: We are processing Verifiable Credentials as plain JSON,
+  while they actually are JSON-LD. This creates some discrepancies:
+  - The Access Grants and Access Requests status is now accepted in its abbreviated
   form, and not only as a fully qualified IRI, as allowed by the JSON-LD context.
+  - Arrays containing a single value are also accepted as a literal equal to said
+  single value.
+  
   This is a stopgap solution: a proper fix would be to do full JSON-LD parsing,
   but we aren't doing it for the moment because of issues between existing libraries
   and our build setup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - JSON-LD/JSON alignment: We are processing Verifiable Credentials as plain JSON,
   while they actually are JSON-LD. This creates some discrepancies:
+
   - The Access Grants and Access Requests status is now accepted in its abbreviated
-  form, and not only as a fully qualified IRI, as allowed by the JSON-LD context.
+    form, and not only as a fully qualified IRI, as allowed by the JSON-LD context.
   - Arrays containing a single value are also accepted as a literal equal to said
-  single value.
-  
+    single value.
+
   This is a stopgap solution: a proper fix would be to do full JSON-LD parsing,
   but we aren't doing it for the moment because of issues between existing libraries
   and our build setup.

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -257,6 +257,8 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       );
     });
 
+    // The following test is disabled until ESS adds support for recursive Access Grants.
+    // eslint-disable-next-line jest/no-disabled-tests
     it.skip("can issue a non-recursive access grant", async () => {
       const grant = await approveAccessRequest(
         undefined,
@@ -275,7 +277,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           accessEndpoint: vcProvider,
         }
       );
-
       await expect(
         isValidAccessGrant(grant, {
           fetch: resourceOwnerSession.fetch,
@@ -963,10 +964,9 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       await sc.createContainerAt(testContainerIri, {
         fetch: resourceOwnerSession.fetch,
       });
-
       await sc.saveFileInContainer(
         testContainerIri,
-        new Blob([testFileContent]),
+        Buffer.from(testFileContent),
         {
           fetch: resourceOwnerSession.fetch,
           slug: testFileName,
@@ -1024,7 +1024,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           accessEndpoint: vcProvider,
         }
       );
-
       const requestorFile = await getFile(testFileIri, accessGrant, {
         fetch: requestorSession.fetch,
       });

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -252,13 +252,11 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         })
       ).resolves.toMatchObject({ errors: [] });
       expect(grant.expirationDate).toBeUndefined();
-      expect(grant.credentialSubject.providedConsent.mode).toStrictEqual([
-        "http://www.w3.org/ns/auth/acl#Read",
-      ]);
+      expect(["http://www.w3.org/ns/auth/acl#Read", "Read"]).toContain(
+        grant.credentialSubject.providedConsent.mode[0]
+      );
     });
 
-    // The following test is disabled until ESS adds support for recursive Access Grants.
-    // eslint-disable-next-line jest/no-disabled-tests
     it.skip("can issue a non-recursive access grant", async () => {
       const grant = await approveAccessRequest(
         undefined,

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -178,7 +178,13 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
       // Test that looking up the access grants for the given resource returns
       // the access we just granted.
-      expect(grantedAccess).toContainEqual(grant);
+      // The issuer and query service return the grants with a slight difference
+      // in the value order in arrays, so we can't use deep comparison to verify
+      // if the issued grant is part of the query result set. Matching on the proofs
+      // is sufficient, as proofs are generated on canonicalized datasets.
+      expect(
+        grantedAccess.map((matchingGrant) => matchingGrant.proof)
+      ).toContainEqual(grant.proof);
 
       const sharedFile = await getFile(sharedFileIri, grant, {
         fetch: requestorSession.fetch,

--- a/src/fetch/index.test.ts
+++ b/src/fetch/index.test.ts
@@ -161,7 +161,14 @@ describe("exchangeTicketForAccessToken", () => {
       },
       body: new URLSearchParams({
         claim_token: base64url.encode(
-          JSON.stringify({ verifiableCredential: [MOCK_VC] })
+          JSON.stringify({
+            "@context": [
+              "https://www.w3.org/2018/credentials/v1",
+              "https://schema.inrupt.com/credentials/v1.jsonld",
+            ],
+            type: ["VerifiablePresentation"],
+            verifiableCredential: [MOCK_VC],
+          })
         ),
         claim_token_format: "https://www.w3.org/TR/vc-data-model/#json-ld",
         grant_type: "urn:ietf:params:oauth:grant-type:uma-ticket",

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -25,7 +25,11 @@ import type { UrlString } from "@inrupt/solid-client";
 import type { VerifiableCredential } from "@inrupt/solid-client-vc";
 import type { UmaConfiguration } from "../type/UmaConfiguration";
 import type { FetchOptions } from "../type/FetchOptions";
-import { CONTEXT_VC_W3C, CONTEXT_ESS_DEFAULT, PRESENTATION_TYPE_BASE } from "../gConsent/constants";
+import {
+  CONTEXT_VC_W3C,
+  CONTEXT_ESS_DEFAULT,
+  PRESENTATION_TYPE_BASE,
+} from "../gConsent/constants";
 
 const WWW_AUTH_HEADER = "www-authenticate";
 const VC_CLAIM_TOKEN_TYPE = "https://www.w3.org/TR/vc-data-model/#json-ld";

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -25,6 +25,7 @@ import type { UrlString } from "@inrupt/solid-client";
 import type { VerifiableCredential } from "@inrupt/solid-client-vc";
 import type { UmaConfiguration } from "../type/UmaConfiguration";
 import type { FetchOptions } from "../type/FetchOptions";
+import { CONTEXT_VC_W3C, CONTEXT_ESS_DEFAULT, PRESENTATION_TYPE_BASE } from "../gConsent/constants";
 
 const WWW_AUTH_HEADER = "www-authenticate";
 const VC_CLAIM_TOKEN_TYPE = "https://www.w3.org/TR/vc-data-model/#json-ld";
@@ -86,6 +87,8 @@ export async function exchangeTicketForAccessToken(
   authFetch: typeof fetch
 ): Promise<string | null> {
   const credentialPresentation = {
+    "@context": [CONTEXT_VC_W3C, CONTEXT_ESS_DEFAULT],
+    type: [PRESENTATION_TYPE_BASE],
     verifiableCredential: [accessGrant],
   };
   const response = await authFetch(tokenEndpoint, {

--- a/src/gConsent/constants.ts
+++ b/src/gConsent/constants.ts
@@ -54,7 +54,7 @@ export const PREFERRED_CONSENT_MANAGEMENT_UI =
 export const CONTEXT_VC_W3C = "https://www.w3.org/2018/credentials/v1" as const;
 // This static context is used from the 2.1 version, instead of having a context
 // specific to the deployment.
-export const DEFAULT_ESS_CONTEXT =
+export const CONTEXT_ESS_DEFAULT =
   "https://schema.inrupt.com/credentials/v1.jsonld" as const;
 
 // According to the [ESS documentation](https://docs.inrupt.com/ess/latest/services/service-vc/#ess-vc-service-endpoints),
@@ -65,7 +65,7 @@ const instanciateContextVcEssTemplate = (essVcDomain: string): string =>
 // A default context value is provided for mocking purpose accross the codebase.
 export const ACCESS_GRANT_CONTEXT_DEFAULT = [
   CONTEXT_VC_W3C,
-  DEFAULT_ESS_CONTEXT,
+  CONTEXT_ESS_DEFAULT,
   instanciateContextVcEssTemplate("vc.inrupt.com"),
 ] as const;
 
@@ -75,7 +75,7 @@ export const instanciateEssAccessGrantContext = (
 ): typeof ACCESS_GRANT_CONTEXT_DEFAULT =>
   [
     CONTEXT_VC_W3C,
-    DEFAULT_ESS_CONTEXT,
+    CONTEXT_ESS_DEFAULT,
     instanciateContextVcEssTemplate(essVcDomain),
   ] as const;
 
@@ -94,6 +94,7 @@ export const CREDENTIAL_TYPE_ACCESS_GRANT = "SolidAccessGrant";
 export const CREDENTIAL_TYPE_ACCESS_DENIAL = "SolidAccessDenial";
 export const CREDENTIAL_TYPE_LEGACY_CONSENT_REQUEST = "SolidConsentRequest";
 export const CREDENTIAL_TYPE_BASE = "VerifiableCredential";
+export const PRESENTATION_TYPE_BASE = "VerifiablePresentation";
 
 export const ACCESS_CREDENTIAL_TYPE = new Set([
   CREDENTIAL_TYPE_ACCESS_REQUEST,

--- a/src/gConsent/constants.ts
+++ b/src/gConsent/constants.ts
@@ -79,8 +79,6 @@ export const instanciateEssAccessGrantContext = (
     instanciateContextVcEssTemplate(essVcDomain),
   ] as const;
 
-
-
 export const WELL_KNOWN_SOLID = ".well-known/solid";
 
 export const INRUPT_CONSENT_SERVICE_LEGACY =

--- a/src/gConsent/constants.ts
+++ b/src/gConsent/constants.ts
@@ -52,22 +52,34 @@ export const PREFERRED_CONSENT_MANAGEMENT_UI =
   "http://inrupt.com/ns/ess#ConsentManagementUI";
 
 export const CONTEXT_VC_W3C = "https://www.w3.org/2018/credentials/v1" as const;
+// This static context is used from the 2.1 version, instead of having a context
+// specific to the deployment.
+export const DEFAULT_ESS_CONTEXT =
+  "https://schema.inrupt.com/credentials/v1.jsonld" as const;
 
 // According to the [ESS documentation](https://docs.inrupt.com/ess/latest/services/service-vc/#ess-vc-service-endpoints),
 // the JSON-LD context for ESS-issued VCs will match the following template.
 const instanciateContextVcEssTemplate = (essVcDomain: string): string =>
   `https://${essVcDomain}/credentials/v1`;
 
-// When issuing a VC using a given service, be sure to set the context using the following.
-export const instanciateEssAccessGrantContext = (
-  essVcDomain: string
-): string[] => [CONTEXT_VC_W3C, instanciateContextVcEssTemplate(essVcDomain)];
-
 // A default context value is provided for mocking purpose accross the codebase.
 export const ACCESS_GRANT_CONTEXT_DEFAULT = [
   CONTEXT_VC_W3C,
+  DEFAULT_ESS_CONTEXT,
   instanciateContextVcEssTemplate("vc.inrupt.com"),
 ] as const;
+
+// When issuing a VC using a given service,"https://schema.inrupt.com/credentials/v1.jsonld" be sure to set the context using the following.
+export const instanciateEssAccessGrantContext = (
+  essVcDomain: string
+): typeof ACCESS_GRANT_CONTEXT_DEFAULT =>
+  [
+    CONTEXT_VC_W3C,
+    DEFAULT_ESS_CONTEXT,
+    instanciateContextVcEssTemplate(essVcDomain),
+  ] as const;
+
+
 
 export const WELL_KNOWN_SOLID = ".well-known/solid";
 
@@ -81,6 +93,7 @@ export const CREDENTIAL_TYPE_ACCESS_REQUEST = "SolidAccessRequest";
 export const CREDENTIAL_TYPE_ACCESS_GRANT = "SolidAccessGrant";
 export const CREDENTIAL_TYPE_ACCESS_DENIAL = "SolidAccessDenial";
 export const CREDENTIAL_TYPE_LEGACY_CONSENT_REQUEST = "SolidConsentRequest";
+export const CREDENTIAL_TYPE_BASE = "VerifiableCredential";
 
 export const ACCESS_CREDENTIAL_TYPE = new Set([
   CREDENTIAL_TYPE_ACCESS_REQUEST,

--- a/src/gConsent/manage/approveAccessRequest.ts
+++ b/src/gConsent/manage/approveAccessRequest.ts
@@ -46,7 +46,18 @@ export type ApproveAccessRequestOverrides = Omit<
   "expirationDate"
 > & { expirationDate?: Date | null };
 
-function normalizeAccessGrant<T extends VerifiableCredential>(
+/**
+ * Internal function. This is a stopgap until we have proper JSON-LD parsing.
+ * It enforces the shape of the JSON returned by the issuer service, which may
+ * vary while still serializing the same data.
+ *
+ * In particular, this transforms some literals into a one-value array.
+ *
+ * @hidden
+ * @param accessGrant The grant returned by the VC issuer
+ * @returns An equivalent JSON-LD document framed according to our typing.
+ */
+export function normalizeAccessGrant<T extends VerifiableCredential>(
   accessGrant: T
 ): T {
   // Proper type checking is performed after normalization, so casting here is fine.

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -36,6 +36,7 @@ import { isAccessGrant } from "../guard/isAccessGrant";
 import { isBaseAccessGrantVerifiableCredential } from "../guard/isBaseAccessGrantVerifiableCredential";
 import { AccessGrant } from "../type/AccessGrant";
 import { getInherit, getResources } from "../../common/getters";
+import { normalizeAccessGrant } from "./approveAccessRequest";
 
 // Iteratively build the list of ancestor containers from the breakdown of the
 // resource path: for resource https://pod.example/foo/bar/baz, we'll want the result
@@ -126,7 +127,8 @@ async function getAccessGrantAll(
   )
     // getVerifiableCredentialAllFromShape returns a list, so the previous map
     // should be flattened to have all the candidate grants in a non-nested list.
-    .flat();
+    .flat()
+    .map(normalizeAccessGrant);
 
   return (
     result

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -92,9 +92,11 @@ async function getAccessGrantAll(
   options: AccessBaseOptions & { includeExpired?: boolean } = {}
 ): Promise<Array<VerifiableCredential>> {
   const sessionFetch = await getSessionFetch(options);
-  const vcServiceBase = await getAccessApiEndpoint(resource, options);
   // TODO: Fix access API endpoint retrieval (should include all the different API endpoints)
-  const holderEndpoint = new URL("derive", vcServiceBase);
+  const holderEndpoint = new URL(
+    "derive",
+    await getAccessApiEndpoint(resource, options)
+  );
 
   const ancestorUrls = getAncestorUrls(
     typeof resource === "string" ? new URL(resource) : resource

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -25,6 +25,8 @@ import {
   VerifiableCredential,
 } from "@inrupt/solid-client-vc";
 import {
+  CONTEXT_ESS_DEFAULT,
+  CONTEXT_VC_W3C,
   CREDENTIAL_TYPE_ACCESS_GRANT,
   CREDENTIAL_TYPE_BASE,
   GC_CONSENT_STATUS_EXPLICITLY_GIVEN,
@@ -102,7 +104,7 @@ async function getAccessGrantAll(
 
   const vcShapes: RecursivePartial<BaseGrantBody & VerifiableCredential>[] =
     ancestorUrls.map((url) => ({
-      "@context": instanciateEssAccessGrantContext(vcServiceBase),
+      "@context": [CONTEXT_VC_W3C, CONTEXT_ESS_DEFAULT],
       type: [CREDENTIAL_TYPE_ACCESS_GRANT, CREDENTIAL_TYPE_BASE],
       credentialSubject: {
         providedConsent: {

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -30,8 +30,6 @@ import {
   CREDENTIAL_TYPE_ACCESS_GRANT,
   CREDENTIAL_TYPE_BASE,
   GC_CONSENT_STATUS_EXPLICITLY_GIVEN,
-  GC_CONSENT_STATUS_EXPLICITLY_GIVEN_ABBREV,
-  instanciateEssAccessGrantContext,
 } from "../constants";
 import { getAccessApiEndpoint } from "../discover/getAccessApiEndpoint";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";

--- a/src/gConsent/request/issueAccessRequest.test.ts
+++ b/src/gConsent/request/issueAccessRequest.test.ts
@@ -68,6 +68,7 @@ describe("getRequestBody", () => {
     expect(requestBody).toStrictEqual({
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
+        "https://schema.inrupt.com/credentials/v1.jsonld",
         "https://vc.inrupt.com/credentials/v1",
       ],
       credentialSubject: {
@@ -103,6 +104,7 @@ describe("getRequestBody", () => {
     expect(requestBody).toStrictEqual({
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
+        "https://schema.inrupt.com/credentials/v1.jsonld",
         "https://vc.inrupt.com/credentials/v1",
       ],
       credentialSubject: {

--- a/src/gConsent/request/issueAccessRequest.ts
+++ b/src/gConsent/request/issueAccessRequest.ts
@@ -30,6 +30,17 @@ import type {
 import type { AccessRequest } from "../type/AccessRequest";
 import { isAccessRequest } from "../guard/isAccessRequest";
 
+/**
+ * Internal function. This is a stopgap until we have proper JSON-LD parsing.
+ * It enforces the shape of the JSON returned by the issuer service, which may
+ * vary while still serializing the same data.
+ *
+ * In particular, this transforms some literals into a one-value array.
+ *
+ * @hidden
+ * @param accessRequest The grant returned by the VC issuer
+ * @returns An equivalent JSON-LD document framed according to our typing.
+ */
 function normalizeAccessRequest<T extends VerifiableCredential>(
   accessRequest: T
 ): T {

--- a/src/gConsent/util/initializeGrantParameters.ts
+++ b/src/gConsent/util/initializeGrantParameters.ts
@@ -21,11 +21,14 @@
 
 import { UrlString } from "@inrupt/solid-client";
 import type { AccessRequestBody } from "../type/AccessVerifiableCredential";
-import type { ResourceAccessMode } from "../../type/ResourceAccessMode";
 import {
+  ACL_RESOURCE_ACCESS_MODE_APPEND_ABBREV,
+  ResourceAccessMode,
   ACL_RESOURCE_ACCESS_MODE_APPEND,
   ACL_RESOURCE_ACCESS_MODE_READ,
   ACL_RESOURCE_ACCESS_MODE_WRITE,
+  ACL_RESOURCE_ACCESS_MODE_READ_ABBREV,
+  ACL_RESOURCE_ACCESS_MODE_WRITE_ABBREV,
 } from "../../type/ResourceAccessMode";
 import { ApproveAccessRequestOverrides } from "../manage/approveAccessRequest";
 import { AccessModes } from "../../type/AccessModes";
@@ -43,9 +46,24 @@ function getModesFromRequest(
 function modesToAccess(modes: ResourceAccessMode[]): AccessModes {
   const accessMode: AccessModes = {};
 
-  accessMode.append = modes.includes(ACL_RESOURCE_ACCESS_MODE_APPEND);
-  accessMode.read = modes.includes(ACL_RESOURCE_ACCESS_MODE_READ);
-  accessMode.write = modes.includes(ACL_RESOURCE_ACCESS_MODE_WRITE);
+  accessMode.append = modes.some((mode) =>
+    [
+      ACL_RESOURCE_ACCESS_MODE_APPEND,
+      ACL_RESOURCE_ACCESS_MODE_APPEND_ABBREV,
+    ].includes(mode)
+  );
+  accessMode.read = modes.some((mode) =>
+  [
+    ACL_RESOURCE_ACCESS_MODE_READ,
+    ACL_RESOURCE_ACCESS_MODE_READ_ABBREV,
+  ].includes(mode)
+);
+  accessMode.write = modes.some((mode) =>
+  [
+    ACL_RESOURCE_ACCESS_MODE_WRITE,
+    ACL_RESOURCE_ACCESS_MODE_WRITE_ABBREV,
+  ].includes(mode)
+);
 
   return accessMode;
 }

--- a/src/gConsent/util/initializeGrantParameters.ts
+++ b/src/gConsent/util/initializeGrantParameters.ts
@@ -53,17 +53,17 @@ function modesToAccess(modes: ResourceAccessMode[]): AccessModes {
     ].includes(mode)
   );
   accessMode.read = modes.some((mode) =>
-  [
-    ACL_RESOURCE_ACCESS_MODE_READ,
-    ACL_RESOURCE_ACCESS_MODE_READ_ABBREV,
-  ].includes(mode)
-);
+    [
+      ACL_RESOURCE_ACCESS_MODE_READ,
+      ACL_RESOURCE_ACCESS_MODE_READ_ABBREV,
+    ].includes(mode)
+  );
   accessMode.write = modes.some((mode) =>
-  [
-    ACL_RESOURCE_ACCESS_MODE_WRITE,
-    ACL_RESOURCE_ACCESS_MODE_WRITE_ABBREV,
-  ].includes(mode)
-);
+    [
+      ACL_RESOURCE_ACCESS_MODE_WRITE,
+      ACL_RESOURCE_ACCESS_MODE_WRITE_ABBREV,
+    ].includes(mode)
+  );
 
   return accessMode;
 }

--- a/src/type/ResourceAccessMode.ts
+++ b/src/type/ResourceAccessMode.ts
@@ -26,15 +26,19 @@ export const ACL_RESOURCE_ACCESS_MODE_READ =
 export const ACL_RESOURCE_ACCESS_MODE_WRITE =
   "http://www.w3.org/ns/auth/acl#Write";
 
+export const ACL_RESOURCE_ACCESS_MODE_APPEND_ABBREV = "Append";
+export const ACL_RESOURCE_ACCESS_MODE_READ_ABBREV = "Read";
+export const ACL_RESOURCE_ACCESS_MODE_WRITE_ABBREV = "Write";
+
 export const RESOURCE_ACCESS_MODE = new Set([
   ACL_RESOURCE_ACCESS_MODE_APPEND,
   ACL_RESOURCE_ACCESS_MODE_READ,
   ACL_RESOURCE_ACCESS_MODE_WRITE,
   // The following are linked to the previous through our JSON-LD context.
-  "Read",
-  "Write",
-  "Append",
-] as const);
+  ACL_RESOURCE_ACCESS_MODE_READ_ABBREV,
+  ACL_RESOURCE_ACCESS_MODE_WRITE_ABBREV,
+  ACL_RESOURCE_ACCESS_MODE_APPEND_ABBREV,
+]);
 
 export type ResourceAccessMode = typeof RESOURCE_ACCESS_MODE extends Set<
   infer T


### PR DESCRIPTION
In JSON-LD, a plain value and an array of a single value are equivalent: 

```
{
  "@context": [...],
  someKey: "someValue"
}
```

and 

```
{
  "@context": [...],
  someKey: ["someValue"]
}
```

are equivalent, because they are serializations of the same graph.

This changes ensures that Access Request and Access Grants VCs are normalized:
- For fields where multiple values are possible, if a single value is available, it can be returned as a plain literal instead of an array. That is equivalent in JSON-LD, but we are currently parsing VCs as JSON. To keep our JSON type consistent, a single value is converted back to a one-value array.
- IRI values are supportede in both their fully qualified version (`https://w3id.org/GConsent#ConsentStatusExplicitlyGiven`) and local name version (`ConsentStatusExplicitlyGiven`) are supported.

Currently, the client libraries are parsing Verifiable Credentials as plain JSON, and running validation on the individual fields, expecting some to be arrays. However, since the ESS VC service transitioned to managing VCs as RDF, we don’t have a guarantee that the frame won’t change and single-value arrays will be converted into plain values.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [ ] ~Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/)~ The fixups won't autosquash but since it all gets squashed at the end it doesn't make a difference.