### PR TITLE
Prevent duplicates from `getAccessGrantAll` fitlering by container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           name: code-coverage-ubuntu-latest-20.x
           path: coverage/
-      - uses: SonarSource/sonarcloud-github-action@v1.9
+      - uses: SonarSource/sonarcloud-github-action@v2.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The following changes are pending, and will be applied on the next major release
 
 ## Unreleased
 
+### Bugfix
+
+- `getAccessGrantAll` no longer includes duplicates in the result set when using a container
+  filtering by resource.
+
 ## [3.0.1](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v3.0.1) - 2024-01-10
 
 ### Bugfix

--- a/src/gConsent/manage/getAccessGrantAll.test.ts
+++ b/src/gConsent/manage/getAccessGrantAll.test.ts
@@ -403,6 +403,17 @@ describe("getAccessGrantAll", () => {
     );
   });
 
+  it("doesn't include duplicates when filtering by resources using a container", async () => {
+    await getAccessGrantAll({
+      resource: "https://pod.example/container-1/child/",
+    });
+    expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledTimes(3);
+    await getAccessGrantAll({
+      resource: "https://pod.example/container-1/child",
+    });
+    expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledTimes(6);
+  });
+
   it("filters out non-recursive grants for ancestors", async () => {
     const mockedGrant = await mockAccessGrantVc({
       inherit: false,

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -72,7 +72,9 @@ interface QueryOptions extends AccessBaseOptions {
 const getAncestorUrls = (resourceUrl: URL) => {
   // Splitting on / will result in the first element being empty (since the path
   // starts with /) and in the last element being the target resource name.
-  const ancestorNames = resourceUrl.pathname.split("/").slice(1, -1);
+  const ancestorNames = resourceUrl.pathname
+    .split("/")
+    .slice(1, resourceUrl.pathname.endsWith("/") ? -2 : -1);
   return ancestorNames.reduce(
     (ancestors, curName) => {
       // Add each intermediary container to ancestorPaths


### PR DESCRIPTION
`getAccessGrantAll` would make one call too many if filtering by resources and using a container, resulting in duplicates being included in the result set. This is now resolved.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).