### PR TITLE
Add Dev-2-1 to end-to-end environments

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        environment-name: ["ESS PodSpaces"]
+        environment-name: ["ESS PodSpaces", "ESS Dev-2-1"]
         experimental: [false]
         include:
           - environment-name: "ESS Dev-2-2"

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version: ["16.x", "18.x", "20.x"]
-        environment-name: ["ESS PodSpaces"]
+        environment-name: ["ESS PodSpaces", "ESS Dev-2-1"]
         experimental: [false]
         include:
           - environment-name: "ESS Dev-2-2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@inrupt/eslint-config-lib": "^2.1.3",
         "@inrupt/internal-playwright-helpers": "^2.1.3",
         "@inrupt/internal-playwright-testids": "^2.0.4",
-        "@inrupt/internal-test-env": "^2.0.4",
+        "@inrupt/internal-test-env": "^2.6.0",
         "@inrupt/jest-jsdom-polyfills": "^2.0.0",
         "@inrupt/solid-client-authn-browser": "^1.12.2",
         "@inrupt/solid-client-authn-node": "^1.12.1",
@@ -922,13 +922,7 @@
         "@playwright/test": "^1.37.0"
       }
     },
-    "node_modules/@inrupt/internal-playwright-testids": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.4.1.tgz",
-      "integrity": "sha512-j5YnuqbzLbYTH2TNMBG09uf8uigf0Q0XC6kAh74lAE9mKUj2s0cYe6pkULu7GX+beOo9HEZaD+h0FXqeuzqanw==",
-      "dev": true
-    },
-    "node_modules/@inrupt/internal-test-env": {
+    "node_modules/@inrupt/internal-playwright-helpers/node_modules/@inrupt/internal-test-env": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.4.1.tgz",
       "integrity": "sha512-fOaDUjNybeAYsVN8sxw8VqXrtGBpKrLuXTnhvlrm+xYDBHaJwYCMbMJvctiBW68kSCgCCq1OUt+D/da76UO6DQ==",
@@ -937,6 +931,26 @@
         "@inrupt/solid-client": "^1.30.0",
         "@inrupt/solid-client-authn-browser": "^1.17.2",
         "@inrupt/solid-client-authn-node": "^1.17.2",
+        "@jeswr/css-auth-utils": "^1.4.0",
+        "deepmerge-json": "^1.5.0",
+        "dotenv": "^16.3.1"
+      }
+    },
+    "node_modules/@inrupt/internal-playwright-testids": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.4.1.tgz",
+      "integrity": "sha512-j5YnuqbzLbYTH2TNMBG09uf8uigf0Q0XC6kAh74lAE9mKUj2s0cYe6pkULu7GX+beOo9HEZaD+h0FXqeuzqanw==",
+      "dev": true
+    },
+    "node_modules/@inrupt/internal-test-env": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.6.0.tgz",
+      "integrity": "sha512-uWW7P+HDd9k/fM23lGdU+pf9SlYffoRYlJSKtAMEszRyBVsKlnFj8zZkgjAZrzbcZn1jY+Yj9PlTXnB5GtAu1g==",
+      "dev": true,
+      "dependencies": {
+        "@inrupt/solid-client": "^1.30.2",
+        "@inrupt/solid-client-authn-browser": "^1.17.5",
+        "@inrupt/solid-client-authn-node": "^1.17.5",
         "@jeswr/css-auth-utils": "^1.4.0",
         "deepmerge-json": "^1.5.0",
         "dotenv": "^16.3.1"
@@ -968,13 +982,13 @@
       }
     },
     "node_modules/@inrupt/oidc-client-ext": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.17.4.tgz",
-      "integrity": "sha512-IlpsGmuYzFkEtaOFAFgN0C9s6PXkq8fmFcbeuxE1877r5arcHIxX+7VQCZQMqyQLleBOEae+cHMbRAwKDQByew==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.17.5.tgz",
+      "integrity": "sha512-vYnYbNW+EwDeAkzLzLF77PLXVeajhZ0IqocC5M2xM9aGc0JgRIy8lnrwxrV/VLf2AXRig9Aqlv/RmLY1VTz2eg==",
       "dev": true,
       "dependencies": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.17.4",
+        "@inrupt/solid-client-authn-core": "^1.17.5",
         "@inrupt/universal-fetch": "^1.0.1",
         "jose": "^4.15.4",
         "uuid": "^9.0.1"
@@ -1003,13 +1017,13 @@
       }
     },
     "node_modules/@inrupt/solid-client-authn-browser": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.17.4.tgz",
