### PR TITLE
Docs 643 update api docs dependencies

### DIFF
--- a/docs/api/Makefile
+++ b/docs/api/Makefile
@@ -41,11 +41,14 @@ prepare: clean
 # Copying to SOURCECOPYDIR instead of copying source dir to BUILDDIR
 # in case someone forgets to backslash after build/
 # Copying source/api/* to BUILDDIR.
+
 	mkdir -p $(SOURCECOPYDIR)
-	cp -R $(SOURCEDIR)/index.rst $(SOURCECOPYDIR)
 	cp -R $(SOURCEDIR)/api/* $(SOURCECOPYDIR)
-# Note: remove the typedoc generated `index.md` since we use a custom index.rst instead
-	rm $(SOURCECOPYDIR)/index.md
+# Note: remove the typedoc generated `index.rst` (see tsconfig.json) since we use a custom index.rst instead
+	rm $(SOURCECOPYDIR)/index.rst
+
+# Use our custom index.rst
+	cp -R $(SOURCEDIR)/index.rst $(SOURCECOPYDIR)
 
 html: Makefile check prepare
 	@$(SPHINXBUILD) -M $@ "$(SOURCECOPYDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -c . --keep-going

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -93,7 +93,8 @@ html_theme_options = {
     'show_api_menu': True,
     
     # below are pydata_sphinx_theme
-    "footer_items": [ "copyright.html"],
+    "footer_start": [ "copyright.html"],
+    "footer_end": [ ],
     "navbar_align": "left",
     "icon_links": [
         {
@@ -110,13 +111,6 @@ html_theme_options = {
             "name": "Inrupt Blog",
             "url": "https://inrupt.com/blog",
             "icon": "fas fa-blog",
-        },
-    ],
-    "favicons": [
-        {
-         "rel": "icon",
-         "sizes": "16x16",
-         "href": "https://docs.inrupt.com/inrupt_stickers_v2-03.png",
         },
     ],
 }

--- a/docs/api/requirements.txt
+++ b/docs/api/requirements.txt
@@ -1,5 +1,5 @@
 # pip install -r requirements.txt
 
-pydata-sphinx-theme==0.12.0
-myst-parser==0.18.1
-Sphinx==5.3.0
+pydata-sphinx-theme==0.13.2
+myst-parser==1.0.0
+Sphinx==6.1.3

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,6 +57,6 @@
     "theme": "markdown",
     "readme": "none",
     "hideInPageTOC": true,
-    "entryDocument": "index.md"
+    "entryDocument": "index.rst"
   }
 }


### PR DESCRIPTION
Updates for API docs dependency version bumps (sphinx, pydata theme, etc.):

-  Commit 1: 
   - requirements.txt updates
    - conf.py changes due to updated versions
- Commit 2:
   - update tsconfig's entryDoc to index.rst (from index.md) to avoid missing xref link warnings.
   - update Makefile to use our custom index.rst instead of typedoc generated index.rst

