### PR TITLE
Fix filtering of non-recursive grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The following changes are pending, and will be applied on the next major release
 
 ## Unreleased
 
+### Bugfix
+
+- `getAccessGrantAll` incorrectly excluded non-recursive grants if not filtering on target resource.
+
 ## [3.0.0](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v3.0.0) - 2023-12-22
 
 ### Breaking Changes

--- a/src/gConsent/manage/getAccessGrantAll.test.ts
+++ b/src/gConsent/manage/getAccessGrantAll.test.ts
@@ -436,6 +436,31 @@ describe("getAccessGrantAll", () => {
       getAccessGrantAll({ resource: resource.href }),
     ).resolves.toStrictEqual([mockedGrant]);
   });
+
+  it("accepts explicitly non-recursive grants if the target resource is left undefined", async () => {
+    const mockedGrant = await mockAccessGrantVc({
+      inherit: false,
+      resources: [resource.href],
+    });
+    (
+      VcModule as jest.Mocked<typeof VcLibrary>
+    ).getVerifiableCredentialAllFromShape
+      .mockResolvedValueOnce([mockedGrant])
+      // Override the default mock to an unapplicable non-recursive grant.
+      .mockResolvedValue([
+        await mockAccessGrantVc({
+          inherit: false,
+          resources: [resourceAncestors[0]],
+        }),
+      ]);
+    await expect(
+      getAccessGrantAll(
+        { resource: undefined },
+        { accessEndpoint: "https://example.org/vc/" },
+      ),
+    ).resolves.toStrictEqual([mockedGrant]);
+  });
+
   it("throws if both resource and accessEndpoint are undefined", async () => {
     await expect(getAccessGrantAll({})).rejects.toThrow(
       "resource and accessEndpoint cannot both be undefined",

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -249,13 +249,15 @@ async function getAccessGrantAll(
         (vc) => isBaseAccessGrantVerifiableCredential(vc) && isAccessGrant(vc),
       );
   }
-  return result.filter((vc) => {
-    return (
+  // Explicitly non-recursive grants are filtered out, except if they apply
+  // directly to the target resource (in the case a resource is used as a
+  // filtering criteria for getAccessGrantAll).
+  return result.filter(
+    (vc) =>
       getInherit(vc) !== false ||
       params.resource === undefined ||
-      getResources(vc).includes(params.resource.toString())
-    );
-  });
+      getResources(vc).includes(params.resource.toString()),
+  );
 }
 
 export { getAccessGrantAll };

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -249,15 +249,13 @@ async function getAccessGrantAll(
         (vc) => isBaseAccessGrantVerifiableCredential(vc) && isAccessGrant(vc),
       );
   }
-
-  return result.filter(
-    (vc) =>
-      // Explicitly non-recursive grants are filtered out, except if they apply
-      // directly to the target resource.
+  return result.filter((vc) => {
+    return (
       getInherit(vc) !== false ||
-      (params.resource &&
-        getResources(vc).includes(params.resource.toString())),
-  );
+      params.resource === undefined ||
+      getResources(vc).includes(params.resource.toString())
+    );
+  });
 }
 
 export { getAccessGrantAll };


### PR DESCRIPTION
When calling `getAccessGrantAll`, if not filtering grants by target resource, non-recursive grants should not be excluded of the result set.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).