### PR TITLE
Fix end-to-end test environment feature flag

### DIFF
--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -1009,7 +1009,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         const grants = await getAccessGrantAll(testFileIri, undefined, {
           fetch: resourceOwnerSession.fetch,
         });
-        expect(grants).toHaveLength(0);
+        expect(grants).not.toContainEqual(accessGrant);
       }
     );
 

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -28,7 +28,6 @@ import { getNodeTestingEnvironment } from "@inrupt/internal-test-env";
 // the access grant API
 import * as sc from "@inrupt/solid-client";
 import { custom } from "openid-client";
-import { session } from "rdf-namespaces/dist/link";
 import {
   AccessGrant,
   AccessRequest,

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -28,6 +28,7 @@ import { getNodeTestingEnvironment } from "@inrupt/internal-test-env";
 // the access grant API
 import * as sc from "@inrupt/solid-client";
 import { custom } from "openid-client";
+import { session } from "rdf-namespaces/dist/link";
 import {
   AccessGrant,
   AccessRequest,
@@ -1061,7 +1062,16 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
     testIf(
       environmentFeatures?.E2E_TEST_FEATURE_RECURSIVE_ACCESS_GRANTS === "true"
     )("can use the saveSolidDatasetAt API for a new dataset", async () => {
-      // Delete the dataset created in the beforeEach:
+      accessGrant = await approveAccessRequest(
+        accessRequest,
+        // Access is granted to the target container and all contained resources.
+        { inherit: true },
+        {
+          fetch: resourceOwnerSession.fetch,
+          accessEndpoint: vcProvider,
+        }
+      );
+
       await sc.deleteFile(testFileIri, {
         fetch: resourceOwnerSession.fetch,
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@inrupt/eslint-config-lib": "^1.0.0",
         "@inrupt/internal-playwright-helpers": "^1.5.3",
-        "@inrupt/internal-test-env": "^1.4.2",
+        "@inrupt/internal-test-env": "^1.5.4",
         "@inrupt/jest-jsdom-polyfills": "^1.3.0",
         "@inrupt/solid-client-authn-browser": "^1.12.2",
         "@inrupt/solid-client-authn-node": "^1.12.1",
@@ -758,6 +758,18 @@
         "@playwright/test": "^1.28.1"
       }
     },
+    "node_modules/@inrupt/internal-playwright-helpers/node_modules/@inrupt/internal-test-env": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-1.5.3.tgz",
+      "integrity": "sha512-8maCuDJQ1IowD9eEmpTF8a+yOouPqZHOapinJb8KNzOAKrmyxcKG1OOvDfogEy1cmU9IPjvA/dF3WNJLSLOmTQ==",
+      "dev": true,
+      "dependencies": {
+        "@inrupt/solid-client": "^1.23.3",
+        "@inrupt/solid-client-authn-browser": "^1.12.2",
+        "@inrupt/solid-client-authn-node": "^1.12.2",
+        "deepmerge-json": "^1.5.0"
+      }
+    },
     "node_modules/@inrupt/internal-playwright-testids": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-1.5.3.tgz",
@@ -765,9 +777,9 @@
       "dev": true
     },
     "node_modules/@inrupt/internal-test-env": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-1.5.3.tgz",
-      "integrity": "sha512-8maCuDJQ1IowD9eEmpTF8a+yOouPqZHOapinJb8KNzOAKrmyxcKG1OOvDfogEy1cmU9IPjvA/dF3WNJLSLOmTQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-1.5.4.tgz",
+      "integrity": "sha512-t3fOoE5es/t+5CQ93RLB36MRBh3h1XJj/xduMdynN4FItPrnzgoAiNHW21AypN+GSnfsM+are5CF8fqppHjuig==",
       "dev": true,
       "dependencies": {
         "@inrupt/solid-client": "^1.23.3",
@@ -8948,6 +8960,20 @@
       "requires": {
         "@inrupt/internal-playwright-testids": "1.5.3",
         "@inrupt/internal-test-env": "1.5.3"
+      },
+      "dependencies": {
+        "@inrupt/internal-test-env": {
+          "version": "1.5.3",
+          "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-1.5.3.tgz",
+          "integrity": "sha512-8maCuDJQ1IowD9eEmpTF8a+yOouPqZHOapinJb8KNzOAKrmyxcKG1OOvDfogEy1cmU9IPjvA/dF3WNJLSLOmTQ==",
+          "dev": true,
+          "requires": {
+            "@inrupt/solid-client": "^1.23.3",
+            "@inrupt/solid-client-authn-browser": "^1.12.2",
+            "@inrupt/solid-client-authn-node": "^1.12.2",
+            "deepmerge-json": "^1.5.0"
+          }
+        }
       }
     },
     "@inrupt/internal-playwright-testids": {
@@ -8957,9 +8983,9 @@
       "dev": true
     },
     "@inrupt/internal-test-env": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-1.5.3.tgz",
-      "integrity": "sha512-8maCuDJQ1IowD9eEmpTF8a+yOouPqZHOapinJb8KNzOAKrmyxcKG1OOvDfogEy1cmU9IPjvA/dF3WNJLSLOmTQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-1.5.4.tgz",
+      "integrity": "sha512-t3fOoE5es/t+5CQ93RLB36MRBh3h1XJj/xduMdynN4FItPrnzgoAiNHW21AypN+GSnfsM+are5CF8fqppHjuig==",
       "dev": true,
       "requires": {
         "@inrupt/solid-client": "^1.23.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest --ignoreProjects e2e-node",
     "test:unit:browser": "jest --selectProjects browser",
     "test:unit:node": "jest --selectProjects node",
-    "test:e2e:node": "jest --selectProjects e2e-node --testTimeout 15000 --collectCoverage false",
+    "test:e2e:node": "jest --selectProjects e2e-node --testTimeout 30000 --collectCoverage false",
     "test:e2e:browser": "playwright test",
     "test:e2e:browser:setup": "cd e2e/browser/test-app && npm ci",
     "licenses:list": "license-checker --production --csv --out LICENSE_DEPENDENCIES_ALL",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "devDependencies": {
     "@inrupt/eslint-config-lib": "^1.0.0",
     "@inrupt/internal-playwright-helpers": "^1.5.3",
-    "@inrupt/internal-test-env": "^1.4.2",
+    "@inrupt/internal-test-env": "^1.5.4",
     "@inrupt/jest-jsdom-polyfills": "^1.3.0",
     "@inrupt/solid-client-authn-browser": "^1.12.2",
     "@inrupt/solid-client-authn-node": "^1.12.1",


### PR DESCRIPTION
This PR fixes the end-to-end tests, which were previously skipping the recursive access grant tests in all environments, and were ignoring the feature flags passed through environment variable to control whether the tests should be skipped or not.
The issue was coming from a bug in the environment test helper, which is now fixed.

This also moves the dataset and non-RDF resource overwrite to the recursive access grants test section, as these features require using access grants.