### PR TITLE
Investigate end-to-end flakyness

### DIFF
--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -20,7 +20,6 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: true
-      max-parallel: 1
       matrix:
         os: [ubuntu-latest]
         node-version: ["14.x", "16.x"]

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -20,6 +20,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: true
+      max-parallel: 1
       matrix:
         os: [ubuntu-latest]
         node-version: ["14.x", "16.x"]

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -836,9 +836,16 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
     });
 
     afterEach(async () => {
-      await revokeAccessGrant(accessGrant, {
-        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
-      });
+      try {
+        await revokeAccessGrant(accessGrant, {
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
+        });
+      } catch (e) {
+        // Allow console statement as this is useful to capture, either
+        // running tests locally or in CI.
+        // eslint-disable-next-line no-console
+        console.error(`Revoking the Access Grant failed: ${e.toString()}`);
+      }
 
       await sc.deleteFile(testFileIri, {
         fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -51,7 +51,6 @@ import {
   saveSolidDatasetAt,
   saveSolidDatasetInContainer,
 } from "../../src/index";
-import { getSourceIri } from "@inrupt/solid-client";
 
 if (process.env.CI === "true") {
   // Tests running in the CI runners tend to be more flaky.
@@ -804,7 +803,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           slugSuggestion: "file-apis",
         }
       );
-      testContainerIri = getSourceIri(fileApisContainer);
+      testContainerIri = sc.getSourceIri(fileApisContainer);
 
       testFileName = `upload-${Date.now()}.txt`;
       fileContents = Buffer.from("hello world", "utf-8");
@@ -818,7 +817,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         }
       );
 
-      testFileIri = getSourceIri(uploadedFile);
+      testFileIri = sc.getSourceIri(uploadedFile);
 
       const request = await issueAccessRequest(
         {
@@ -851,7 +850,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         // Allow console statement as this is useful to capture, either
         // running tests locally or in CI.
         // eslint-disable-next-line no-console
-        console.error(`Revoking the Access Grant failed: ${e.toString()}`);
+        console.error(`Revoking the Access Grant failed: ${e}`);
       }
 
       await sc.deleteFile(testFileIri, {

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -45,6 +45,11 @@ import {
   saveSolidDatasetInContainer,
 } from "../../src/index";
 
+if (process.env.CI === "true") {
+  // Tests running in the CI runners tend to be more flaky.
+  jest.retryTimes(3, { logErrorsBeforeRetry: true });
+}
+
 // Extend the timeout because of frequent issues in CI (default is 3500)
 custom.setHttpOptionsDefaults({
   timeout: 10000,

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -78,6 +78,17 @@ const {
   features: environmentFeatures,
 } = env;
 
+const TEST_USER_AGENT = `Node-based solid-client-access-grant end-to-end tests running ${
+  process.env.CI === "true" ? "in CI" : "locally"
+}`;
+const addUserAgent =
+  (myFetch: typeof fetch, agent: string): typeof fetch =>
+  (input: Parameters<typeof fetch>[0], init: Parameters<typeof fetch>[1]) =>
+    myFetch(input, {
+      ...init,
+      headers: { ...init?.headers, "User-Agent": agent },
+    });
+
 const testIf = (condition: boolean) => (condition ? it : it.skip);
 // Conditional tests confuse eslint.
 /* eslint-disable jest/no-standalone-expect */
@@ -134,7 +145,10 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       {
         // The session ID is a random string, used here as a unique slug.
         slug: `${resourceOwnerSession.info.sessionId}.txt`,
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(
+          addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
+          TEST_USER_AGENT
+        ),
       }
     );
 
@@ -146,7 +160,10 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
     if (sharedFileIri) {
       // Remove the shared file from the resource owner's Pod.
       await sc.deleteFile(sharedFileIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(
+          addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
+          TEST_USER_AGENT
+        ),
       });
     }
     // Making sure the session is logged out prevents tests from hanging due
@@ -168,7 +185,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           ],
         },
         {
-          fetch: requestorSession.fetch,
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         }
       );
@@ -178,14 +195,14 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         request,
         {},
         {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         }
       );
 
       await expect(
         isValidAccessGrant(grant, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           // FIXME: Currently looking up JSON-LD doesn't work in jest tests.
           // It is an issue documented in the VC library e2e test, and in a ticket
           // to be fixed.
@@ -194,7 +211,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       ).resolves.toMatchObject({ errors: [] });
 
       const grantedAccess = await getAccessGrantAll(sharedFileIri, undefined, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         accessEndpoint: vcProvider,
       });
 
