### PR TITLE
Node16 EoL: remove universal fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: ["20.x", "18.x", "16.x"]
+        node-version: ["20.x", "18.x"]
         experimental: [false]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        node-version: ["16.x", "18.x", "20.x"]
+        node-version: ["18.x", "20.x"]
         environment-name: ["ESS PodSpaces", "ESS Dev-2-1"]
         experimental: [false]
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,17 @@ The following changes are pending, and will be applied on the next major release
 
 ### Breaking Changes
 
-- Parsing Access Grants & Access Requests. This allows the Access Grants & Access Requests to be read using the RDF/JS DatasetCore API. This is a breaking change because their type also now extends the `DatasetCore` type. Importantly, this dataset is not preserved when converting to verifiableCredentials a string and back doing `JSON.parse(JSON.stringify(verifiableCredential))`. We reccomend that developers set `returnLegacyJsonld` to `false` in functions such as `getAccessGrant` in order to avoid returning deprecated object properties. Instead developers should make use of the exported `getter` functions to get these attributes.
-- Use the global `fetch` function instead of `@inrupt/universal-fetch`. This means this library now only works
-  with Node 18 and higher.
-  
+- **Parsing Access Grants and Access Requests as RDF from JSON-LD**: This allows the Access Grants
+  and Access Requests to be read using the RDF/JS DatasetCore API. This is a breaking change,
+  because their type also now extends the `DatasetCore` type. Importantly, this dataset is not
+  preserved when converting a Verifiable Credential to a string and back doing 
+  `JSON.parse(JSON.stringify(verifiableCredential))`. We reccomend that developers set
+  `returnLegacyJsonld` to `false` in functions such as `getAccessGrant` in order to avoid
+  returning deprecated object properties. Instead developers should make use of the exported
+  `getter` functions to get these attributes.
+- **Node 16 is no longer supported**: The global `fetch` function is now used instead of
+  `@inrupt/universal-fetch`. This means this library now only works with Node 18 and higher.
+
 ## [2.6.2](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v2.6.2) - 2023-11-16
 
 ### Removed features (non-breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ The following changes are pending, and will be applied on the next major release
 ### Breaking Changes
 
 - Parsing Access Grants & Access Requests. This allows the Access Grants & Access Requests to be read using the RDF/JS DatasetCore API. This is a breaking change because their type also now extends the `DatasetCore` type. Importantly, this dataset is not preserved when converting to verifiableCredentials a string and back doing `JSON.parse(JSON.stringify(verifiableCredential))`. We reccomend that developers set `returnLegacyJsonld` to `false` in functions such as `getAccessGrant` in order to avoid returning deprecated object properties. Instead developers should make use of the exported `getter` functions to get these attributes.
-
+- Use the global `fetch` function instead of `@inrupt/universal-fetch`. This means this library now only works
+  with Node 18 and higher.
+  
 ## [2.6.2](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v2.6.2) - 2023-11-16
 
 ### Removed features (non-breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The following changes are pending, and will be applied on the next major release
 - **Parsing Access Grants and Access Requests as RDF from JSON-LD**: This allows the Access Grants
   and Access Requests to be read using the RDF/JS DatasetCore API. This is a breaking change,
   because their type also now extends the `DatasetCore` type. Importantly, this dataset is not
