### PR TITLE
Fix: WebKit e2e tests

### DIFF
--- a/e2e/browser/test/e2e.playwright.ts
+++ b/e2e/browser/test/e2e.playwright.ts
@@ -47,15 +47,15 @@ test("Redirect to Podbrowser to accept Access Request", async ({
   await page.getByRole("button", { name: "Allow" }).click();
 
   // We validate the request fields are editable before we confirm access
-  // Select our permissions
+  // Select our purposes
   await page.getByRole("checkbox").nth(1).check();
 
   // Select our resources for allowing access
-  await page.getByTestId("request-select-all").click();
+  await page.getByRole("checkbox").nth(2).check();
 
   // The test user confirms the access they selected and is redirected back to app
   await Promise.all([
-    page.getByRole("button", { name: "Confirm Access" }).click(),
+    page.getByRole("button", { name: "Confirm Access" }).click({ force: true }),
     page.waitForURL("http://localhost:3000/?accessGrantUrl=*"),
   ]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@inrupt/eslint-config-lib": "^2.0.0",
-        "@inrupt/internal-playwright-helpers": "^2.0.4",
+        "@inrupt/internal-playwright-helpers": "^2.1.1",
         "@inrupt/internal-playwright-testids": "^2.0.4",
         "@inrupt/internal-test-env": "^2.0.4",
         "@inrupt/jest-jsdom-polyfills": "^2.0.0",
@@ -858,28 +858,28 @@
       }
     },
     "node_modules/@inrupt/internal-playwright-helpers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-helpers/-/internal-playwright-helpers-2.1.0.tgz",
-      "integrity": "sha512-bKWdIUcDt9IdYgUPWsrbn+lCCOgFJWP9knQCiMqd4G+/t/Ta0vTwS9sU7i/vPHZt0u1YeK3VjbRrX5QO70XivQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-helpers/-/internal-playwright-helpers-2.1.1.tgz",
+      "integrity": "sha512-SsFcTqwm9uzdUhd8u6bA5AVfPvgjPia7Sn/wtPBxj48n9WSmBfaFSz/2/O8oSix2yNJWO+Cro5g9cTR7iA7MmQ==",
       "dev": true,
       "dependencies": {
-        "@inrupt/internal-playwright-testids": "2.1.0",
-        "@inrupt/internal-test-env": "2.1.0"
+        "@inrupt/internal-playwright-testids": "2.1.1",
+        "@inrupt/internal-test-env": "2.1.1"
       },
       "peerDependencies": {
         "@playwright/test": "^1.28.1"
       }
     },
     "node_modules/@inrupt/internal-playwright-testids": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.1.0.tgz",
-      "integrity": "sha512-qKaLCi3Z0K0oUqao9bl+xpAqX9bOkPcDEbDRhuSI6DdDE/d+dOPk5mM5EiPMAX4yBhanH5q+XXk+v1OHdkYkXg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.1.1.tgz",
+      "integrity": "sha512-WwpCbePhMqFQGDV9DdyInbzwYXtB2r1cd1+n9rcjZO0pl4MhWbjEVlM++92B2/N79fPQLz4iy60WxNFZJJy3sQ==",
       "dev": true
     },
     "node_modules/@inrupt/internal-test-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.1.0.tgz",
-      "integrity": "sha512-IhlLJfNvX2Mo+jHcxfVxEMTzh1WuM5JVWHTBK4InrFB6L0fjKBMVC2ETKX92Q2A4c9yFYeaKRqVKPjiYZVcmrA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.1.1.tgz",
+      "integrity": "sha512-5k3+GYaKO+6RDvNrofS0/nLT59/1RzZAterwgbGKf3kGYFEEJQaQMuv81auXfv9vGNy5jg5OwVSi2pUC40Gqzg==",
       "dev": true,
       "dependencies": {
         "@inrupt/solid-client": "^1.29.0",
@@ -11018,25 +11018,25 @@
       }
     },
     "@inrupt/internal-playwright-helpers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-helpers/-/internal-playwright-helpers-2.1.0.tgz",
