### PR TITLE
chore/deps solid client vc 0.6.0

### DIFF
--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -82,8 +82,8 @@ const TEST_USER_AGENT = `Node-based solid-client-access-grant end-to-end tests r
   process.env.CI === "true" ? "in CI" : "locally"
 }`;
 const addUserAgent =
-  (myFetch: typeof fetch, agent: string): typeof fetch =>
-  (input: Parameters<typeof fetch>[0], init: Parameters<typeof fetch>[1]) =>
+  (myFetch: typeof fetch, agent: string) =>
+  (input: RequestInfo | URL, init?: RequestInit | undefined) =>
     myFetch(input, {
       ...init,
       headers: { ...init?.headers, "User-Agent": agent },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^1.25.1",
-        "@inrupt/solid-client-vc": "^0.5.0",
+        "@inrupt/solid-client-vc": "^0.6.0",
         "@inrupt/universal-fetch": "^1.0.1",
         "@types/rdfjs__dataset": "^1.0.5",
         "auth-header": "^1.0.0",
@@ -977,12 +977,18 @@
       }
     },
     "node_modules/@inrupt/solid-client-vc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.5.0.tgz",
-      "integrity": "sha512-Rglf0I47hhkZ/kOjM2Vtxph6sh8ZzxHN/vUOYOMZR/fiRtN8DotCFASBZ3qgMbRYmroKCxs8QDEHF36sq3ftrQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.6.0.tgz",
+      "integrity": "sha512-Jiwgp2R0IXt7J4o2/hHhE0Pxy9g46DYi+TyA8vrX55UQw6tm8jaalYVnwPna1xmSmc+TPnHAoS8xVbWflDitbw==",
       "dependencies": {
-        "@inrupt/solid-client": "^1.15.0",
-        "cross-fetch": "^3.1.4"
+        "@inrupt/solid-client": "^1.25.2",
+        "@inrupt/universal-fetch": "^1.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.0.0 || ^18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
       }
     },
     "node_modules/@inrupt/universal-fetch": {
@@ -9830,12 +9836,13 @@
       }
     },
     "@inrupt/solid-client-vc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.5.0.tgz",