-  preserved when converting a Verifiable Credential to a string and back doing 
+  preserved when converting a Verifiable Credential to a string and back doing
   `JSON.parse(JSON.stringify(verifiableCredential))`. We reccomend that developers set
   `returnLegacyJsonld` to `false` in functions such as `getAccessGrant` in order to avoid
   returning deprecated object properties. Instead developers should make use of the exported

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ and `String.prototype.endsWith`.
 ## Node.js Support
 
 Our JavaScript Client Libraries track Node.js [LTS
-releases](https://nodejs.org/en/about/releases/), and support 16.x, 18.x and 20.x.
+releases](https://nodejs.org/en/about/releases/), and support 18.x and 20.x.
 
 # Installation
 

--- a/docs/api/source/index.rst
+++ b/docs/api/source/index.rst
@@ -61,7 +61,7 @@ Node.js Support
 ^^^^^^^^^^^^^^^
 
 Our JavaScript Client Libraries track Node.js `LTS releases
-<https://nodejs.org/en/about/releases/>`__, and support 16.x, 18.x and 20.x.
+<https://nodejs.org/en/about/releases/>`__, and support 18.x and 20.x.
 
 .. _issues--help:
 

--- a/examples/grant-access/README.md
+++ b/examples/grant-access/README.md
@@ -3,7 +3,7 @@
 ## Install and build
 
 - Run `npm ci` and `npm run build` in the current directory to build the demo app.
-- (Optional, requires node16+) Run the app using the local repository's code:
+- (Optional, requires node18+) Run the app using the local repository's code:
   - run `npm ci` and `npm run build` in the root repository to make sure the library is built,
   - run `npm ci` and `npm run build:local` in the current directory to build the demo app.
 

--- a/examples/grant-access/src/request-access.ts
+++ b/examples/grant-access/src/request-access.ts
@@ -22,7 +22,6 @@
 /* eslint-disable no-console, import/no-unresolved */
 
 import { Session } from "@inrupt/solid-client-authn-node";
-import { fetch as crossFetch } from "@inrupt/universal-fetch";
 import express from "express";
 import {
   issueAccessRequest,
@@ -87,7 +86,7 @@ app.post("/request", async (req, res) => {
       // Note: the following is only necessary because this projects depends for testing puspose
       // on solid-client-authn-browser, which is picked up automatically for convenience in
       // browser-side apps. A typical node app would not have this dependence.
-      fetch: crossFetch,
+      fetch,
     },
   );
 });

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -20,3 +20,6 @@
 //
 
 import "@inrupt/jest-jsdom-polyfills";
+globalThis.fetch = () => {
+    throw new Error('Global fetch should not be called without being mocked in unit tests')
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "uuid": "^9.0.1"
       },
       "engines": {
-        "node": "^16.0.0 || ^18.0.0 || ^20.0.0"
+        "node": "^18.0.0 || ^20.0.0"
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@inrupt/solid-client": "^1.25.1",
         "@inrupt/solid-client-vc": "^0.8.0-beta.4",
-        "@inrupt/universal-fetch": "^1.0.1",
         "@types/rdfjs__dataset": "^1.0.5",
         "auth-header": "^1.0.0",
         "base64url": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
   "dependencies": {
     "@inrupt/solid-client": "^1.25.1",
     "@inrupt/solid-client-vc": "^0.8.0-beta.4",
-    "@inrupt/universal-fetch": "^1.0.1",
     "@types/rdfjs__dataset": "^1.0.5",
     "auth-header": "^1.0.0",
     "base64url": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "rdf-namespaces": "^1.9.2"
   },
   "engines": {
-    "node": "^16.0.0 || ^18.0.0 || ^20.0.0"
+    "node": "^18.0.0 || ^20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/common/util/getSessionFetch.ts
+++ b/src/common/util/getSessionFetch.ts
@@ -18,8 +18,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
-import { fetch as crossFetch } from "@inrupt/universal-fetch";
 import type { AccessBaseOptions } from "../../gConsent/type/AccessBaseOptions";
 
 /**
@@ -47,6 +45,6 @@ export async function getSessionFetch(
     return fetchFn;
   } catch (e) {
     /* istanbul ignore next: @inrupt/solid-client-authn-browser is a devDependency, so this path is not hit in tests: */
-    return crossFetch;
+    return fetch;
   }
 }

--- a/src/common/verify/isValidAccessGrant.test.ts
+++ b/src/common/verify/isValidAccessGrant.test.ts
@@ -20,8 +20,6 @@
 //
 
 import { jest, describe, it, expect, beforeAll } from "@jest/globals";