-      "integrity": "sha512-bKWdIUcDt9IdYgUPWsrbn+lCCOgFJWP9knQCiMqd4G+/t/Ta0vTwS9sU7i/vPHZt0u1YeK3VjbRrX5QO70XivQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-helpers/-/internal-playwright-helpers-2.1.1.tgz",
+      "integrity": "sha512-SsFcTqwm9uzdUhd8u6bA5AVfPvgjPia7Sn/wtPBxj48n9WSmBfaFSz/2/O8oSix2yNJWO+Cro5g9cTR7iA7MmQ==",
       "dev": true,
       "requires": {
-        "@inrupt/internal-playwright-testids": "2.1.0",
-        "@inrupt/internal-test-env": "2.1.0"
+        "@inrupt/internal-playwright-testids": "2.1.1",
+        "@inrupt/internal-test-env": "2.1.1"
       }
     },
     "@inrupt/internal-playwright-testids": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.1.0.tgz",
-      "integrity": "sha512-qKaLCi3Z0K0oUqao9bl+xpAqX9bOkPcDEbDRhuSI6DdDE/d+dOPk5mM5EiPMAX4yBhanH5q+XXk+v1OHdkYkXg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.1.1.tgz",
+      "integrity": "sha512-WwpCbePhMqFQGDV9DdyInbzwYXtB2r1cd1+n9rcjZO0pl4MhWbjEVlM++92B2/N79fPQLz4iy60WxNFZJJy3sQ==",
       "dev": true
     },
     "@inrupt/internal-test-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.1.0.tgz",
-      "integrity": "sha512-IhlLJfNvX2Mo+jHcxfVxEMTzh1WuM5JVWHTBK4InrFB6L0fjKBMVC2ETKX92Q2A4c9yFYeaKRqVKPjiYZVcmrA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.1.1.tgz",
+      "integrity": "sha512-5k3+GYaKO+6RDvNrofS0/nLT59/1RzZAterwgbGKf3kGYFEEJQaQMuv81auXfv9vGNy5jg5OwVSi2pUC40Gqzg==",
       "dev": true,
       "requires": {
         "@inrupt/solid-client": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "devDependencies": {
     "@inrupt/eslint-config-lib": "^2.0.0",
-    "@inrupt/internal-playwright-helpers": "^2.0.4",
+    "@inrupt/internal-playwright-helpers": "^2.1.1",
     "@inrupt/internal-playwright-testids": "^2.0.4",
     "@inrupt/internal-test-env": "^2.0.4",
     "@inrupt/jest-jsdom-polyfills": "^2.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -58,18 +58,16 @@ const config: PlaywrightTestConfig = {
           process.env.CI === "true" ? "in CI" : "locally"
         }. Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36`,
       },
+    },    
+    {
+      name: "WebKit",
+      use: {
+        browserName: "webkit",
+        userAgent: `Browser-based solid-client-access-grant end-to-end tests running ${
+          process.env.CI === "true" ? "in CI" : "locally"
+        }. Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1`,
+      },
     },
-    // TODO: readd Webkit to the flow once we can determine what is causing the error with Node 20 env, and the inconsistent flakiness
-    //
-    // {
-    //   name: "WebKit",
-    //   use: {
-    //     browserName: "webkit",
-    //     userAgent: `Browser-based solid-client-access-grant end-to-end tests running ${
-    //       process.env.CI === "true" ? "in CI" : "locally"
-    //     }. Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1`,
-    //   },
-    // },
   ],
 };
 


### PR DESCRIPTION
This PR fixes the issues with webkit e2e tests. The cause is a bug in PodBrowser. This PR:

- updates the playwright helpers library 
- updates tests to toggle resources using a different element that is clickable

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description

# Checklist

- [ ] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When cutting a release: -->

This PR bumps the version to <version number>.

# Release steps:

1. Inspecting the `CHANGELOG.md` to determine if the release was major, minor or patch. Make sure you align with the rest of the team first.
2. Use `npm version --no-git-tag-version <major|minor|patch>` to update `package.json`.
3. Update the `CHANGELOG.md` has been updated to show version and release date.
4. Add any `@since X.Y.Z` annotations if there have been any added or deprecated APIs.
5. Commit the changes as `release: prepare vX.Y.Z` on a branch named `release/X.Y.Z`
6. Create a PR, once CI passes, merge as a squash merge.
7. Create and publish the release via GitHub, this will create the tag and trigger the npm publish.