@@ -209,17 +226,17 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       ).toContainEqual(grant.proof);
 
       const sharedFile = await getFile(sharedFileIri, grant, {
-        fetch: requestorSession.fetch,
+        fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
       });
       await expect(sharedFile.text()).resolves.toBe(SHARED_FILE_CONTENT);
 
       await revokeAccessGrant(grant, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
       expect(
         (
           await isValidAccessGrant(grant, {
-            fetch: resourceOwnerSession.fetch,
+            fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
             // FIXME: Ditto verification endpoint discovery.
             verificationEndpoint: `${vcProvider}/verify`,
           })
@@ -243,7 +260,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           expirationDate,
         },
         {
-          fetch: requestorSession.fetch,
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         }
       );
@@ -259,14 +276,14 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           expirationDate: null,
         },
         {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         }
       );
 
       await expect(
         isValidAccessGrant(grant, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           // FIXME: Currently looking up JSON-LD doesn't work in jest tests.
           // It is an issue documented in the VC library e2e test, and in a ticket
           // to be fixed.
@@ -293,13 +310,13 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           inherit: false,
         },
         {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         }
       );
       await expect(
         isValidAccessGrant(grant, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           // FIXME: Currently looking up JSON-LD doesn't work in jest tests.
           // It is an issue documented in the VC library e2e test, and in a ticket
           // to be fixed.
@@ -321,7 +338,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           ],
         },
         {
-          fetch: requestorSession.fetch,
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         }
       );
@@ -331,7 +348,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         request,
         {},
         {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
           updateAcr: false,
         }
@@ -339,7 +356,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
       await expect(
         isValidAccessGrant(grant, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           // FIXME: Currently looking up JSON-LD doesn't work in jest tests.
           // It is an issue documented in the VC library e2e test, and in a ticket
           // to be fixed.
@@ -350,7 +367,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       const sharedFileWithAcr = await sc.acp_ess_2.getFileWithAcr(
         sharedFileIri,
         {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         }
       );
 
@@ -381,7 +398,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           ],
         },
         {
-          fetch: requestorSession.fetch,
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         }
       );
@@ -391,7 +408,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         request,
         {},
         {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
           updateAcr: true,
         }
@@ -399,7 +416,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
       await expect(
         isValidAccessGrant(grant, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           // FIXME: Currently looking up JSON-LD doesn't work in jest tests.
           // It is an issue documented in the VC library e2e test, and in a ticket
           // to be fixed.
@@ -410,7 +427,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       const sharedFileWithAcr = await sc.acp_ess_2.getFileWithAcr(
         sharedFileIri,
         {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         }
       );
 
@@ -437,7 +454,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           sharedFileIri,
           { requestor: requestorSession.info.webId as string },
           {
-            fetch: resourceOwnerSession.fetch,
+            fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
             accessEndpoint: vcProvider,
           }
         )
@@ -447,7 +464,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           sharedFileIri,
           { requestor: "https://some.unknown.requestor" },
           {
-            fetch: resourceOwnerSession.fetch,
+            fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
             accessEndpoint: vcProvider,
           }
         )
@@ -457,13 +474,13 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
     it("can filter VCs held by the service based on target resource", async () => {
       await expect(
         getAccessGrantAll(sharedFileIri, undefined, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         })
       ).resolves.not.toHaveLength(0);
       await expect(
         getAccessGrantAll("https://some.unkown.resource", undefined, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         })
       ).resolves.toHaveLength(0);
@@ -478,14 +495,14 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         unknownPurposeFilter,
       ] = await Promise.all([
         getAccessGrantAll(sharedFileIri, undefined, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         }),
         getAccessGrantAll(
           sharedFileIri,
           { purpose: ["https://some.purpose/not-a-nefarious-one/i-promise"] },
           {
-            fetch: resourceOwnerSession.fetch,
+            fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
             accessEndpoint: vcProvider,
           }
         ),
@@ -493,7 +510,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           sharedFileIri,
           { purpose: ["https://some.other.purpose/"] },
           {
-            fetch: resourceOwnerSession.fetch,
+            fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
             accessEndpoint: vcProvider,
           }
         ),
@@ -506,7 +523,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
             ],
           },
           {
-            fetch: resourceOwnerSession.fetch,
+            fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
             accessEndpoint: vcProvider,
           }
         ),
@@ -514,7 +531,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           sharedFileIri,
           { purpose: ["https://some.unknown.purpose/"] },
           {
-            fetch: resourceOwnerSession.fetch,
+            fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
             accessEndpoint: vcProvider,
           }
         ),
@@ -567,7 +584,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       testFileIri = new URL(testFileName, testContainerIri).href;
 
       await sc.createContainerAt(testContainerIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       const newThing = sc.setStringNoLocale(
@@ -581,7 +598,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       const dataset = sc.setThing(sc.createSolidDataset(), newThing);
 
       await sc.saveSolidDatasetInContainer(testContainerIri, dataset, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         slugSuggestion: testFileName,
       });
 
@@ -596,7 +613,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           ],
         },
         {
-          fetch: requestorSession.fetch,
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         }
       );