-import { Response } from "@inrupt/universal-fetch";
-import type * as CrossFetch from "@inrupt/universal-fetch";
 import {
   isVerifiableCredential,
   getVerifiableCredentialApiConfiguration,
@@ -101,13 +99,11 @@ describe("isValidAccessGrant", () => {
 
   it("uses the provided fetch if any", async () => {
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
-    const mockedFetch = jest
-      .fn<(typeof CrossFetch)["fetch"]>()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
-          status: 200,
-        }),
-      );
+    const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
+        status: 200,
+      }),
+    );
     await isValidAccessGrant(MOCK_ACCESS_GRANT, {
       fetch: mockedFetch,
       verificationEndpoint: MOCK_ACCESS_ENDPOINT,
@@ -123,13 +119,11 @@ describe("isValidAccessGrant", () => {
       specCompliant: {},
       legacy: {},
     });
-    const mockedFetch = jest
-      .fn<(typeof CrossFetch)["fetch"]>()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
-          status: 200,
-        }),
-      );
+    const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
+        status: 200,
+      }),
+    );
 
     await isValidAccessGrant(MOCK_ACCESS_GRANT, {
       fetch: mockedFetch,
@@ -146,7 +140,7 @@ describe("isValidAccessGrant", () => {
   it("retrieves the vc if a url was passed", async () => {
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest
-      .fn<(typeof CrossFetch)["fetch"]>()
+      .fn<typeof fetch>()
       // First, the VC is fetched
       .mockResolvedValueOnce(
         new Response(JSON.stringify(MOCK_ACCESS_GRANT), { status: 200 }),
@@ -168,7 +162,7 @@ describe("isValidAccessGrant", () => {
 
   it("throws if the passed url returns a non-vc", async () => {
     const mockedFetch = jest
-      .fn<(typeof CrossFetch)["fetch"]>()
+      .fn<typeof fetch>()
       .mockResolvedValue(
         new Response(JSON.stringify({ someField: "Not a credential" })),
       );
@@ -193,13 +187,11 @@ describe("isValidAccessGrant", () => {
       "getVerifiableCredentialApiConfiguration",
     );
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
-    const mockedFetch = jest
-      .fn<(typeof CrossFetch)["fetch"]>()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
-          status: 200,
-        }),
-      );
+    const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
+        status: 200,
+      }),
+    );
     await isValidAccessGrant(MOCK_ACCESS_GRANT, {
       fetch: mockedFetch,
       verificationEndpoint: "https://some.verification.api",
@@ -221,7 +213,7 @@ describe("isValidAccessGrant", () => {
       });
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest
-      .fn<(typeof CrossFetch)["fetch"]>()
+      .fn<typeof fetch>()
       // First, the VC is fetched
       .mockResolvedValueOnce(
         new Response(JSON.stringify(MOCK_ACCESS_GRANT), { status: 200 }),
@@ -247,7 +239,7 @@ describe("isValidAccessGrant", () => {
     });
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
     const mockedFetch = jest
-      .fn<(typeof CrossFetch)["fetch"]>()
+      .fn<typeof fetch>()
       // First, the VC is fetched
       .mockResolvedValueOnce(
         new Response(JSON.stringify(MOCK_ACCESS_GRANT), { status: 200 }),
@@ -275,13 +267,11 @@ describe("isValidAccessGrant", () => {
       legacy: {},
     });
     jest.mocked(isVerifiableCredential).mockReturnValueOnce(true);
-    const mockedFetch = jest
-      .fn<(typeof CrossFetch)["fetch"]>()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
-          status: 200,
-        }),
-      );
+    const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(JSON.stringify(MOCK_VERIFY_RESPONSE), {
+        status: 200,
+      }),
+    );
     await expect(
       isValidAccessGrant(MOCK_ACCESS_GRANT, {
         fetch: mockedFetch,

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -19,7 +19,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { fetch as crossFetch } from "@inrupt/universal-fetch";
 import base64url from "base64url";
 import type { UrlString } from "@inrupt/solid-client";
 import type {
@@ -76,7 +75,7 @@ export async function getUmaConfiguration(
   authIri: string,
 ): Promise<UmaConfiguration> {
   const configurationUrl = new URL(UMA_CONFIG_PATH, authIri).href;
-  const response = await crossFetch(configurationUrl);
+  const response = await fetch(configurationUrl);
   return response.json().catch((e) => {
     throw new Error(
       `Parsing the UMA configuration found at ${configurationUrl} failed with the following error: ${e.toString()}`,
@@ -126,7 +125,7 @@ export async function exchangeTicketForAccessToken(
 export function boundFetch(accessToken: string): typeof fetch {
   // Explicitly use a named function such that it appears in stacktraces
   return function authenticatedFetch(url, init) {
-    return crossFetch(url, {
+    return fetch(url, {
       ...init,
       headers: {
         ...(init?.headers || {}),
@@ -165,7 +164,7 @@ export async function fetchWithVc(
 ): Promise<typeof fetch> {
   // Use an authenticated session to fetch the resource so that we can parse
   // its headers to find the UMA endpoint information and ticket
-  const response = await crossFetch(resourceIri);
+  const response = await fetch(resourceIri);
   const { headers } = response;
 
   const wwwAuthentication = headers.get(WWW_AUTH_HEADER);
@@ -192,7 +191,7 @@ export async function fetchWithVc(
     tokenEndpoint,
     accessGrant,
     authTicket,
-    options?.fetch ?? crossFetch,
+    options?.fetch ?? fetch,
   );
 
   if (!accessToken) {

--- a/src/gConsent/discover/getAccessApiEndpoint.ts
+++ b/src/gConsent/discover/getAccessApiEndpoint.ts
@@ -20,7 +20,6 @@
 //
 
 import type { UrlString } from "@inrupt/solid-client";
-import { fetch as crossFetch } from "@inrupt/universal-fetch";
 import { parse } from "auth-header";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 
@@ -29,7 +28,7 @@ async function getAccessEndpointForResource(
 ): Promise<UrlString> {
   // Explicitly makes an unauthenticated fetch to be sure to get the link to the
   // authorization server.
-  const response = await crossFetch(resource);
+  const response = await fetch(resource);
   if (!response.headers.has("WWW-Authenticate")) {
     throw new Error(
       `Expected a 401 error with a WWW-Authenticate header, got a [${response.status}: ${response.statusText}] response lacking the WWW-Authenticate header.`,
@@ -47,7 +46,7 @@ async function getAccessEndpointForResource(
     "/.well-known/uma2-configuration",
     authorizationServerIri,
   );
-  const rawDiscoveryDocument = await crossFetch(wellKnownIri.href);
+  const rawDiscoveryDocument = await fetch(wellKnownIri.href);
   const discoveryDocument = await rawDiscoveryDocument.json();
   if (typeof discoveryDocument.verifiable_credential_issuer !== "string") {
     throw new Error(

--- a/src/gConsent/discover/getAccessManagementUi.test.ts
+++ b/src/gConsent/discover/getAccessManagementUi.test.ts
@@ -50,7 +50,7 @@ describe("getAccessManagementUi", () => {
         "getSolidDataset",
       )
       .mockResolvedValueOnce(mockWebIdWithUi("https://some.webid"));
-    const mockedFetch = jest.fn(global.fetch);
+    const mockedFetch = jest.fn<typeof fetch>();
 
     await getAccessManagementUi("https://some.webid", { fetch: mockedFetch });
 

--- a/src/gConsent/discover/redirectToAccessManagementUi.browser.test.ts
+++ b/src/gConsent/discover/redirectToAccessManagementUi.browser.test.ts
@@ -27,7 +27,6 @@ import {
   beforeEach,
   afterEach,
 } from "@jest/globals";
-import { Response } from "@inrupt/universal-fetch";
 import { redirectToAccessManagementUi } from "./redirectToAccessManagementUi";
 import {
   getAccessManagementUiFromWellKnown,

--- a/src/gConsent/manage/approveAccessRequest.test.ts
+++ b/src/gConsent/manage/approveAccessRequest.test.ts
@@ -20,8 +20,6 @@
 //
 
 import { jest, it, describe, expect, beforeAll } from "@jest/globals";
-import { Response } from "@inrupt/universal-fetch";
-import type * as CrossFetch from "@inrupt/universal-fetch";
 
 import { mockSolidDatasetFrom } from "@inrupt/solid-client";
 import type * as VcClient from "@inrupt/solid-client-vc";
@@ -85,16 +83,6 @@ jest.mock("@inrupt/solid-client-vc", () => {
     getId,
     issueVerifiableCredential: jest.fn(),
     getVerifiableCredential,
-  };
-});
-jest.mock("@inrupt/universal-fetch", () => {
-  const crossFetch = jest.requireActual(
-    "@inrupt/universal-fetch",
-  ) as jest.Mocked<typeof CrossFetch>;
-  return {
-    // Do no mock the globals such as Response.
-    ...crossFetch,
-    fetch: jest.fn<(typeof crossFetch)["fetch"]>(),
   };
 });
 
@@ -185,7 +173,7 @@ describe("approveAccessRequest", () => {
       }),
       undefined,
       {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
       },
     );
     // The resource's IRI is picked up from the access grant.
@@ -278,7 +266,7 @@ describe("approveAccessRequest", () => {
   it("uses the provided fetch, if any", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
-    const mockedFetch = jest.fn(global.fetch);
+    const mockedFetch = jest.fn<typeof fetch>();
     const mockedVcModule = jest.requireMock(
       "@inrupt/solid-client-vc",
     ) as typeof VcClient;
@@ -315,7 +303,7 @@ describe("approveAccessRequest", () => {
     const mockedIssue = jest.spyOn(mockedVcModule, "issueVerifiableCredential");
     mockedIssue.mockResolvedValueOnce(accessGrantVc);
     await approveAccessRequest(accessRequestVc, undefined, {
-      fetch: jest.fn(global.fetch),
+      fetch: jest.fn<typeof fetch>(),
     });
 
     expect(spiedIssueRequest).toHaveBeenCalledWith(
@@ -346,7 +334,7 @@ describe("approveAccessRequest", () => {
       "issueVerifiableCredential",
     );
     mockedIssue.mockResolvedValueOnce(accessGrantVc);
-    const mockedFetch = jest.fn(global.fetch);
+    const mockedFetch = jest.fn<typeof fetch>();
     mockedFetch.mockResolvedValueOnce(
       new Response(JSON.stringify(consentRequestVc)),
     );
@@ -387,7 +375,7 @@ describe("approveAccessRequest", () => {
     mockedIssue.mockResolvedValueOnce(mockedVc);
     await expect(
       approveAccessRequest(accessRequestVc, undefined, {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
         updateAcr: false,
       }),
     ).resolves.not.toThrow();
@@ -401,7 +389,7 @@ describe("approveAccessRequest", () => {
       "issueVerifiableCredential",
     );
     mockedIssue.mockResolvedValueOnce(accessRequestVc);
-    const mockedFetch = jest.fn(global.fetch);
+    const mockedFetch = jest.fn<typeof fetch>();
     mockedFetch.mockResolvedValueOnce(
       new Response(JSON.stringify(consentRequestVc)),
     );
@@ -425,7 +413,7 @@ describe("approveAccessRequest", () => {
     );
     spiedIssueRequest.mockResolvedValueOnce(await mockAccessGrantVc());
     await approveAccessRequest(consentRequestVc, undefined, {
-      fetch: jest.fn(global.fetch),
+      fetch: jest.fn<typeof fetch>(),
     });
 
     expect(spiedIssueRequest).toHaveBeenCalledWith(
@@ -468,7 +456,7 @@ describe("approveAccessRequest", () => {
         purpose: ["https://some-custom.purpose"],
       },
       {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
       },
     );
 
@@ -508,7 +496,7 @@ describe("approveAccessRequest", () => {
         inherit: true,
       },
       {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
       },
     );
     expect(spiedIssueRequest.mock.lastCall?.[1]).toMatchObject({
@@ -541,7 +529,7 @@ describe("approveAccessRequest", () => {
         requestorInboxUrl: "https://some-custom.inbox",
       },
       {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
       },
     );
 
@@ -587,7 +575,7 @@ describe("approveAccessRequest", () => {
         requestorInboxUrl: "https://some-custom.inbox",
       },
       {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
       },
     );
 
@@ -627,7 +615,7 @@ describe("approveAccessRequest", () => {
         issuanceDate: new Date(2021, 8, 15),
       },
       {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
       },
     );
 
@@ -671,7 +659,7 @@ describe("approveAccessRequest", () => {
         expirationDate: new Date(2021, 8, 16),
       },
       {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
       },
     );
 
@@ -714,7 +702,7 @@ describe("approveAccessRequest", () => {
         expirationDate: null,
       },
       {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
       },
     );
 
@@ -759,7 +747,7 @@ describe("approveAccessRequest", () => {
       },
       undefined,
       {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
       },
     );
 
@@ -800,7 +788,7 @@ describe("approveAccessRequest", () => {
       accessRequestVc,
       undefined,
       {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
       },
     );
 
@@ -839,7 +827,7 @@ describe("approveAccessRequest", () => {
         accessRequestVc,
         undefined,
         {
-          fetch: jest.fn(global.fetch),
+          fetch: jest.fn<typeof fetch>(),
         },
       ),
     ).rejects.toThrow();
@@ -881,7 +869,7 @@ describe("approveAccessRequest", () => {
     );
     await expect(
       approveAccessRequest(accessRequestVc, undefined, {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
       }),
     ).resolves.toStrictEqual(normalizedAccessGrant);
   });
@@ -910,7 +898,7 @@ describe("approveAccessRequest", () => {
       }),
       undefined,
       {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
       },
     );
     // The resource's IRI is picked up from the access grant.
@@ -957,7 +945,7 @@ describe("approveAccessRequest", () => {
       }),
       undefined,
       {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
         updateAcr: true,
       },
     );
@@ -1006,7 +994,7 @@ describe("approveAccessRequest", () => {
       }),
       undefined,
       {
-        fetch: jest.fn(global.fetch),
+        fetch: jest.fn<typeof fetch>(),
         updateAcr: false,
       },
     );

--- a/src/gConsent/manage/getAccessGrant.test.ts
+++ b/src/gConsent/manage/getAccessGrant.test.ts
@@ -19,8 +19,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import type * as CrossFetch from "@inrupt/universal-fetch";
-import { Response } from "@inrupt/universal-fetch";
 import { beforeAll, describe, expect, it, jest } from "@jest/globals";
 import { isomorphic } from "rdf-isomorphic";
 import { getResources } from "../../common/getters";
@@ -32,17 +30,6 @@ import {
 } from "../util/access.mock";
 import { toBeEqual } from "../util/toBeEqual.mock";
 import { getAccessGrant } from "./getAccessGrant";
-
-jest.mock("@inrupt/universal-fetch", () => {
-  const crossFetch = jest.requireActual(
-    "@inrupt/universal-fetch",
-  ) as jest.Mocked<typeof CrossFetch>;
-  return {
-    // Do no mock the globals such as Response.
-    Response: crossFetch.Response,
-    fetch: jest.fn<(typeof crossFetch)["fetch"]>(),
-  };
-});
 
 describe("getAccessGrant", () => {
   let mockAccessGrant: Awaited<ReturnType<typeof mockAccessGrantVc>>;

--- a/src/gConsent/manage/getAccessGrantAll.test.ts
+++ b/src/gConsent/manage/getAccessGrantAll.test.ts
@@ -22,7 +22,6 @@
 import { jest, it, describe, expect } from "@jest/globals";
 import { getVerifiableCredentialAllFromShape } from "@inrupt/solid-client-vc";
 import * as VcModule from "@inrupt/solid-client-vc";
-import type { fetch } from "@inrupt/universal-fetch";
 import type * as VcLibrary from "@inrupt/solid-client-vc";
 import type {
   AccessParameters,
@@ -33,7 +32,7 @@ import { getAccessApiEndpoint } from "../discover/getAccessApiEndpoint";
 import { mockAccessGrantVc } from "../util/access.mock";
 import { normalizeAccessGrant } from "./approveAccessRequest";
 
-const otherFetch = jest.fn(global.fetch);
+const otherFetch = jest.fn<typeof fetch>();
 
 jest.mock("@inrupt/solid-client-vc", () => {
   const { verifiableCredentialToDataset, getCredentialSubject } =

--- a/src/gConsent/manage/getAccessRequest.test.ts
+++ b/src/gConsent/manage/getAccessRequest.test.ts
@@ -21,7 +21,6 @@
 
 import { describe, it, jest, expect, beforeEach } from "@jest/globals";
 import * as VcModule from "@inrupt/solid-client-vc";
-import { fetch } from "@inrupt/universal-fetch";
 import { isomorphic } from "rdf-isomorphic";
 import { getAccessRequest } from "./getAccessRequest";
 import { mockAccessGrantVc, mockAccessRequestVc } from "../util/access.mock";

--- a/src/gConsent/manage/getAccessRequestFromRedirectUrl.test.ts
+++ b/src/gConsent/manage/getAccessRequestFromRedirectUrl.test.ts
@@ -20,7 +20,6 @@
 //
 
 import type { getVerifiableCredential } from "@inrupt/solid-client-vc";
-import { fetch } from "@inrupt/universal-fetch";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { isomorphic } from "rdf-isomorphic";
 import type { getSessionFetch } from "../../common/util/getSessionFetch";

--- a/src/gConsent/manage/revokeAccessGrant.test.ts
+++ b/src/gConsent/manage/revokeAccessGrant.test.ts
@@ -20,7 +20,6 @@
 //
 
 import { jest, describe, it, expect } from "@jest/globals";
-import { Response } from "@inrupt/universal-fetch";
 
 import type * as VcLibrary from "@inrupt/solid-client-vc";
 import { revokeAccessGrant } from "./revokeAccessGrant";
@@ -102,7 +101,7 @@ describe("revokeAccessGrant", () => {
   });
 
   it("throws if dereferencing the credential ID fails", async () => {
-    const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
+    const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
       new Response(undefined, {
         status: 401,
         statusText: "Unauthorized",
@@ -129,7 +128,7 @@ describe("revokeAccessGrant", () => {
       mockedVcModule,
       "revokeVerifiableCredential",
     );
-    const mockedFetch = jest.fn(global.fetch);
+    const mockedFetch = jest.fn<typeof fetch>();
     await revokeAccessGrant(
       await mockAccessGrantVc({ issuer: "https://some.issuer/" }),
       {

--- a/src/gConsent/request/cancelAccessRequest.test.ts
+++ b/src/gConsent/request/cancelAccessRequest.test.ts
@@ -20,7 +20,6 @@
 //
 
 import { jest, describe, it, expect } from "@jest/globals";
-import { Response } from "@inrupt/universal-fetch";
 import type * as VcLibrary from "@inrupt/solid-client-vc";
 import { cancelAccessRequest } from "./cancelAccessRequest";
 import { MOCKED_CREDENTIAL_ID } from "./request.mock";
@@ -111,7 +110,7 @@ describe("cancelAccessRequest", () => {
   });
 
   it("throws if dereferencing the credential ID fails", async () => {
-    const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
+    const mockedFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
       new Response(undefined, {
         status: 401,
         statusText: "Unauthorized",
@@ -130,7 +129,7 @@ describe("cancelAccessRequest", () => {
       mockedVcModule,
       "revokeVerifiableCredential",
     );
-    const mockedFetch = jest.fn(global.fetch);
+    const mockedFetch = jest.fn<typeof fetch>();
     await cancelAccessRequest(
       await mockAccessGrantVc({ issuer: "https://some.issuer" }),
       {

--- a/src/gConsent/request/getAccessGrantFromRedirectUrl.test.ts
+++ b/src/gConsent/request/getAccessGrantFromRedirectUrl.test.ts
@@ -24,7 +24,6 @@ import type {
   VerifiableCredential,
   getVerifiableCredential,
 } from "@inrupt/solid-client-vc";
-import { fetch } from "@inrupt/universal-fetch";
 import { getAccessGrantFromRedirectUrl } from "./getAccessGrantFromRedirectUrl";
 import type { getSessionFetch } from "../../common/util/getSessionFetch";
 import { mockAccessGrantVc, mockAccessRequestVc } from "../util/access.mock";

--- a/src/gConsent/request/issueAccessRequest.test.ts
+++ b/src/gConsent/request/issueAccessRequest.test.ts
@@ -20,7 +20,6 @@
 //
 
 import { jest, describe, it, expect, beforeAll } from "@jest/globals";
-import type * as CrossFetch from "@inrupt/universal-fetch";
 import type * as VcLibrary from "@inrupt/solid-client-vc";
 
 import {
@@ -60,16 +59,6 @@ jest.mock("@inrupt/solid-client-vc", () => {
   return {
     ...actualVcLibrary,
     issueVerifiableCredential: jest.fn(),
-  };
-});
-jest.mock("@inrupt/universal-fetch", () => {
-  const crossFetch = jest.requireActual(
-    "@inrupt/universal-fetch",
-  ) as jest.Mocked<typeof CrossFetch>;
-  return {
-    // Do no mock the globals such as Response.
-    ...crossFetch,
-    fetch: jest.fn<(typeof crossFetch)["fetch"]>(),
   };
 });
 

--- a/src/gConsent/request/request.mock.ts
+++ b/src/gConsent/request/request.mock.ts
@@ -30,8 +30,6 @@ import {
   mockSolidDatasetFrom,
   setThing,
 } from "@inrupt/solid-client";
-// eslint-disable-next-line no-shadow
-import { Response } from "@inrupt/universal-fetch";
 
 import { PREFERRED_CONSENT_MANAGEMENT_UI } from "../constants";
 
@@ -79,7 +77,7 @@ export const mockWebIdWithUi = (
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const mockAccessApiEndpoint = (withCredentialIssuer = true) => {
   const mockedFetch = jest
-    .fn(global.fetch)
+    .spyOn(globalThis, "fetch")
     .mockResolvedValueOnce(
       new Response("", {
         status: 401,
@@ -99,9 +97,5 @@ export const mockAccessApiEndpoint = (withCredentialIssuer = true) => {
         ),
       ),
     );
-  const crossFetchModule = jest.requireMock("@inrupt/universal-fetch") as {
-    fetch: typeof global.fetch;
-  };
-  crossFetchModule.fetch = mockedFetch;
   return mockedFetch;
 };

--- a/src/resource/deleteFile.test.ts
+++ b/src/resource/deleteFile.test.ts
@@ -21,7 +21,6 @@
 
 import { it, jest, describe, expect, beforeAll } from "@jest/globals";
 import type SolidClientCore from "@inrupt/solid-client";
-import { fetch } from "@inrupt/universal-fetch";
 import { mockAccessGrantVc } from "../gConsent/util/access.mock";
 import { deleteFile } from "./deleteFile";
 import { fetchWithVc } from "../fetch";


### PR DESCRIPTION
Drop usage of `@inrupt/universal-fetch`, replacing it with the native fetch, globally available in all environments starting with Node 18. 