### PR TITLE
chore: e2e test deny request

### DIFF
--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -485,10 +485,6 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         }
       );
 
-      console.log("request", request);
-
-      // TODO: Investigate deprecation - almost certain this is
-      // wrong at the moment
       const grant = await denyAccessRequest(
         resourceOwnerSession.info.webId as string,
         request,

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -29,7 +29,10 @@ import {
   afterEach,
 } from "@jest/globals";
 import { Session } from "@inrupt/solid-client-authn-node";
-import { isVerifiableCredential, VerifiableCredential } from "@inrupt/solid-client-vc";
+import {
+  isVerifiableCredential,
+  VerifiableCredential,
+} from "@inrupt/solid-client-vc";
 import { getNodeTestingEnvironment } from "@inrupt/internal-test-env";
 // Making a named import here to avoid confusion with the wrapped functions from
 // the access grant API
@@ -247,11 +250,14 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       });
 
       // After revocation getFile should throw errors
-      await expect(filePromise).rejects.toThrowError();
+      await expect(filePromise).rejects.toThrow();
 
       // In particular the error should be a 403
-      const fileResponse = await addUserAgent(requestorSession.fetch, TEST_USER_AGENT)(sharedFileIri);
-      expect(fileResponse.status).toEqual(403);
+      const fileResponse = await addUserAgent(
+        requestorSession.fetch,
+        TEST_USER_AGENT
+      )(sharedFileIri);
+      expect(fileResponse.status).toBe(403);
     });
 
     it("can issue an access grant overriding an access request", async () => {
@@ -479,7 +485,7 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         }
       );
 
-      console.log('request', request)
+      console.log("request", request);
 
       // TODO: Investigate deprecation - almost certain this is
       // wrong at the moment
@@ -489,7 +495,8 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
         {
           fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
           accessEndpoint: vcProvider,
-        });
+        }
+      );
 
       await expect(
         isValidAccessGrant(grant, {
@@ -507,13 +514,16 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       });
 
       // After revocation getFile should throw errors
-      await expect(filePromise).rejects.toThrowError();
+      await expect(filePromise).rejects.toThrow();
 
       // In particular the error should be a 403
-      const fileResponse = await addUserAgent(requestorSession.fetch, TEST_USER_AGENT)(sharedFileIri);
-      expect(fileResponse.status).toEqual(403);
+      const fileResponse = await addUserAgent(
+        requestorSession.fetch,
+        TEST_USER_AGENT
+      )(sharedFileIri);
+      expect(fileResponse.status).toBe(403);
     });
-  })
+  });
 
   describe("resource owner interaction with VC provider", () => {
     let accessGrant: AccessGrant;

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -29,7 +29,7 @@ import {
   afterEach,
 } from "@jest/globals";
 import { Session } from "@inrupt/solid-client-authn-node";
-import { isVerifiableCredential } from "@inrupt/solid-client-vc";
+import { isVerifiableCredential, VerifiableCredential } from "@inrupt/solid-client-vc";
 import { getNodeTestingEnvironment } from "@inrupt/internal-test-env";
 // Making a named import here to avoid confusion with the wrapped functions from
 // the access grant API
@@ -40,6 +40,7 @@ import {
   AccessRequest,
   approveAccessRequest,
   createContainerInContainer,
+  denyAccessRequest,
   getAccessGrantAll,
   getFile,
   getSolidDataset,
@@ -240,6 +241,17 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
           })
         ).errors
       ).toHaveLength(1);
+
+      const filePromise = getFile(sharedFileIri, grant, {
+        fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
+      });
+
+      // After revocation getFile should throw errors
+      await expect(filePromise).rejects.toThrowError();
+
+      // In particular the error should be a 403
+      const fileResponse = await addUserAgent(requestorSession.fetch, TEST_USER_AGENT)(sharedFileIri);
+      expect(fileResponse.status).toEqual(403);
     });
 
     it("can issue an access grant overriding an access request", async () => {
@@ -444,6 +456,64 @@ describe(`End-to-end access grant tests for environment [${environment}}]`, () =
       );
     });
   });
+
+  describe("access request, deny flow", () => {
+    it("can issue an access grant denying an access request", async () => {
+      const expirationDate = new Date();
+      // Request a 3-month grant
+      expirationDate.setMonth((expirationDate.getMonth() + 3) % 12);
+      const request: VerifiableCredential = await issueAccessRequest(
+        {
+          access: { read: true, append: true },
+          resourceOwner: resourceOwnerSession.info.webId as string,
+          resources: [sharedFileIri],
+          purpose: [
+            "https://some.purpose/not-a-nefarious-one/i-promise",
+            "https://some.other.purpose/",
+          ],
+          expirationDate,
+        },
+        {
+          fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
+          accessEndpoint: vcProvider,
+        }
+      );
+
+      console.log('request', request)
+
+      // TODO: Investigate deprecation - almost certain this is
+      // wrong at the moment
+      const grant = await denyAccessRequest(
+        resourceOwnerSession.info.webId as string,
+        request,
+        {
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
+          accessEndpoint: vcProvider,
+        });
+
+      await expect(
+        isValidAccessGrant(grant, {
+          fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
+          // FIXME: Currently looking up JSON-LD doesn't work in jest tests.
+          // It is an issue documented in the VC library e2e test, and in a ticket
+          // to be fixed.
+          verificationEndpoint: `${vcProvider}/verify`,
+        })
+      ).resolves.toMatchObject({ errors: [] });
+      expect(grant.expirationDate).toBeUndefined();
+
+      const filePromise = getFile(sharedFileIri, grant, {
+        fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
+      });
+
+      // After revocation getFile should throw errors
+      await expect(filePromise).rejects.toThrowError();
+
+      // In particular the error should be a 403
+      const fileResponse = await addUserAgent(requestorSession.fetch, TEST_USER_AGENT)(sharedFileIri);
+      expect(fileResponse.status).toEqual(403);
+    });
+  })
 
   describe("resource owner interaction with VC provider", () => {
     let accessGrant: AccessGrant;


### PR DESCRIPTION
Adds e2e tests for the `denyRequest` call.

Also checks for a 403 after a revocation in the existing revocation e2e tests.