-      "integrity": "sha512-Bf1N5vt0NEO/xP9nSaQb67y/O46mx3Qzgx/7QQslyrn8mZ7I/dCmzsd5oY+FnwZD9FHhyFfqaScsebB6/rhxNA==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.17.5.tgz",
+      "integrity": "sha512-zjyXPmKACp7syNsctQfkFhYCwEQ5QoTStLMbBFhtqJAsoWpo+d/awI1nljTDKxlJtYnvEoYjl2pM2aZMJ7mtew==",
       "dev": true,
       "dependencies": {
-        "@inrupt/oidc-client-ext": "^1.17.4",
-        "@inrupt/solid-client-authn-core": "^1.17.4",
+        "@inrupt/oidc-client-ext": "^1.17.5",
+        "@inrupt/solid-client-authn-core": "^1.17.5",
         "@inrupt/universal-fetch": "^1.0.2",
         "events": "^3.3.0",
         "jose": "^4.15.4",
@@ -3436,9 +3450,9 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "3.33.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.2.tgz",
-      "integrity": "sha512-XeBzWI6QL3nJQiHmdzbAOiMYqjrb7hwU7A39Qhvd/POSa/t9E1AeZyEZx3fNvp/vtM8zXwhoL0FsiS0hD0pruQ==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.34.0.tgz",
+      "integrity": "sha512-aDdvlDder8QmY91H88GzNi9EtQi2TjvQhpCX6B1v/dAZHU1AuLgHvRh54RiOerpEhEW46Tkf+vgAViB/CWC0ag==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,10 @@
       },
       "devDependencies": {
         "@inrupt/eslint-config-lib": "^2.1.3",
-        "@inrupt/internal-playwright-helpers": "^2.1.3",
+        "@inrupt/internal-playwright-helpers": "^2.6.0",
         "@inrupt/internal-playwright-testids": "^2.0.4",
         "@inrupt/internal-test-env": "^2.6.0",
-        "@inrupt/jest-jsdom-polyfills": "^2.0.0",
+        "@inrupt/jest-jsdom-polyfills": "^2.6.0",
         "@inrupt/solid-client-authn-browser": "^1.12.2",
         "@inrupt/solid-client-authn-node": "^1.12.1",
         "@playwright/test": "^1.34.3",
@@ -910,36 +910,22 @@
       }
     },
     "node_modules/@inrupt/internal-playwright-helpers": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-helpers/-/internal-playwright-helpers-2.4.1.tgz",
-      "integrity": "sha512-SzGcsRRAKqymv5Eha1A4fkfCHu9L36BoXEP28xdYrB1XOojW0+lpiPg4aoAazTRpwkTsmCFDmyMwZyDpXYeNJA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-helpers/-/internal-playwright-helpers-2.6.0.tgz",
+      "integrity": "sha512-rVSwTVWIpAHua3xZpxWAodKAovUeNWgo0whZ1fawmr7QztYMgsqG7c8S7kZSdQhTFCw/gADuEDEIuYz9DHJ2CA==",
       "dev": true,
       "dependencies": {
-        "@inrupt/internal-playwright-testids": "2.4.1",
-        "@inrupt/internal-test-env": "2.4.1"
+        "@inrupt/internal-playwright-testids": "2.6.0",
+        "@inrupt/internal-test-env": "2.6.0"
       },
       "peerDependencies": {
         "@playwright/test": "^1.37.0"
       }
     },
-    "node_modules/@inrupt/internal-playwright-helpers/node_modules/@inrupt/internal-test-env": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.4.1.tgz",
-      "integrity": "sha512-fOaDUjNybeAYsVN8sxw8VqXrtGBpKrLuXTnhvlrm+xYDBHaJwYCMbMJvctiBW68kSCgCCq1OUt+D/da76UO6DQ==",
-      "dev": true,
-      "dependencies": {
-        "@inrupt/solid-client": "^1.30.0",
-        "@inrupt/solid-client-authn-browser": "^1.17.2",
-        "@inrupt/solid-client-authn-node": "^1.17.2",
-        "@jeswr/css-auth-utils": "^1.4.0",
-        "deepmerge-json": "^1.5.0",
-        "dotenv": "^16.3.1"
-      }
-    },
     "node_modules/@inrupt/internal-playwright-testids": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.4.1.tgz",
