### PR TITLE
SDK-3184: improve `getAccessGrantAll` API docs

### DIFF
--- a/e2e/env/.env.example
+++ b/e2e/env/.env.example
@@ -25,3 +25,5 @@ E2E_TEST_OWNER_CLIENT_SECRET=<client secret>
 
 E2E_TEST_LOGIN=<a login for the UI tests>
 E2E_TEST_PASSWORD=<a password for the UI tests>
+
+E2E_TEST_FEATURE_RECURSIVE_ACCESS_GRANTS=true

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -195,17 +195,40 @@ async function getAccessGrantAll(
 
 /**
  * Retrieve Access Grants issued over a resource. The Access Grants may be filtered
- * by requestor, access modes and purpose. In order to discover all applicable Access
- * Grants for the target resource, including recursive Access Grants issued over
- * an ancestor container, the resources hierarchy is walked up to the storage root.
+ * by resource, requestor, access modes and purpose.
+ *
+ * If a resource filter is specified, the resources hierarchy is walked up to the
+ * storage root so that all applicable Access Grants for the target resource are
+ * discovered, including recursive Access Grants issued over an ancestor container.
+ *
+ * @example ```
+ * const grantsForResource = await getAccessGrantAll({
+ *  resource: "https://example.org/storage/some-resource"
+ * }, {
+ *  fetch: session.fetch,
+ *  accessEndpoint: "https://example.org/grants-holder/"
+ * });
+ *
+ * const grantsForAgentWrite = await getAccessGrantAll({
+ *  requestor: "https://id.example.org/some-agent-webid",
+ *  modes: ["write"]
+ * }, {
+ *  fetch: session.fetch,
+ *  accessEndpoint: "https://example.org/grants-holder/"
+ * });
+ * ```
  *
  * @param grantShape The properties of grants to filter results.
  * @param options Optional parameter:
- * - `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- * This can be typically used for authentication. Note that if it is omitted, and
- * `@inrupt/solid-client-authn-browser` is in your dependencies, the default session
- * is picked up.
+ * - `options.fetch`: An alternative `fetch` function to make the HTTP request,
+ *   compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ *   This is typically used for authentication.
  * - `options.includeExpiredGrants`: include expired grants in the result set.
+ * - accessEndpoint: A base URL used when determining the location of access API calls.
+ *   If not given, it is attempted to be found by determining the server URL from the resource
+ *   involved in the request and reading its .well-known/solid file for an Access API entry. If
+ *   you are not providing a resource this url must point to the vcProvider endpoint associated
+ *   with the environment you are requesting against. 
  * @returns A void promise.
  * @since 0.4.0
  */

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -203,7 +203,7 @@ async function internal_getAccessGrantAll(
  *   If not given, it is attempted to be found by determining the server URL from the resource
  *   involved in the request and reading its .well-known/solid file for an Access API entry. If
  *   you are not providing a resource this url must point to the vcProvider endpoint associated
- *   with the environment you are requesting against. 
+ *   with the environment you are requesting against.
  * @returns A promise resolving to an array of Access Grants matching the request.
  * @since 0.4.0
  */

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -170,31 +170,6 @@ async function internal_getAccessGrantAll(
 
 /**
  * Retrieve Access Grants issued over a resource. The Access Grants may be filtered
- * by requestor, access modes and purpose. In order to discover all applicable Access
- * Grants for the target resource, including recursive Access Grants issued over
- * an ancestor container, the resources hierarchy is walked up to the storage root.
- *
- * @param resource The URL of a resource to which access grants might have been issued.
- * @param grantShape The properties of grants to filter results.
- * @param options Optional parameter:
- * - `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- * This can be typically used for authentication. Note that if it is omitted, and
- * `@inrupt/solid-client-authn-browser` is in your dependencies, the default session
- * is picked up.
- * - `options.includeExpiredGrants`: include expired grants in the result set.
- * @returns A void promise.
- * @since 0.4.0
- * @deprecated Please remove `resource` parameter.
- */
-
-async function getAccessGrantAll(
-  resource: URL | UrlString,
-  params?: AccessParameters,
-  options?: QueryOptions,
-): Promise<Array<VerifiableCredential>>;
-
-/**
- * Retrieve Access Grants issued over a resource. The Access Grants may be filtered
  * by resource, requestor, access modes and purpose.
  *
  * If a resource filter is specified, the resources hierarchy is walked up to the
@@ -229,12 +204,37 @@ async function getAccessGrantAll(
  *   involved in the request and reading its .well-known/solid file for an Access API entry. If
  *   you are not providing a resource this url must point to the vcProvider endpoint associated
  *   with the environment you are requesting against. 
- * @returns A void promise.
+ * @returns A promise resolving to an array of Access Grants matching the request.
  * @since 0.4.0
  */
 
 async function getAccessGrantAll(
   params: AccessParameters,
+  options?: QueryOptions,
+): Promise<Array<VerifiableCredential>>;
+
+/**
+ * Retrieve Access Grants issued over a resource. The Access Grants may be filtered
+ * by requestor, access modes and purpose. In order to discover all applicable Access
+ * Grants for the target resource, including recursive Access Grants issued over
+ * an ancestor container, the resources hierarchy is walked up to the storage root.
+ *
+ * @param resource The URL of a resource to which access grants might have been issued.
+ * @param grantShape The properties of grants to filter results.
+ * @param options Optional parameter:
+ * - `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * This can be typically used for authentication. Note that if it is omitted, and
+ * `@inrupt/solid-client-authn-browser` is in your dependencies, the default session
+ * is picked up.
+ * - `options.includeExpiredGrants`: include expired grants in the result set.
+ * @returns A promise resolving to an array of Access Grants matching the request.
+ * @since 0.4.0
+ * @deprecated Please remove `resource` parameter.
+ */
+
+async function getAccessGrantAll(
+  resource: URL | UrlString,
+  params?: AccessParameters,
   options?: QueryOptions,
 ): Promise<Array<VerifiableCredential>>;
 


### PR DESCRIPTION
This adds example usage and clarifies that filtering by resource  is optional.