### PR TITLE
Remove slug usage from end-to-end tests

### DIFF
--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -27,8 +27,6 @@ import {
   expect,
   beforeEach,
   afterEach,
-  beforeAll,
-  afterAll,
 } from "@jest/globals";
 import { Session } from "@inrupt/solid-client-authn-node";
 import { isVerifiableCredential } from "@inrupt/solid-client-vc";
@@ -449,7 +447,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
   describe("resource owner interaction with VC provider", () => {
     let accessGrant: AccessGrant;
-    beforeAll(async () => {
+    beforeEach(async () => {
       const request = await issueAccessRequest(
         {
           access: { read: true, write: true, append: true },
@@ -476,7 +474,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       );
     });
 
-    afterAll(async () => {
+    afterEach(async () => {
       await revokeAccessGrant(accessGrant, {
         fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
       });

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -446,6 +446,40 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
   });
 
   describe("resource owner interaction with VC provider", () => {
+    let accessGrant: AccessGrant;
+    beforeEach(async () => {
+      const request = await issueAccessRequest(
+        {
+          access: { read: true, write: true, append: true },
+          resourceOwner: resourceOwnerSession.info.webId as string,
+          resources: [sharedFileIri],
+          purpose: [
+            "https://some.purpose/not-a-nefarious-one/i-promise",
+            "https://some.other.purpose/",
+          ],
+        },
+        {
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
+          accessEndpoint: vcProvider,
+        }
+      );
+
+      accessGrant = await approveAccessRequest(
+        request,
+        {},
+        {
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
+          accessEndpoint: vcProvider,
+        }
+      );
+    });
+
+    afterEach(async () => {
+      await revokeAccessGrant(accessGrant, {
+        fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
+      });
+    });
+
     it("can filter VCs held by the service based on requestor", async () => {
       await expect(
         getAccessGrantAll(

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -143,8 +143,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       resourceOwnerPodAll[0],
       Buffer.from(SHARED_FILE_CONTENT),
       {
-        // The session ID is a random string, used here as a unique slug.
-        slug: `${resourceOwnerSession.info.sessionId}.txt`,
         fetch: addUserAgent(
           addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           TEST_USER_AGENT
@@ -599,7 +597,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
 
       await sc.saveSolidDatasetInContainer(testContainerIri, dataset, {
         fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
-        slugSuggestion: testFileName,
       });
 
       const request = await issueAccessRequest(
@@ -714,13 +711,11 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
     });
 
     it("can use the createContainerInContainer API to create a new container", async () => {
-      const containerNameSuggestion = "newTestContainer";
       const newChildContainer = await createContainerInContainer(
         testContainerIri,
         accessGrant,
         {
           fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
-          slugSuggestion: containerNameSuggestion,
         }
       );
 
@@ -757,7 +752,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         accessGrant,
         {
           fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
-          slugSuggestion: testFileName,
         }
       );
 
@@ -800,7 +794,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         resourceOwnerPod,
         {
           fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
-          slugSuggestion: "file-apis",
         }
       );
       testContainerIri = sc.getSourceIri(fileApisContainer);
@@ -813,7 +806,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         fileContents,
         {
           fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
-          slug: testFileName,
         }
       );
 
@@ -876,7 +868,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         accessGrant,
         {
           fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
-          slug: testFileName,
         }
       );
 
@@ -952,7 +943,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         Buffer.from(testFileContent),
         {
           fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
-          slug: testFileName,
         }
       );
 


### PR DESCRIPTION
Some servers will use slugs as a definitive name for the resource, rather than a name that should appear in the created resource IRI. This may result in some cases in a 409 conflict response, if the previous run wasn't cleaned up properly.