### PR TITLE
Exp/universal fetch

### DIFF
--- a/examples/grant-access/src/request-access.ts
+++ b/examples/grant-access/src/request-access.ts
@@ -22,7 +22,7 @@
 /* eslint-disable no-console */
 
 import { Session } from "@inrupt/solid-client-authn-node";
-import { fetch as crossFetch } from "cross-fetch";
+import { fetch as crossFetch } from "@inrupt/universal-fetch";
 import express from "express";
 import {
   issueAccessRequest,

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -20,17 +20,3 @@
 //
 
 import "@inrupt/jest-jsdom-polyfills";
-import { Request, Response, Headers, fetch as undiFetch } from "undici";
-
-if (
-  typeof globalThis.Response === "undefined" ||
-  typeof globalThis.Request === "undefined" ||
-  typeof globalThis.Headers === "undefined" ||
-  typeof globalThis.fetch === "undefined"
-) {
-  // eslint-disable @typescript-eslint/no-explicit-any
-  globalThis.Response = Response as any;
-  globalThis.Request = Request as any;
-  globalThis.Headers = Headers as any;
-  globalThis.fetch = undiFetch as any;
-}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -20,3 +20,17 @@
 //
 
 import "@inrupt/jest-jsdom-polyfills";
+import { Request, Response, Headers, fetch as undiFetch } from "undici";
+
+if (
+  typeof globalThis.Response === "undefined" ||
+  typeof globalThis.Request === "undefined" ||
+  typeof globalThis.Headers === "undefined" ||
+  typeof globalThis.fetch === "undefined"
+) {
+  // eslint-disable @typescript-eslint/no-explicit-any
+  globalThis.Response = Response as any;
+  globalThis.Request = Request as any;
+  globalThis.Headers = Headers as any;
+  globalThis.fetch = undiFetch as any;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
       "dependencies": {
         "@inrupt/solid-client": "^1.25.1",
         "@inrupt/solid-client-vc": "^0.5.0",
+        "@inrupt/universal-fetch": "^1.0.0-alpha.0",
         "@types/rdfjs__dataset": "^1.0.5",
         "auth-header": "^1.0.0",
         "base64url": "^3.0.1",
-        "cross-fetch": "^3.1.4",
         "rdf-namespaces": "^1.9.2"
       },
       "devDependencies": {
@@ -909,6 +909,15 @@
       "dependencies": {
         "@inrupt/solid-client": "^1.15.0",
         "cross-fetch": "^3.1.4"
+      }
+    },
+    "node_modules/@inrupt/universal-fetch": {
+      "version": "1.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.0-alpha.0.tgz",
+      "integrity": "sha512-EL6uTgL6CkGuv5oHhaRGIe9JHeOYYiqBONuHeTyOWbSOca0gAqky8U/8tuLaYQ4wiMNqLzeudG51opNLhTlQKg==",
+      "dependencies": {
+        "node-fetch": "^2.6.7",
+        "undici": "^5.12.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -2679,6 +2688,17 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -7554,6 +7574,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -8076,6 +8104,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.19.1.tgz",
+      "integrity": "sha512-YiZ61LPIgY73E7syxCDxxa3LV2yl3sN8spnIuTct60boiiRaE1J8mNWHO8Im2Zi/sFrPusjLlmRPrsyraSqX6A==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
       }
     },
     "node_modules/universalify": {
@@ -9138,6 +9177,15 @@
       "requires": {
         "@inrupt/solid-client": "^1.15.0",
         "cross-fetch": "^3.1.4"
+      }
+    },
+    "@inrupt/universal-fetch": {
+      "version": "1.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.0-alpha.0.tgz",
+      "integrity": "sha512-EL6uTgL6CkGuv5oHhaRGIe9JHeOYYiqBONuHeTyOWbSOca0gAqky8U/8tuLaYQ4wiMNqLzeudG51opNLhTlQKg==",
+      "requires": {
+        "node-fetch": "^2.6.7",
+        "undici": "^5.12.0"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -10400,6 +10448,14 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -13725,6 +13781,11 @@
         }
       }
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -14056,6 +14117,14 @@
         "has-bigints": "^1.0.2",
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "undici": {
+      "version": "5.19.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.19.1.tgz",
+      "integrity": "sha512-YiZ61LPIgY73E7syxCDxxa3LV2yl3sN8spnIuTct60boiiRaE1J8mNWHO8Im2Zi/sFrPusjLlmRPrsyraSqX6A==",
+      "requires": {
+        "busboy": "^1.6.0"
       }
     },
     "universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@inrupt/solid-client": "^1.25.1",
         "@inrupt/solid-client-vc": "^0.5.0",
-        "@inrupt/universal-fetch": "^1.0.0-alpha.0",
+        "@inrupt/universal-fetch": "^1.0.1",
         "@types/rdfjs__dataset": "^1.0.5",
         "auth-header": "^1.0.0",
         "base64url": "^3.0.1",
@@ -21,7 +21,7 @@
         "@inrupt/eslint-config-lib": "^1.0.0",
         "@inrupt/internal-playwright-helpers": "^1.5.3",
         "@inrupt/internal-test-env": "^1.5.4",
-        "@inrupt/jest-jsdom-polyfills": "^1.3.0",
+        "@inrupt/jest-jsdom-polyfills": "^1.6.0",
         "@inrupt/solid-client-authn-browser": "^1.12.2",
         "@inrupt/solid-client-authn-node": "^1.12.1",
         "@playwright/test": "^1.28.1",
@@ -796,14 +796,15 @@
       }
     },
     "node_modules/@inrupt/jest-jsdom-polyfills": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.5.5.tgz",