-      "integrity": "sha512-j5YnuqbzLbYTH2TNMBG09uf8uigf0Q0XC6kAh74lAE9mKUj2s0cYe6pkULu7GX+beOo9HEZaD+h0FXqeuzqanw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.6.0.tgz",
+      "integrity": "sha512-myDnVYvABMGEKTHtelISIxxWNlPW4oM7dEncqPr9E0ZMx6xiBFQlsbt7u3nHlW/QVNt+9re8GhylWoWrCCWtnA==",
       "dev": true
     },
     "node_modules/@inrupt/internal-test-env": {
@@ -957,15 +943,15 @@
       }
     },
     "node_modules/@inrupt/jest-jsdom-polyfills": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-2.1.3.tgz",
-      "integrity": "sha512-0+yVUdAJ7v5L5JzvqjGdVlDSLdC17yHXStZSNGoXSnUns9OH/Jn3pQFu2IppBMYxyzAbPor7R2geGNtFoqRuig==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-2.6.0.tgz",
+      "integrity": "sha512-EVZ4X6incoQjoE1wM42fk2qoDgC76d8u0+ffzD8HpY5ax/Fo2zMlFe/gC1PH0t0yddZiMARCKZrMs50tLPK71w==",
       "dev": true,
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
-        "@web-std/blob": "^3.0.4",
-        "@web-std/file": "^3.0.2",
-        "undici": "^5.23.0"
+        "@web-std/blob": "^3.0.5",
+        "@web-std/file": "^3.0.3",
+        "undici": "^5.27.2"
       }
     },
     "node_modules/@inrupt/oidc-client": {
@@ -2406,9 +2392,9 @@
       "dev": true
     },
     "node_modules/@web-std/blob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.4.tgz",
-      "integrity": "sha512-+dibyiw+uHYK4dX5cJ7HA+gtDAaUUe6JsOryp2ZpAC7h4ICsh49E34JwHoEKPlPvP0llCrNzz45vvD+xX5QDBg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.5.tgz",
+      "integrity": "sha512-Lm03qr0eT3PoLBuhkvFBLf0EFkAsNz/G/AYCzpOdi483aFaVX86b4iQs0OHhzHJfN5C15q17UtDbyABjlzM96A==",
       "dev": true,
       "dependencies": {
         "@web-std/stream": "1.0.0",
@@ -2416,9 +2402,9 @@
       }
     },
     "node_modules/@web-std/file": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-3.0.2.tgz",
-      "integrity": "sha512-pIH0uuZsmY8YFvSHP1NsBIiMT/1ce0suPrX74fEeO3Wbr1+rW0fUGEe4d0R99iLwXtyCwyserqCFI4BJkJlkRA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-3.0.3.tgz",
+      "integrity": "sha512-X7YYyvEERBbaDfJeC9lBKC5Q5lIEWYCP1SNftJNwNH/VbFhdHm+3neKOQP+kWEYJmosbDFq+NEUG7+XIvet/Jw==",
       "dev": true,
       "dependencies": {
         "@web-std/blob": "^3.0.3"
@@ -10354,9 +10340,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.26.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.3.tgz",
-      "integrity": "sha512-H7n2zmKEWgOllKkIUkLvFmsJQj062lSm3uA4EYApG8gLuiOM0/go9bIoC3HVaSnfg4xunowDE2i9p8drkXuvDw==",
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@inrupt/eslint-config-lib": "^2.1.3",
     "@inrupt/internal-playwright-helpers": "^2.1.3",
     "@inrupt/internal-playwright-testids": "^2.0.4",
-    "@inrupt/internal-test-env": "^2.0.4",
+    "@inrupt/internal-test-env": "^2.6.0",
     "@inrupt/jest-jsdom-polyfills": "^2.0.0",
     "@inrupt/solid-client-authn-browser": "^1.12.2",
     "@inrupt/solid-client-authn-node": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -101,10 +101,10 @@
   },
   "devDependencies": {
     "@inrupt/eslint-config-lib": "^2.1.3",
-    "@inrupt/internal-playwright-helpers": "^2.1.3",
+    "@inrupt/internal-playwright-helpers": "^2.6.0",
     "@inrupt/internal-playwright-testids": "^2.0.4",
     "@inrupt/internal-test-env": "^2.6.0",
-    "@inrupt/jest-jsdom-polyfills": "^2.0.0",
+    "@inrupt/jest-jsdom-polyfills": "^2.6.0",
     "@inrupt/solid-client-authn-browser": "^1.12.2",
     "@inrupt/solid-client-authn-node": "^1.12.1",
     "@playwright/test": "^1.34.3",


### PR DESCRIPTION
This will require a release of the typescript-sdk-tools repository, and a run of the e2e-environments script before it passes.