### PR TITLE
fix: add a types export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The following changes are pending, and will be applied on the next major release
   JSON-LD frame different from the value returned by `approveAccessRequest`. The value is now normalized,
   and both functions return a similarly shaped object. This also fixes the return type of `denyAccessRequest`,
   which now returns the more strict `AccessGrant` type rather than the `VerifiableCredential` type.
+- add `types` entry in the package.json exports so that bundlers such as esbuild can discover type definitions.
 
 ## [2.6.0](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v2.6.0) - 2023-09-18
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },


### PR DESCRIPTION
After merging https://github.com/inrupt/solid-client-access-grants-js/pull/773 can be used to release.