### PR TITLE
Delete resource with Access Grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## Unreleased
 
+### New feature
+
+- `deleteSolidDataset`: Add a function in the `resource` module to delete a dataset, 
+mimicing the interface of `@inrupt/solid-client`'s `deleteSolidDataset`.
+
 ## [2.3.2](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v2.3.2) - 2023-06-05
 
 ### Deprecation notice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### New feature
 
-- `deleteSolidDataset`: Add a function in the `resource` module to delete a dataset, 
-mimicing the interface of `@inrupt/solid-client`'s `deleteSolidDataset`.
+- `deleteSolidDataset` and `deleteFile`: Add functions to the `resource` module
+  to delete resources, following the interface of `@inrupt/solid-client`.
 
 ## [2.3.2](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v2.3.2) - 2023-06-05
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -41,6 +41,7 @@ import {
   overwriteFile,
   getSolidDataset,
   createContainerInContainer,
+  deleteSolidDataset,
   saveSolidDatasetAt,
   saveSolidDatasetInContainer,
   GRANT_VC_URL_PARAM_NAME,
@@ -80,6 +81,7 @@ describe("Index exports", () => {
     expect(saveFileInContainer).toBeDefined();
     expect(createContainerInContainer).toBeDefined();
     expect(getSolidDataset).toBeDefined();
+    expect(deleteSolidDataset).toBeDefined();
     expect(saveSolidDatasetAt).toBeDefined();
     expect(saveSolidDatasetInContainer).toBeDefined();
     expect(GRANT_VC_URL_PARAM_NAME).toBeDefined();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -41,6 +41,7 @@ import {
   overwriteFile,
   getSolidDataset,
   createContainerInContainer,
+  deleteFile,
   deleteSolidDataset,
   saveSolidDatasetAt,
   saveSolidDatasetInContainer,
@@ -81,6 +82,7 @@ describe("Index exports", () => {
     expect(saveFileInContainer).toBeDefined();
     expect(createContainerInContainer).toBeDefined();
     expect(getSolidDataset).toBeDefined();
+    expect(deleteFile).toBeDefined();
     expect(deleteSolidDataset).toBeDefined();
     expect(saveSolidDatasetAt).toBeDefined();
     expect(saveSolidDatasetInContainer).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ export { fetchWithVc } from "./fetch";
 
 export {
   createContainerInContainer,
+  deleteSolidDataset,
   getFile,
   getSolidDataset,
   overwriteFile,

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ export { fetchWithVc } from "./fetch";
 
 export {
   createContainerInContainer,
+  deleteFile,
   deleteSolidDataset,
   getFile,
   getSolidDataset,

--- a/src/resource/deleteFile.test.ts
+++ b/src/resource/deleteFile.test.ts
@@ -1,0 +1,54 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { it, jest, describe, expect } from "@jest/globals";
+import type SolidClientCore from "@inrupt/solid-client";
+import { mockAccessGrantVc } from "../gConsent/util/access.mock";
+import { deleteFile } from "./deleteFile";
+import { fetchWithVc } from "../fetch";
+
+jest.mock("../fetch");
+jest.mock("@inrupt/solid-client", () => {
+  const solidClientModule = jest.requireActual("@inrupt/solid-client") as any;
+  solidClientModule.deleteFile = jest.fn();
+  return solidClientModule;
+});
+
+describe("deleteSolidDataset", () => {
+  it("authenticates using the provided VC", async () => {
+    const solidClientModule = jest.requireMock(
+      "@inrupt/solid-client"
+    ) as jest.Mocked<typeof SolidClientCore>;
+    const mockedFetch = jest.fn<typeof fetch>();
+    await deleteFile("https://some.file.url", mockAccessGrantVc(), {
+      fetch: mockedFetch,
+    });
+    expect(fetchWithVc).toHaveBeenCalledWith(
+      expect.anything(),
+      mockAccessGrantVc(),
+      { fetch: mockedFetch }
+    );
+    expect(solidClientModule.deleteFile).toHaveBeenCalledWith(
+      "https://some.file.url",
+      expect.anything()
+    );
+  });
+});

--- a/src/resource/deleteFile.ts
+++ b/src/resource/deleteFile.ts
@@ -1,0 +1,62 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import type { UrlString } from "@inrupt/solid-client";
+import { deleteFile as coreDeleteFile } from "@inrupt/solid-client";
+import type { VerifiableCredential } from "@inrupt/solid-client-vc";
+import { fetchWithVc } from "../fetch";
+import type { FetchOptions } from "../type/FetchOptions";
+
+/**
+ * Delete a File from a Solid Pod using an Access Grant to prove the caller
+ * is authorized to overwrite the target file.
+ *
+ * @see [@inrupt/solid-client's
+ * deleteSolidDataset](https://docs.inrupt.com/developer-tools/api/javascript/solid-client/modules/resource_solidDataset.html#deletefile)
+ *
+ * @param fileUrl The URL of the target file.
+ * @param accessGrant The Access Grant VC proving the caller is authorized.
+ * @param options Optional properties to customise the request behaviour.
+ * @returns A promise that resolves to a SolidDataset if successful, and that
+ * rejects otherwise.
+ * @since unreleased
+ */
+export async function deleteFile(
+  fileUrl: UrlString,
+  accessGrant: VerifiableCredential,
+  options?: FetchOptions
+) {
+  const fetchOptions: FetchOptions = {};
+  if (options && options.fetch) {
+    fetchOptions.fetch = options.fetch;
+  }
+
+  const authenticatedFetch = await fetchWithVc(
+    fileUrl,
+    accessGrant,
+    fetchOptions
+  );
+
+  return await coreDeleteFile(fileUrl, {
+    ...options,
+    fetch: authenticatedFetch,
+  });
+}

--- a/src/resource/deleteSolidDataset.test.ts
+++ b/src/resource/deleteSolidDataset.test.ts
@@ -1,0 +1,54 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { it, jest, describe, expect } from "@jest/globals";
+import type SolidClientCore from "@inrupt/solid-client";
+import { mockAccessGrantVc } from "../gConsent/util/access.mock";
+import { deleteSolidDataset } from "./deleteSolidDataset";
+import { fetchWithVc } from "../fetch";
+
+jest.mock("../fetch");
+jest.mock("@inrupt/solid-client", () => {
+  const solidClientModule = jest.requireActual("@inrupt/solid-client") as any;
+  solidClientModule.deleteSolidDataset = jest.fn();
+  return solidClientModule;
+});
+
+describe("deleteSolidDataset", () => {
+  it("authenticates using the provided VC", async () => {
+    const solidClientModule = jest.requireMock(
+      "@inrupt/solid-client"
+    ) as jest.Mocked<typeof SolidClientCore>;
+    const mockedFetch = jest.fn<typeof fetch>();
+    await deleteSolidDataset("https://some.dataset.url", mockAccessGrantVc(), {
+      fetch: mockedFetch,
+    });
+    expect(fetchWithVc).toHaveBeenCalledWith(
+      expect.anything(),
+      mockAccessGrantVc(),
+      { fetch: mockedFetch }
+    );
+    expect(solidClientModule.deleteSolidDataset).toHaveBeenCalledWith(
+      "https://some.dataset.url",
+      expect.anything()
+    );
+  });
+});

--- a/src/resource/deleteSolidDataset.ts
+++ b/src/resource/deleteSolidDataset.ts
@@ -1,0 +1,62 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import type { UrlString } from "@inrupt/solid-client";
+import { deleteSolidDataset as coreDeleteSolidDataset } from "@inrupt/solid-client";
+import type { VerifiableCredential } from "@inrupt/solid-client-vc";
+import { fetchWithVc } from "../fetch";
+import type { FetchOptions } from "../type/FetchOptions";
+
+/**
+ * Delete a Dataset from a Solid Pod using an Access Grant to prove the caller
+ * is authorized to overwrite the target dataset.
+ *
+ * @see [@inrupt/solid-client's
+ * deleteSolidDataset](https://docs.inrupt.com/developer-tools/api/javascript/solid-client/modules/resource_solidDataset.html#deletesoliddataset)
+ *
+ * @param datasetUrl The URL of the target dataset.
+ * @param accessGrant The Access Grant VC proving the caller is authorized.
+ * @param options Optional properties to customise the request behaviour.
+ * @returns A promise that resolves to a SolidDataset if successful, and that
+ * rejects otherwise.
+ * @since unreleased
+ */
+export async function deleteSolidDataset(
+  datasetUrl: UrlString,
+  accessGrant: VerifiableCredential,
+  options?: FetchOptions
+) {
+  const fetchOptions: FetchOptions = {};
+  if (options && options.fetch) {
+    fetchOptions.fetch = options.fetch;
+  }
+
+  const authenticatedFetch = await fetchWithVc(
+    datasetUrl,
+    accessGrant,
+    fetchOptions
+  );
+
+  return await coreDeleteSolidDataset(datasetUrl, {
+    ...options,
+    fetch: authenticatedFetch,
+  });
+}

--- a/src/resource/index.ts
+++ b/src/resource/index.ts
@@ -21,6 +21,7 @@
 
 export { getFile, overwriteFile, saveFileInContainer } from "./file";
 export { createContainerInContainer } from "./createContainerInContainer";
+export { deleteSolidDataset } from "./deleteSolidDataset";
 export { getSolidDataset } from "./getSolidDataset";
 export { saveSolidDatasetAt } from "./saveSolidDatasetAt";
 export { saveSolidDatasetInContainer } from "./saveSolidDatasetInContainer";

--- a/src/resource/index.ts
+++ b/src/resource/index.ts
@@ -21,6 +21,7 @@
 
 export { getFile, overwriteFile, saveFileInContainer } from "./file";
 export { createContainerInContainer } from "./createContainerInContainer";
+export { deleteFile } from "./deleteFile";
 export { deleteSolidDataset } from "./deleteSolidDataset";
 export { getSolidDataset } from "./getSolidDataset";
 export { saveSolidDatasetAt } from "./saveSolidDatasetAt";


### PR DESCRIPTION
Wrap `@inrupt/solid-client`'s `deleteSolidDataset` and `deleteFile` into the access-grant `resource` module to handle UMA authentication.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).