### PR TITLE
Fix/normalize on lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+# Bugfixes
+
+- The JSON-LD/JSON normalization is now applied not only when issuing an Access Request
+  or an Access Grant, but also when dereferencing one.
+
 ## [2.1.1](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v2.1.1) - 2023-02-01
 
 ### Bugfixes

--- a/src/gConsent/manage/approveAccessRequest.ts
+++ b/src/gConsent/manage/approveAccessRequest.ts
@@ -62,6 +62,13 @@ export function normalizeAccessGrant<T extends VerifiableCredential>(
 ): T {
   // Proper type checking is performed after normalization, so casting here is fine.
   const normalized = { ...accessGrant } as unknown as AccessGrant;
+  if (normalized.credentialSubject.providedConsent === undefined) {
+    throw new Error(
+      `${JSON.stringify(
+        normalized
+      )} is not an Access Grant: missing field "credentialSubject.providedConsent".`
+    );
+  }
   if (!Array.isArray(normalized.credentialSubject.providedConsent.mode)) {
     normalized.credentialSubject.providedConsent.mode = [
       normalized.credentialSubject.providedConsent.mode,

--- a/src/gConsent/manage/approveAccessRequest.ts
+++ b/src/gConsent/manage/approveAccessRequest.ts
@@ -64,9 +64,7 @@ export function normalizeAccessGrant<T extends VerifiableCredential>(
   const normalized = { ...accessGrant } as unknown as AccessGrant;
   if (normalized.credentialSubject.providedConsent === undefined) {
     throw new Error(
-      `${JSON.stringify(
-        normalized
-      )} is not an Access Grant: missing field "credentialSubject.providedConsent".`
+      `[${normalized.id}] is not an Access Grant: missing field "credentialSubject.providedConsent".`
     );
   }
   if (!Array.isArray(normalized.credentialSubject.providedConsent.mode)) {

--- a/src/gConsent/manage/getAccessGrant.test.ts
+++ b/src/gConsent/manage/getAccessGrant.test.ts
@@ -96,9 +96,7 @@ describe("getAccessGrant", () => {
       getAccessGrant("https://some.vc.url", {
         fetch: mockedFetch,
       })
-    ).rejects.toThrow(
-      /Unexpected response.*\[https:\/\/some.vc.url\].*not an Access Grant/
-    );
+    ).rejects.toThrow(/not an Access Grant/);
   });
 
   it("supports denied access grants with a given IRI", async () => {

--- a/src/gConsent/manage/getAccessGrant.ts
+++ b/src/gConsent/manage/getAccessGrant.ts
@@ -26,6 +26,8 @@ import type { AccessGrant } from "../type/AccessGrant";
 import { isBaseAccessGrantVerifiableCredential } from "../guard/isBaseAccessGrantVerifiableCredential";
 import { isAccessGrant } from "../guard/isAccessGrant";
 import { getSessionFetch } from "../../common/util/getSessionFetch";
+import { normalizeAccessGrant } from "./approveAccessRequest";
+import { BaseGrantBody } from "../type/AccessVerifiableCredential";
 
 /**
  * Retrieve the Access Grant associated to the given URL.
@@ -53,7 +55,7 @@ export async function getAccessGrant(
   const responseErrorClone = response.clone();
   let data;
   try {
-    data = await response.json();
+    data = normalizeAccessGrant(await response.json());
   } catch (e) {
     throw new Error(
       `Unexpected response when resolving [${vcUrl}], the result is not a Verifiable Credential: ${await responseErrorClone.text()}`

--- a/src/gConsent/manage/getAccessGrant.ts
+++ b/src/gConsent/manage/getAccessGrant.ts
@@ -55,12 +55,13 @@ export async function getAccessGrant(
   const responseErrorClone = response.clone();
   let data;
   try {
-    data = normalizeAccessGrant(await response.json());
+    data = await response.json();
   } catch (e) {
     throw new Error(
       `Unexpected response when resolving [${vcUrl}], the result is not a Verifiable Credential: ${await responseErrorClone.text()}`
     );
   }
+  data = normalizeAccessGrant(data);
   if (
     !isVerifiableCredential(data) ||
     !isBaseAccessGrantVerifiableCredential(data) ||

--- a/src/gConsent/manage/getAccessRequestFromRedirectUrl.ts
+++ b/src/gConsent/manage/getAccessRequestFromRedirectUrl.ts
@@ -28,6 +28,7 @@ import {
 import { isAccessRequest } from "../guard/isAccessRequest";
 import type { AccessRequest } from "../type/AccessRequest";
 import { getSessionFetch } from "../../common/util/getSessionFetch";
+import { normalizeAccessRequest } from "../request/issueAccessRequest";
 
 /**
  * Get the Access Request out of the incoming redirect from the Access Management app.
@@ -73,9 +74,11 @@ export async function getAccessRequestFromRedirectUrl(
     );
   }
 
-  const accessRequest = await getVerifiableCredential(accessRequestIri, {
-    fetch: authFetch,
-  });
+  const accessRequest = normalizeAccessRequest(
+    await getVerifiableCredential(accessRequestIri, {
+      fetch: authFetch,
+    })
+  );
 
   if (!isAccessRequest(accessRequest)) {
     throw new Error(

--- a/src/gConsent/request/getAccessGrantFromRedirectUrl.ts
+++ b/src/gConsent/request/getAccessGrantFromRedirectUrl.ts
@@ -26,6 +26,7 @@ import { isAccessGrant } from "../guard/isAccessGrant";
 import { isBaseAccessVcBody } from "../guard/isBaseAccessVcBody";
 import { GRANT_VC_URL_PARAM_NAME } from "../manage/redirectToRequestor";
 import { getSessionFetch } from "../../common/util/getSessionFetch";
+import { normalizeAccessGrant } from "../manage/approveAccessRequest";
 
 /**
  * Get the Access Grant out of the incoming redirect from the Access Management app.
@@ -55,9 +56,11 @@ export async function getAccessGrantFromRedirectUrl(
     );
   }
 
-  const accessGrant = await getVerifiableCredential(accessGrantIri, {
-    fetch: authFetch,
-  });
+  const accessGrant = normalizeAccessGrant(
+    await getVerifiableCredential(accessGrantIri, {
+      fetch: authFetch,
+    })
+  );
 
   if (!isBaseAccessVcBody(accessGrant) || !isAccessGrant(accessGrant)) {
     throw new Error(`${JSON.stringify(accessGrant)} is not an Access Grant`);

--- a/src/gConsent/request/issueAccessRequest.ts
+++ b/src/gConsent/request/issueAccessRequest.ts
@@ -41,7 +41,7 @@ import { isAccessRequest } from "../guard/isAccessRequest";
  * @param accessRequest The grant returned by the VC issuer
  * @returns An equivalent JSON-LD document framed according to our typing.
  */
-function normalizeAccessRequest<T extends VerifiableCredential>(
+export function normalizeAccessRequest<T extends VerifiableCredential>(
   accessRequest: T
 ): T {
   // Proper type checking is performed after normalization, so casting here is fine.

--- a/src/gConsent/util/getBaseAccessVerifiableCredential.ts
+++ b/src/gConsent/util/getBaseAccessVerifiableCredential.ts
@@ -29,6 +29,7 @@ import type {
 import { getSessionFetch } from "../../common/util/getSessionFetch";
 import { isBaseAccessRequestVerifiableCredential } from "../guard/isBaseAccessRequestVerifiableCredential";
 import { isBaseAccessGrantVerifiableCredential } from "../guard/isBaseAccessGrantVerifiableCredential";
+import { normalizeAccessRequest } from "../request/issueAccessRequest";
 
 async function getVerifiableCredential(
   vc: URL | UrlString,
@@ -66,10 +67,11 @@ export async function getBaseAccessRequestVerifiableCredential(
   vc: VerifiableCredential | URL | UrlString,
   options: AccessBaseOptions
 ): Promise<AccessRequestBody & VerifiableCredential> {
-  const fetchedVerifiableCredential =
+  const fetchedVerifiableCredential = normalizeAccessRequest(
     typeof vc === "string" || vc instanceof URL
       ? await getVerifiableCredential(vc, options)
-      : vc;
+      : vc
+  );
   if (!isBaseAccessRequestVerifiableCredential(fetchedVerifiableCredential)) {
     throw new Error(
       `An error occurred when type checking the VC, it is not a BaseAccessVerifiableCredential.`


### PR DESCRIPTION
This is a piece of work complementary to https://github.com/inrupt/solid-client-access-grants-js/commit/25ac1849252249126a923d24e2a3bd779b16e679. The JSON-LD/JSON misalignments need to be normalized in all the places where a VC may be fetched from a remote service, not only on issue.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