-      "integrity": "sha512-3wLPAoWLhQFwnlGBNv+iHkDM6wSsplEbEBAFjFc3Eab1CR2KeQ+TxSSw+IylA7958qpWtw6DRN7/TPR97qXGvw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.6.0.tgz",
+      "integrity": "sha512-Gu/92kmr2pg4+1UR3uZlY8/dXphFi730wZaJl/em7U2yZCtNhi5b9d6r3Cr3aiWxD2x57GF1nHTCeskVIEm2Fg==",
       "dev": true,
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
         "@web-std/blob": "^3.0.4",
-        "@web-std/file": "^3.0.2"
+        "@web-std/file": "^3.0.2",
+        "undici": "^5.20.0"
       }
     },
     "node_modules/@inrupt/oidc-client": {
@@ -912,12 +913,12 @@
       }
     },
     "node_modules/@inrupt/universal-fetch": {
-      "version": "1.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.0-alpha.0.tgz",
-      "integrity": "sha512-EL6uTgL6CkGuv5oHhaRGIe9JHeOYYiqBONuHeTyOWbSOca0gAqky8U/8tuLaYQ4wiMNqLzeudG51opNLhTlQKg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.1.tgz",
+      "integrity": "sha512-oqbG7jS1fa6hVkjSir+u5Ab3eSbyxFyOjsgjDICL27mAd5z8oImTSETnY2hYbkRaJQYKMBOXhtm7L5/+EbeVJg==",
       "dependencies": {
         "node-fetch": "^2.6.7",
-        "undici": "^5.12.0"
+        "undici": "^5.19.1"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -8107,9 +8108,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.19.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.19.1.tgz",
-      "integrity": "sha512-YiZ61LPIgY73E7syxCDxxa3LV2yl3sN8spnIuTct60boiiRaE1J8mNWHO8Im2Zi/sFrPusjLlmRPrsyraSqX6A==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "dependencies": {
         "busboy": "^1.6.0"
       },
@@ -9079,14 +9080,15 @@
       }
     },
     "@inrupt/jest-jsdom-polyfills": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.5.5.tgz",
