### PR TITLE
Chore/docs-redirect

### DIFF
--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -141,7 +141,7 @@ myst_url_schemes = ('https', 'http')
 myst_enable_extensions = ['colon_fence']
 
 redirects = {
-     "<source>": "<target>"
+    "modules/manage.html": "modules/gConsent_manage.html"
 }
 
 # Typedoc by default outputs all files as relative to their directory, but for

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -49,6 +49,7 @@ highlight_language = 'javascript'
 extensions = [
     'sphinx.ext.extlinks',
     'myst_parser',
+    'sphinx_reredirects'
 ]
 
 
@@ -139,6 +140,9 @@ myst_heading_anchors = 6
 myst_url_schemes = ('https', 'http')
 myst_enable_extensions = ['colon_fence']
 
+redirects = {
+     "<source>": "<target>"
+}
 
 # Typedoc by default outputs all files as relative to their directory, but for
 # Interfaces this is not what we want. Instead of

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -141,7 +141,7 @@ myst_url_schemes = ('https', 'http')
 myst_enable_extensions = ['colon_fence']
 
 redirects = {
-    "modules/manage.html": "modules/gConsent_manage.html"
+    "modules/manage.html": "./gConsent_manage.html"
 }
 
 # Typedoc by default outputs all files as relative to their directory, but for

--- a/docs/api/requirements.txt
+++ b/docs/api/requirements.txt
@@ -1,6 +1,7 @@
 # pip install -r requirements.txt
 
 pydata-sphinx-theme==0.13.3
+sphinx-reredirects==0.1.2
 myst-parser==2.0.0
 # Currently myst-parse is incompatible with sphinx v7
 Sphinx==6.2.1


### PR DESCRIPTION
Redirects https://solid-client-access-grants-jhklfihcz-inrupt.vercel.app/modules/manage.html to https://solid-client-access-grants-jhklfihcz-inrupt.vercel.app/modules/gConsent_manage.html