-      "integrity": "sha512-Rglf0I47hhkZ/kOjM2Vtxph6sh8ZzxHN/vUOYOMZR/fiRtN8DotCFASBZ3qgMbRYmroKCxs8QDEHF36sq3ftrQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-0.6.0.tgz",
+      "integrity": "sha512-Jiwgp2R0IXt7J4o2/hHhE0Pxy9g46DYi+TyA8vrX55UQw6tm8jaalYVnwPna1xmSmc+TPnHAoS8xVbWflDitbw==",
       "requires": {
-        "@inrupt/solid-client": "^1.15.0",
-        "cross-fetch": "^3.1.4"
+        "@inrupt/solid-client": "^1.25.2",
+        "@inrupt/universal-fetch": "^1.0.1",
+        "fsevents": "^2.3.2"
       }
     },
     "@inrupt/universal-fetch": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
   },
   "dependencies": {
     "@inrupt/solid-client": "^1.25.1",
-    "@inrupt/solid-client-vc": "^0.5.0",
+    "@inrupt/solid-client-vc": "^0.6.0",
     "@inrupt/universal-fetch": "^1.0.1",
     "@types/rdfjs__dataset": "^1.0.5",
     "auth-header": "^1.0.0",

--- a/src/common/verify/isValidAccessGrant.test.ts
+++ b/src/common/verify/isValidAccessGrant.test.ts
@@ -87,7 +87,7 @@ describe("isValidAccessGrant", () => {
       new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
         status: 200,
       })
-    );
+    ) as (typeof CrossFetch)["fetch"];
     await isValidAccessGrant(MOCK_ACCESS_GRANT, {
       fetch: mockedFetch,
       verificationEndpoint: MOCK_ACCESS_ENDPOINT,
@@ -100,12 +100,14 @@ describe("isValidAccessGrant", () => {
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
     jest.mocked(getVerifiableCredentialApiConfiguration).mockResolvedValueOnce({
       verifierService: "https://some.vc.verifier",
+      specCompliant: {},
+      legacy: {},
     });
     const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
       new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
         status: 200,
       })
-    );
+    ) as (typeof CrossFetch)["fetch"];
 
     await isValidAccessGrant(MOCK_ACCESS_GRANT, {
       fetch: mockedFetch,
@@ -175,7 +177,7 @@ describe("isValidAccessGrant", () => {
       })
     );
     await isValidAccessGrant(MOCK_ACCESS_GRANT, {
-      fetch: mockedFetch,
+      fetch: mockedFetch as typeof fetch,
       verificationEndpoint: "https://some.verification.api",
     });
     expect(mockedFetch).toHaveBeenCalledWith(
@@ -190,6 +192,8 @@ describe("isValidAccessGrant", () => {
       .mocked(getVerifiableCredentialApiConfiguration)
       .mockResolvedValueOnce({
         verifierService: "https://some.vc.verifier",
+        specCompliant: {},
+        legacy: {},
       });
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest
@@ -206,7 +210,7 @@ describe("isValidAccessGrant", () => {
       );
 
     await isValidAccessGrant(MOCK_ACCESS_GRANT, {
-      fetch: mockedFetch,
+      fetch: mockedFetch as typeof fetch,
     });
 
     expect(mockedDiscovery).toHaveBeenCalledWith(MOCK_ACCESS_GRANT.issuer);
@@ -215,7 +219,10 @@ describe("isValidAccessGrant", () => {
   it("throws if no verification endpoint is discovered", async () => {
     jest
       .mocked(getVerifiableCredentialApiConfiguration)
-      .mockResolvedValueOnce({});
+      .mockResolvedValueOnce({
+        specCompliant: {},
+        legacy: {},
+      });
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest
       .fn(global.fetch)
@@ -232,7 +239,7 @@ describe("isValidAccessGrant", () => {
 
     await expect(
       isValidAccessGrant(MOCK_ACCESS_GRANT, {
-        fetch: mockedFetch,
+        fetch: mockedFetch as typeof fetch,
       })
     ).rejects.toThrow(
       `The VC service provider ${MOCK_ACCESS_GRANT.issuer} does not advertize for a verifier service in its .well-known/vc-configuration document`
@@ -242,6 +249,8 @@ describe("isValidAccessGrant", () => {
   it("returns the validation result from the access endpoint", async () => {
     jest.mocked(getVerifiableCredentialApiConfiguration).mockResolvedValueOnce({
       verifierService: "https://some.vc.verifier",
+      specCompliant: {},
+      legacy: {},
     });
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
@@ -251,7 +260,7 @@ describe("isValidAccessGrant", () => {
     );
     await expect(
       isValidAccessGrant(MOCK_ACCESS_GRANT, {
-        fetch: mockedFetch,
+        fetch: mockedFetch as typeof fetch,
         verificationEndpoint: "https://some.verification.api",
       })
     ).resolves.toEqual({ checks: [], errors: [], warning: [] });

--- a/src/common/verify/isValidAccessGrant.test.ts
+++ b/src/common/verify/isValidAccessGrant.test.ts
@@ -217,12 +217,10 @@ describe("isValidAccessGrant", () => {
   });
 
   it("throws if no verification endpoint is discovered", async () => {
-    jest
-      .mocked(getVerifiableCredentialApiConfiguration)
-      .mockResolvedValueOnce({
-        specCompliant: {},
-        legacy: {},
-      });
+    jest.mocked(getVerifiableCredentialApiConfiguration).mockResolvedValueOnce({
+      specCompliant: {},
+      legacy: {},
+    });
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest
       .fn(global.fetch)

--- a/src/common/verify/isValidAccessGrant.test.ts
+++ b/src/common/verify/isValidAccessGrant.test.ts
@@ -83,11 +83,13 @@ describe("isValidAccessGrant", () => {
 
   it("uses the provided fetch if any", async () => {
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
-    const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
-        status: 200,
-      })
-    ) as (typeof CrossFetch)["fetch"];
+    const mockedFetch = jest
+      .fn<(typeof CrossFetch)["fetch"]>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
+          status: 200,
+        })
+      );
     await isValidAccessGrant(MOCK_ACCESS_GRANT, {
       fetch: mockedFetch,
       verificationEndpoint: MOCK_ACCESS_ENDPOINT,
@@ -103,11 +105,13 @@ describe("isValidAccessGrant", () => {
       specCompliant: {},
       legacy: {},
     });
-    const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
-        status: 200,
-      })
-    ) as (typeof CrossFetch)["fetch"];
+    const mockedFetch = jest
+      .fn<(typeof CrossFetch)["fetch"]>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
+          status: 200,
+        })
+      );
 
     await isValidAccessGrant(MOCK_ACCESS_GRANT, {
       fetch: mockedFetch,
@@ -124,7 +128,7 @@ describe("isValidAccessGrant", () => {
   it("retrieves the vc if a url was passed", async () => {
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest
-      .fn(global.fetch)
+      .fn<(typeof CrossFetch)["fetch"]>()
       // First, the VC is fetched
       .mockResolvedValueOnce(
         new Response(JSON.stringify(MOCK_ACCESS_GRANT), { status: 200 })
@@ -137,7 +141,7 @@ describe("isValidAccessGrant", () => {
       );
 
     await isValidAccessGrant("https://example.com/someVc", {
-      fetch: mockedFetch as typeof fetch,
+      fetch: mockedFetch,
       verificationEndpoint: MOCK_ACCESS_ENDPOINT,
     });
 
@@ -145,16 +149,16 @@ describe("isValidAccessGrant", () => {
   });
 
   it("throws if the passed url returns a non-vc", async () => {
-    const mockedFetch = jest.fn().mockReturnValue({
-      ok: true,
-      status: 200,
-      json: jest.fn().mockReturnValueOnce({ someField: "Not a credential" }),
-    });
+    const mockedFetch = jest
+      .fn<(typeof CrossFetch)["fetch"]>()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ someField: "Not a credential" }))
+      );
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(false);
 
     await expect(
       isValidAccessGrant("https://example.com/someVc", {
-        fetch: mockedFetch as typeof fetch,
+        fetch: mockedFetch,
         verificationEndpoint: MOCK_ACCESS_ENDPOINT,
       })
     ).rejects.toThrow(
@@ -171,13 +175,15 @@ describe("isValidAccessGrant", () => {
       "getVerifiableCredentialApiConfiguration"
     );
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
-    const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
-        status: 200,
-      })
-    );
+    const mockedFetch = jest
+      .fn<(typeof CrossFetch)["fetch"]>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
+          status: 200,
+        })
+      );
     await isValidAccessGrant(MOCK_ACCESS_GRANT, {
-      fetch: mockedFetch as typeof fetch,
+      fetch: mockedFetch,
       verificationEndpoint: "https://some.verification.api",
     });
     expect(mockedFetch).toHaveBeenCalledWith(
@@ -197,7 +203,7 @@ describe("isValidAccessGrant", () => {
       });
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest
-      .fn(global.fetch)
+      .fn<(typeof CrossFetch)["fetch"]>()
       // First, the VC is fetched
       .mockResolvedValueOnce(
         new Response(JSON.stringify(MOCK_ACCESS_GRANT), { status: 200 })
@@ -210,7 +216,7 @@ describe("isValidAccessGrant", () => {
       );
 
     await isValidAccessGrant(MOCK_ACCESS_GRANT, {
-      fetch: mockedFetch as typeof fetch,
+      fetch: mockedFetch,
     });
 
     expect(mockedDiscovery).toHaveBeenCalledWith(MOCK_ACCESS_GRANT.issuer);
@@ -223,7 +229,7 @@ describe("isValidAccessGrant", () => {
     });
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest
-      .fn(global.fetch)
+      .fn<(typeof CrossFetch)["fetch"]>()
       // First, the VC is fetched
       .mockResolvedValueOnce(
         new Response(JSON.stringify(MOCK_ACCESS_GRANT), { status: 200 })
@@ -237,7 +243,7 @@ describe("isValidAccessGrant", () => {
 
     await expect(
       isValidAccessGrant(MOCK_ACCESS_GRANT, {
-        fetch: mockedFetch as typeof fetch,
+        fetch: mockedFetch,
       })
     ).rejects.toThrow(
       `The VC service provider ${MOCK_ACCESS_GRANT.issuer} does not advertize for a verifier service in its .well-known/vc-configuration document`
@@ -251,14 +257,16 @@ describe("isValidAccessGrant", () => {
       legacy: {},
     });
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
-    const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
-        status: 200,
-      })
-    );
+    const mockedFetch = jest
+      .fn<(typeof CrossFetch)["fetch"]>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
+          status: 200,
+        })
+      );
     await expect(
       isValidAccessGrant(MOCK_ACCESS_GRANT, {
-        fetch: mockedFetch as typeof fetch,
+        fetch: mockedFetch,
         verificationEndpoint: "https://some.verification.api",
       })
     ).resolves.toEqual({ checks: [], errors: [], warning: [] });


### PR DESCRIPTION
- Chore(deps): Bump @inrupt/solid-client-vc from 0.5.0 to 0.6.0
- fix: resolve test type errors

Supercedes https://github.com/inrupt/solid-client-access-grants-js/pull/576