-      "integrity": "sha512-3wLPAoWLhQFwnlGBNv+iHkDM6wSsplEbEBAFjFc3Eab1CR2KeQ+TxSSw+IylA7958qpWtw6DRN7/TPR97qXGvw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-1.6.0.tgz",
+      "integrity": "sha512-Gu/92kmr2pg4+1UR3uZlY8/dXphFi730wZaJl/em7U2yZCtNhi5b9d6r3Cr3aiWxD2x57GF1nHTCeskVIEm2Fg==",
       "dev": true,
       "requires": {
         "@peculiar/webcrypto": "^1.4.0",
         "@web-std/blob": "^3.0.4",
-        "@web-std/file": "^3.0.2"
+        "@web-std/file": "^3.0.2",
+        "undici": "^5.20.0"
       }
     },
     "@inrupt/oidc-client": {
@@ -9180,12 +9182,12 @@
       }
     },
     "@inrupt/universal-fetch": {
-      "version": "1.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.0-alpha.0.tgz",
-      "integrity": "sha512-EL6uTgL6CkGuv5oHhaRGIe9JHeOYYiqBONuHeTyOWbSOca0gAqky8U/8tuLaYQ4wiMNqLzeudG51opNLhTlQKg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.1.tgz",
+      "integrity": "sha512-oqbG7jS1fa6hVkjSir+u5Ab3eSbyxFyOjsgjDICL27mAd5z8oImTSETnY2hYbkRaJQYKMBOXhtm7L5/+EbeVJg==",
       "requires": {
         "node-fetch": "^2.6.7",
-        "undici": "^5.12.0"
+        "undici": "^5.19.1"
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -14120,9 +14122,9 @@
       }
     },
     "undici": {
-      "version": "5.19.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.19.1.tgz",
-      "integrity": "sha512-YiZ61LPIgY73E7syxCDxxa3LV2yl3sN8spnIuTct60boiiRaE1J8mNWHO8Im2Zi/sFrPusjLlmRPrsyraSqX6A==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
       "requires": {
         "busboy": "^1.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -129,10 +129,10 @@
   "dependencies": {
     "@inrupt/solid-client": "^1.25.1",
     "@inrupt/solid-client-vc": "^0.5.0",
+    "@inrupt/universal-fetch": "^1.0.0-alpha.0",
     "@types/rdfjs__dataset": "^1.0.5",
     "auth-header": "^1.0.0",
     "base64url": "^3.0.1",
-    "cross-fetch": "^3.1.4",
     "rdf-namespaces": "^1.9.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@inrupt/eslint-config-lib": "^1.0.0",
     "@inrupt/internal-playwright-helpers": "^1.5.3",
     "@inrupt/internal-test-env": "^1.5.4",
-    "@inrupt/jest-jsdom-polyfills": "^1.3.0",
+    "@inrupt/jest-jsdom-polyfills": "^1.6.0",
     "@inrupt/solid-client-authn-browser": "^1.12.2",
     "@inrupt/solid-client-authn-node": "^1.12.1",
     "@playwright/test": "^1.28.1",
@@ -129,7 +129,7 @@
   "dependencies": {
     "@inrupt/solid-client": "^1.25.1",
     "@inrupt/solid-client-vc": "^0.5.0",
-    "@inrupt/universal-fetch": "^1.0.0-alpha.0",
+    "@inrupt/universal-fetch": "^1.0.1",
     "@types/rdfjs__dataset": "^1.0.5",
     "auth-header": "^1.0.0",
     "base64url": "^3.0.1",

--- a/src/common/util/getSessionFetch.ts
+++ b/src/common/util/getSessionFetch.ts
@@ -19,7 +19,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { fetch as crossFetch } from "cross-fetch";
+import { fetch as crossFetch } from "@inrupt/universal-fetch";
 import { AccessBaseOptions } from "../../gConsent/type/AccessBaseOptions";
 
 /**

--- a/src/common/verify/isValidAccessGrant.test.ts
+++ b/src/common/verify/isValidAccessGrant.test.ts
@@ -20,8 +20,8 @@
 //
 
 import { jest, describe, it, expect } from "@jest/globals";
-import { Response } from "cross-fetch";
-import type * as CrossFetch from "cross-fetch";
+import { Response } from "@inrupt/universal-fetch";
+import type * as CrossFetch from "@inrupt/universal-fetch";
 import {
   isVerifiableCredential,
   getVerifiableCredentialApiConfiguration,
@@ -38,10 +38,10 @@ jest.mock("@inrupt/solid-client", () => {
   return solidClientModule;
 });
 jest.mock("@inrupt/solid-client-vc");
-jest.mock("cross-fetch", () => {
-  const crossFetch = jest.requireActual("cross-fetch") as jest.Mocked<
-    typeof CrossFetch
-  >;
+jest.mock("@inrupt/universal-fetch", () => {
+  const crossFetch = jest.requireActual(
+    "@inrupt/universal-fetch"
+  ) as jest.Mocked<typeof CrossFetch>;
   return {
     // Do no mock the globals such as Response.
     ...crossFetch,

--- a/src/fetch/index.test.ts
+++ b/src/fetch/index.test.ts
@@ -20,7 +20,7 @@
 //
 
 import { jest, describe, it, expect } from "@jest/globals";
-import { fetch as crossFetch, Response } from "cross-fetch";
+import { fetch as crossFetch, Response } from "@inrupt/universal-fetch";
 
 import base64url from "base64url";
 import {
@@ -32,8 +32,8 @@ import {
   fetchWithVc,
 } from "./index";
 
-jest.mock("cross-fetch", () => {
-  const crossFetchModule = jest.requireActual("cross-fetch") as any;
+jest.mock("@inrupt/universal-fetch", () => {
+  const crossFetchModule = jest.requireActual("@inrupt/universal-fetch") as any;
   return {
     ...crossFetchModule,
     fetch: jest.fn(),
@@ -365,7 +365,7 @@ describe("fetchWithVc", () => {
     const resourceIri = "https://fake.url/some-resource";
     const mockHeader =
       'UMA realm="test" as_uri="https://fake.url" ticket="some_value"';
-    // Cross-fetch is necessarily called for unauthenticated calls.
+    // @inrupt/universal-fetch is necessarily called for unauthenticated calls.
     (crossFetch as jest.MockedFunction<typeof crossFetch>)
       // first request is for headers
       .mockResolvedValueOnce(

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -19,7 +19,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { fetch as crossFetch } from "cross-fetch";
+import { fetch as crossFetch } from "@inrupt/universal-fetch";
 import base64url from "base64url";
 import type { UrlString } from "@inrupt/solid-client";
 import type { VerifiableCredential } from "@inrupt/solid-client-vc";

--- a/src/gConsent/discover/getAccessApiEndpoint.test.ts
+++ b/src/gConsent/discover/getAccessApiEndpoint.test.ts
@@ -57,7 +57,7 @@ describe("getAccessApiEndpoint", () => {
   });
 
   it("throws an error if the unauthenticated fetch does not fail", async () => {
-    const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
+    const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
       new Response("", {
         status: 200,
         statusText: "Ok",

--- a/src/gConsent/discover/getAccessApiEndpoint.test.ts
+++ b/src/gConsent/discover/getAccessApiEndpoint.test.ts
@@ -20,8 +20,8 @@
 //
 
 import { jest, describe, it, expect } from "@jest/globals";
-import { Response } from "cross-fetch";
-import type * as CrossFetch from "cross-fetch";
+import { Response } from "@inrupt/universal-fetch";
+import type * as CrossFetch from "@inrupt/universal-fetch";
 
 import {
   MOCKED_ACCESS_ISSUER,
@@ -30,10 +30,10 @@ import {
 } from "../request/request.mock";
 import { getAccessApiEndpoint } from "./getAccessApiEndpoint";
 
-jest.mock("cross-fetch", () => {
-  const crossFetch = jest.requireActual("cross-fetch") as jest.Mocked<
-    typeof CrossFetch
-  >;
+jest.mock("@inrupt/universal-fetch", () => {
+  const crossFetch = jest.requireActual(
+    "@inrupt/universal-fetch"
+  ) as jest.Mocked<typeof CrossFetch>;
   return {
     // Do no mock the globals such as Response.
     ...crossFetch,
@@ -63,7 +63,7 @@ describe("getAccessApiEndpoint", () => {
         statusText: "Ok",
       })
     );
-    const crossFetchModule = jest.requireMock("cross-fetch") as {
+    const crossFetchModule = jest.requireMock("@inrupt/universal-fetch") as {
       fetch: typeof global.fetch;
     };
     crossFetchModule.fetch = mockedFetch;
@@ -81,7 +81,7 @@ describe("getAccessApiEndpoint", () => {
         },
       })
     );
-    const crossFetchModule = jest.requireMock("cross-fetch") as {
+    const crossFetchModule = jest.requireMock("@inrupt/universal-fetch") as {
       fetch: typeof global.fetch;
     };
     crossFetchModule.fetch = mockedFetch;
@@ -108,7 +108,7 @@ describe("getAccessApiEndpoint", () => {
           })
         )
       );
-    const crossFetchModule = jest.requireMock("cross-fetch") as {
+    const crossFetchModule = jest.requireMock("@inrupt/universal-fetch") as {
       fetch: typeof global.fetch;
     };
     crossFetchModule.fetch = mockedFetch;

--- a/src/gConsent/discover/getAccessApiEndpoint.ts
+++ b/src/gConsent/discover/getAccessApiEndpoint.ts
@@ -20,7 +20,7 @@
 //
 
 import { UrlString } from "@inrupt/solid-client";
-import { fetch as crossFetch } from "cross-fetch";
+import { fetch as crossFetch } from "@inrupt/universal-fetch";
 import { parse } from "auth-header";
 import { AccessBaseOptions } from "../type/AccessBaseOptions";
 

--- a/src/gConsent/discover/redirectToAccessManagementUi.browser.test.ts
+++ b/src/gConsent/discover/redirectToAccessManagementUi.browser.test.ts
@@ -27,7 +27,7 @@ import {
   beforeEach,
   afterEach,
 } from "@jest/globals";
-import { Response } from "cross-fetch";
+import { Response } from "@inrupt/universal-fetch";
 import { redirectToAccessManagementUi } from "./redirectToAccessManagementUi";
 import {
   getAccessManagementUiFromWellKnown,

--- a/src/gConsent/manage/approveAccessRequest.test.ts
+++ b/src/gConsent/manage/approveAccessRequest.test.ts
@@ -20,8 +20,8 @@
 //
 
 import { jest, it, describe, expect } from "@jest/globals";
-import { Response } from "cross-fetch";
-import type * as CrossFetch from "cross-fetch";
+import { Response } from "@inrupt/universal-fetch";
+import type * as CrossFetch from "@inrupt/universal-fetch";
 
 import { mockSolidDatasetFrom } from "@inrupt/solid-client";
 import type * as VcClient from "@inrupt/solid-client-vc";
@@ -62,10 +62,10 @@ jest.mock("@inrupt/solid-client", () => {
 });
 
 jest.mock("@inrupt/solid-client-vc");
-jest.mock("cross-fetch", () => {
-  const crossFetch = jest.requireActual("cross-fetch") as jest.Mocked<
-    typeof CrossFetch
-  >;
+jest.mock("@inrupt/universal-fetch", () => {
+  const crossFetch = jest.requireActual(
+    "@inrupt/universal-fetch"
+  ) as jest.Mocked<typeof CrossFetch>;
   return {
     // Do no mock the globals such as Response.
     ...crossFetch,

--- a/src/gConsent/manage/denyAccessRequest.test.ts
+++ b/src/gConsent/manage/denyAccessRequest.test.ts
@@ -20,8 +20,8 @@
 //
 
 import { jest, it, describe, expect } from "@jest/globals";
-import { Response } from "cross-fetch";
-import type * as CrossFetch from "cross-fetch";
+import { Response } from "@inrupt/universal-fetch";
+import type * as CrossFetch from "@inrupt/universal-fetch";
 
 import { denyAccessRequest } from "./denyAccessRequest";
 import { mockAccessRequestVc } from "../util/access.mock";
@@ -39,10 +39,10 @@ jest.mock("@inrupt/solid-client", () => {
   return solidClientModule;
 });
 jest.mock("@inrupt/solid-client-vc");
-jest.mock("cross-fetch", () => {
-  const crossFetch = jest.requireActual("cross-fetch") as jest.Mocked<
-    typeof CrossFetch
-  >;
+jest.mock("@inrupt/universal-fetch", () => {
+  const crossFetch = jest.requireActual(
+    "@inrupt/universal-fetch"
+  ) as jest.Mocked<typeof CrossFetch>;
   return {
     // Do no mock the globals such as Response.
     ...crossFetch,

--- a/src/gConsent/manage/getAccessGrant.test.ts
+++ b/src/gConsent/manage/getAccessGrant.test.ts
@@ -20,18 +20,18 @@
 //
 
 import { jest, it, describe, expect } from "@jest/globals";
-import { Response } from "cross-fetch";
-import type * as CrossFetch from "cross-fetch";
+import { Response } from "@inrupt/universal-fetch";
+import type * as CrossFetch from "@inrupt/universal-fetch";
 import type * as VcClient from "@inrupt/solid-client-vc";
 
 import { mockAccessApiEndpoint } from "../request/request.mock";
 import { mockAccessGrantVc, mockConsentRequestVc } from "../util/access.mock";
 import { getAccessGrant } from "./getAccessGrant";
 
-jest.mock("cross-fetch", () => {
-  const crossFetch = jest.requireActual("cross-fetch") as jest.Mocked<
-    typeof CrossFetch
-  >;
+jest.mock("@inrupt/universal-fetch", () => {
+  const crossFetch = jest.requireActual(
+    "@inrupt/universal-fetch"
+  ) as jest.Mocked<typeof CrossFetch>;
   return {
     // Do no mock the globals such as Response.
     ...crossFetch,

--- a/src/gConsent/manage/getAccessGrant.test.ts
+++ b/src/gConsent/manage/getAccessGrant.test.ts
@@ -155,7 +155,7 @@ describe("getAccessGrant", () => {
       getAccessGrant("https://some.vc.url", {
         fetch: mockedFetch,
       })
-    ).resolves.toStrictEqual(normalizedAccessGrant);
+    ).resolves.toEqual(normalizedAccessGrant);
   });
 
   it("returns the access grant with the given URL object", async () => {

--- a/src/gConsent/manage/getAccessGrantAll.test.ts
+++ b/src/gConsent/manage/getAccessGrantAll.test.ts
@@ -22,6 +22,7 @@
 import { jest, it, describe, expect } from "@jest/globals";
 import { getVerifiableCredentialAllFromShape } from "@inrupt/solid-client-vc";
 import type * as VcModule from "@inrupt/solid-client-vc";
+import { fetch } from "@inrupt/universal-fetch";
 import {
   getAccessGrantAll,
   IssueAccessRequestParameters,
@@ -75,7 +76,9 @@ describe("getAccessGrantAll", () => {
       "https://some.api.endpoint/derive",
       expect.objectContaining(expectedDefaultVcShape),
       expect.objectContaining({
-        // FIXME: expecting fetch to match crossFetch fails in node.
+        // Expecting fetch to match universal-fetch fails in node because the
+        // getSessionFetch function returns the default @inrupt/solid-client-authn-browser
+        // fetch instead.
         fetch: expect.anything(),
       })
     );
@@ -180,15 +183,17 @@ describe("getAccessGrantAll", () => {
   });
 
   it("Calls @inrupt/solid-client-vc/getVerifiableCredentialAllFromShape with the expiration filter if specified", async () => {
+    const mockedFetch = jest.fn<typeof fetch>();
     await getAccessGrantAll(resource.href, undefined, {
       includeExpired: true,
+      fetch: mockedFetch,
     });
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
       "https://some.api.endpoint/derive",
       expect.anything(),
       expect.objectContaining({
         // FIXME: expecting fetch to match crossFetch fails in node.
-        fetch: expect.anything(),
+        fetch: mockedFetch,
         includeExpiredVc: true,
       })
     );

--- a/src/gConsent/manage/getAccessRequestFromRedirectUrl.test.ts
+++ b/src/gConsent/manage/getAccessRequestFromRedirectUrl.test.ts
@@ -21,7 +21,7 @@
 
 import { describe, it, jest, expect } from "@jest/globals";
 import { getVerifiableCredential } from "@inrupt/solid-client-vc";
-import { fetch } from "cross-fetch";
+import { fetch } from "@inrupt/universal-fetch";
 import { getAccessRequestFromRedirectUrl } from "./getAccessRequestFromRedirectUrl";
 import { mockAccessGrantVc, mockAccessRequestVc } from "../util/access.mock";
 import { getSessionFetch } from "../../common/util/getSessionFetch";

--- a/src/gConsent/manage/revokeAccessGrant.test.ts
+++ b/src/gConsent/manage/revokeAccessGrant.test.ts
@@ -21,7 +21,7 @@
 
 import { revokeVerifiableCredential } from "@inrupt/solid-client-vc";
 import { jest, describe, it, expect } from "@jest/globals";
-import { Response } from "cross-fetch";
+import { Response } from "@inrupt/universal-fetch";
 
 import { revokeAccessGrant } from "./revokeAccessGrant";
 import { MOCKED_CREDENTIAL_ID } from "../request/request.mock";

--- a/src/gConsent/request/cancelAccessRequest.test.ts
+++ b/src/gConsent/request/cancelAccessRequest.test.ts
@@ -21,7 +21,7 @@
 
 import { jest, describe, it, expect } from "@jest/globals";
 import { revokeVerifiableCredential } from "@inrupt/solid-client-vc";
-import { Response } from "cross-fetch";
+import { Response } from "@inrupt/universal-fetch";
 import { cancelAccessRequest } from "./cancelAccessRequest";
 import { MOCKED_CREDENTIAL_ID } from "./request.mock";
 import { mockAccessGrantVc } from "../util/access.mock";

--- a/src/gConsent/request/getAccessGrantFromRedirectUrl.test.ts
+++ b/src/gConsent/request/getAccessGrantFromRedirectUrl.test.ts
@@ -21,7 +21,7 @@
 
 import { describe, it, jest, expect } from "@jest/globals";
 import { getVerifiableCredential } from "@inrupt/solid-client-vc";
-import { fetch } from "cross-fetch";
+import { fetch } from "@inrupt/universal-fetch";
 import { getAccessGrantFromRedirectUrl } from "./getAccessGrantFromRedirectUrl";
 import { getSessionFetch } from "../../common/util/getSessionFetch";
 import { mockAccessGrantVc, mockAccessRequestVc } from "../util/access.mock";

--- a/src/gConsent/request/issueAccessRequest.test.ts
+++ b/src/gConsent/request/issueAccessRequest.test.ts
@@ -25,7 +25,7 @@ import {
   JsonLd,
   VerifiableCredential,
 } from "@inrupt/solid-client-vc";
-import type * as CrossFetch from "cross-fetch";
+import type * as CrossFetch from "@inrupt/universal-fetch";
 
 import { issueAccessRequest } from "./issueAccessRequest";
 import { getRequestBody } from "../util/issueAccessVc";
@@ -56,10 +56,10 @@ jest.mock("@inrupt/solid-client", () => {
   return solidClientModule;
 });
 jest.mock("@inrupt/solid-client-vc");
-jest.mock("cross-fetch", () => {
-  const crossFetch = jest.requireActual("cross-fetch") as jest.Mocked<
-    typeof CrossFetch
-  >;
+jest.mock("@inrupt/universal-fetch", () => {
+  const crossFetch = jest.requireActual(
+    "@inrupt/universal-fetch"
+  ) as jest.Mocked<typeof CrossFetch>;
   return {
     // Do no mock the globals such as Response.
     ...crossFetch,

--- a/src/gConsent/request/request.mock.ts
+++ b/src/gConsent/request/request.mock.ts
@@ -29,7 +29,7 @@ import {
   WithServerResourceInfo,
 } from "@inrupt/solid-client";
 // eslint-disable-next-line no-shadow
-import { Response } from "cross-fetch";
+import { Response } from "@inrupt/universal-fetch";
 
 import { PREFERRED_CONSENT_MANAGEMENT_UI } from "../constants";
 
@@ -97,7 +97,7 @@ export const mockAccessApiEndpoint = (withCredentialIssuer = true) => {
         )
       )
     );
-  const crossFetchModule = jest.requireMock("cross-fetch") as {
+  const crossFetchModule = jest.requireMock("@inrupt/universal-fetch") as {
     fetch: typeof global.fetch;
   };
   crossFetchModule.fetch = mockedFetch;


### PR DESCRIPTION
Replacing `cross-fetch` by `@inrupt/universal-fetch`, test for Node 18 compatibility.