@@ -605,7 +622,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         request,
         {},
         {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         }
       );
@@ -613,11 +630,11 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
     afterEach(async () => {
       await revokeAccessGrant(accessGrant, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       await sc.deleteFile(testFileIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       if (testContainerIriChild !== undefined) {
@@ -625,22 +642,22 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         // rather than in the test ensures it is properly removed even on test
         // failure.
         await sc.deleteContainer(testContainerIriChild, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         });
       }
 
       await sc.deleteContainer(testContainerIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
     });
 
     it("can use the getSolidDataset API to fetch an existing dataset", async () => {
       const ownerDataset = await sc.getSolidDataset(testFileIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       const requestorDataset = await getSolidDataset(testFileIri, accessGrant, {
-        fetch: requestorSession.fetch,
+        fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
       });
 
       const ownerTtl = await sc.solidDatasetAsTurtle(ownerDataset);
@@ -655,7 +672,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       // as the requestor, this is just to limit how much of the Access Grants
       // library we're testing in a single test case:
       const dataset = await sc.getSolidDataset(testFileIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       // Create a thing and add it to the dataset:
@@ -675,13 +692,13 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         datasetUpdate,
         accessGrant,
         {
-          fetch: requestorSession.fetch,
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
         }
       );
 
       // Fetch it back as the owner to prove the dataset was actually updated:
       const updatedDatasetAsOwner = await sc.getSolidDataset(testFileIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       // Serialize each to turtle:
@@ -702,13 +719,13 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         testContainerIri,
         accessGrant,
         {
-          fetch: requestorSession.fetch,
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
           slugSuggestion: containerNameSuggestion,
         }
       );
 
       const parentContainer = await sc.getSolidDataset(testContainerIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
       const parentContainerContainsAll = sc.getUrlAll(
         sc.getThing(
@@ -730,7 +747,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       // Need to delete dataset that was already created in test setup,
       // such that our test can create an empty dataset at `testFileIri`.
       await sc.deleteFile(testFileIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       const testDataset = sc.createSolidDataset();
@@ -739,7 +756,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         testDataset,
         accessGrant,
         {
-          fetch: requestorSession.fetch,
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
           slugSuggestion: testFileName,
         }
       );
@@ -747,7 +764,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       const datasetInPodAsResourceOwner = await sc.getSolidDataset(
         sc.getSourceIri(savedDataset),
         {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         }
       );
 
@@ -759,7 +776,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       // const datasetInPodAsRequestor = await
       // getSolidDataset( testFileIri, accessGrant,
       //   {
-      //     fetch: requestorSession.fetch,
+      //     fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
       //   }
       // );
 
@@ -788,11 +805,11 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       fileContents = Buffer.from("hello world", "utf-8");
 
       await sc.createContainerAt(testContainerIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       await sc.saveFileInContainer(testContainerIri, fileContents, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         slug: testFileName,
       });
 
@@ -803,7 +820,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           resourceOwner: resourceOwnerSession.info.webId as string,
         },
         {
-          fetch: requestorSession.fetch,
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         }
       );
@@ -812,7 +829,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         request,
         {},
         {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         }
       );
@@ -820,22 +837,22 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
     afterEach(async () => {
       await revokeAccessGrant(accessGrant, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       await sc.deleteFile(testFileIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       await sc.deleteContainer(testContainerIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
     });
 
     it("can use the saveFileInContainer API to create a new file", async () => {
       // Delete the existing file as to be able to save a new file:
       await sc.deleteFile(testFileIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       const newFileContents = Buffer.from("new contents", "utf-8");
@@ -845,7 +862,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         newFileContents,
         accessGrant,
         {
-          fetch: requestorSession.fetch,
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
           slug: testFileName,
         }
       );
@@ -855,7 +872,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
       // Verify as the resource owner that the file was actually created:
       const fileAsResourceOwner = await sc.getFile(sc.getSourceUrl(newFile), {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       await expect(fileAsResourceOwner.text()).resolves.toBe(
@@ -866,7 +883,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
     it("can use the getFile API to get an existing file", async () => {
       // Try fetching it as the requestor of the access grant:
       const existingFile = await getFile(testFileIri, accessGrant, {
-        fetch: requestorSession.fetch,
+        fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
       });
 
       expect(sc.getSourceUrl(existingFile)).toBe(testFileIri);
@@ -881,7 +898,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         newFileContents,
         accessGrant,
         {
-          fetch: requestorSession.fetch,
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
         }
       );
 
@@ -890,7 +907,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
       // Verify as the resource owner that the file was actually overwritten:
       const fileAsResourceOwner = await sc.getFile(testFileIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       await expect(fileAsResourceOwner.text()).resolves.toBe(
@@ -915,13 +932,13 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       testFileIri = new URL(testFileName, testContainerIri).href;
 
       await sc.createContainerAt(testContainerIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
       await sc.saveFileInContainer(
         testContainerIri,
         Buffer.from(testFileContent),
         {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           slug: testFileName,
         }
       );
@@ -938,7 +955,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           ],
         },
         {
-          fetch: requestorSession.fetch,
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
         }
       );
@@ -946,11 +963,11 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
     afterEach(async () => {
       await revokeAccessGrant(accessGrant, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       await sc.deleteFile(testFileIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
 
       if (testContainerIriChild !== undefined) {
@@ -958,12 +975,12 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         // rather than in the test ensures it is properly removed even on test
         // failure.
         await sc.deleteContainer(testContainerIriChild, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         });
       }
 
       await sc.deleteContainer(testContainerIri, {
-        fetch: resourceOwnerSession.fetch,
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });
     });
 
@@ -976,19 +993,19 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           // Access is granted to the target container and all contained resources.
           { inherit: true },
           {
-            fetch: resourceOwnerSession.fetch,
+            fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
             accessEndpoint: vcProvider,
           }
         );
         const requestorFile = await getFile(testFileIri, accessGrant, {
-          fetch: requestorSession.fetch,
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
         });
 
         await expect(requestorFile.text()).resolves.toBe(testFileContent);
 
         // Lookup grants for the target resource, while it has been issued for the container.
         const grants = await getAccessGrantAll(testFileIri, undefined, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         });
         expect(grants.map((grant) => grant.proof)).toContainEqual(
           accessGrant.proof
@@ -1004,21 +1021,21 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           // Access is granted to the target container only.
           { inherit: false },
           {
-            fetch: resourceOwnerSession.fetch,
+            fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
             accessEndpoint: vcProvider,
           }
         );
 
         await expect(
           getFile(testFileIri, accessGrant, {
-            fetch: requestorSession.fetch,
+            fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
           })
         ).rejects.toThrow();
 
         // Lookup grants for the target resource, while it has been issued for the container.
         // There should be no matching grant, because the issued grant is not recursive.
         const grants = await getAccessGrantAll(testFileIri, undefined, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         });
         expect(grants).not.toContainEqual(accessGrant);
       }
@@ -1029,7 +1046,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       async () => {
         // Delete the existing file as to be able to save a new file:
         await sc.deleteFile(testFileIri, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         });
 
         accessGrant = await approveAccessRequest(
@@ -1037,7 +1054,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           // Access is granted to the target container and all contained resources.
           { inherit: true },
           {
-            fetch: resourceOwnerSession.fetch,
+            fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
             accessEndpoint: vcProvider,
           }
         );
@@ -1049,7 +1066,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           newFileContents,
           accessGrant,
           {
-            fetch: requestorSession.fetch,
+            fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
           }
         );
 
@@ -1058,7 +1075,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
         // Verify as the resource owner that the file was actually created:
         const fileAsResourceOwner = await sc.getFile(testFileIri, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         });
 
         await expect(fileAsResourceOwner.text()).resolves.toBe(
@@ -1075,13 +1092,13 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           // Access is granted to the target container and all contained resources.
           { inherit: true },
           {
-            fetch: resourceOwnerSession.fetch,
+            fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
             accessEndpoint: vcProvider,
           }
         );
 
         await sc.deleteFile(testFileIri, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         });
 
         const dataset = sc.createSolidDataset();
@@ -1092,13 +1109,13 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           dataset,
           accessGrant,
           {
-            fetch: requestorSession.fetch,
+            fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
           }
         );
 
         // Fetch it back as the owner to prove the dataset was actually created:
         const updatedDatasetAsOwner = await sc.getSolidDataset(testFileIri, {
-          fetch: resourceOwnerSession.fetch,
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
         });
 
         // Serialize each to turtle:

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -20,7 +20,14 @@
 //
 
 // Globals are actually not injected, so this does not shadow anything.
-import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
 import { Session } from "@inrupt/solid-client-authn-node";
 import { isVerifiableCredential } from "@inrupt/solid-client-vc";
 import { getNodeTestingEnvironment } from "@inrupt/internal-test-env";


### PR DESCRIPTION
A couple of improvements to improve the reliability of tests, as well as their debuggability: 
- Retry on failed tests
- Do not use static resource names, so that there is no collision on retry
- Make sure that failure of the test doesn't prevent the cleanup, by catching any errors that may happen before deleting the test resource and container
- Add a distinctive user agent to all the HTTP interaction to help going through the logs.