### PR TITLE
Support alternative predicates to gc:isProvidedTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The following changes are pending, and will be applied on the next major release
 
 ## Unreleased
 
+### Bugfixes
+
+- Extend predicate supported by `getRequestor`: `getRequestor` now supports the `gc:isProvidedToPerson` and `gc:isProvidedToController`
+  predicates in addition to the current `gc:isProvidedTo` predicate.
+
 ## [3.0.3](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v3.0.3) - 2024-02-06
 
 ### Bugfix

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -42,6 +42,8 @@ export const gc = {
   hasConsent: namedNode(`${GC}hasConsent`),
   hasStatus: namedNode(`${GC}hasStatus`),
   isProvidedTo: namedNode(`${GC}isProvidedTo`),
+  isProvidedToPerson: namedNode(`${GC}isProvidedToPerson`),
+  isProvidedToController: namedNode(`${GC}isProvidedToController`),
   isConsentForDataSubject: namedNode(`${GC}isConsentForDataSubject`),
   forPurpose: namedNode(`${GC}forPurpose`),
   forPersonalData: namedNode(`${GC}forPersonalData`),

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -237,6 +237,71 @@ describe("getters", () => {
       ).toThrow("Expected exactly one result. Found 2.");
     });
 
+    it("supports alternate gc:isProvidedToPerson", async () => {
+      const store = new Store([...mockedGConsentGrant]);
+      const isProvidedToQuad = store
+        .match(null, gc.isProvidedTo, null, null)
+        .read();
+      if (isProvidedToQuad !== null) {
+        store.removeQuad(
+          isProvidedToQuad.subject,
+          isProvidedToQuad.predicate,
+          isProvidedToQuad.object,
+        );
+      }
+      store.addQuad(
+        getConsent(mockedGConsentGrant),
+        gc.isProvidedToPerson,
+        namedNode("http://example.org/another/requestorPerson"),
+      );
+
+      expect(
+        getRequestor(Object.assign(store, { id: mockedGConsentGrant.id })),
+      ).toBe("http://example.org/another/requestorPerson");
+    });
+
+    it("supports alternate gc:isProvidedToController", async () => {
+      const store = new Store([...mockedGConsentGrant]);
+      const isProvidedToQuad = store
+        .match(null, gc.isProvidedTo, null, null)
+        .read();
+      if (isProvidedToQuad !== null) {
+        store.removeQuad(
+          isProvidedToQuad.subject,
+          isProvidedToQuad.predicate,
+          isProvidedToQuad.object,
+        );
+      }
+      store.addQuad(
+        getConsent(mockedGConsentGrant),
+        gc.isProvidedToController,
+        namedNode("http://example.org/another/requestorController"),
+      );
+
+      expect(
+        getRequestor(Object.assign(store, { id: mockedGConsentGrant.id })),
+      ).toBe("http://example.org/another/requestorController");
+    });
+
+    it("errors out if more than one alternate predicate is present", async () => {
+      const store = new Store([...mockedGConsentGrant]);
+      store.addQuad(
+        getConsent(mockedGConsentGrant),
+        gc.isProvidedToController,
+        namedNode("http://example.org/another/requestorController"),
+      );
+
+      store.addQuad(
+        getConsent(mockedGConsentGrant),
+        gc.isProvidedToPerson,
+        namedNode("http://example.org/another/requestorPerson"),
+      );
+
+      expect(() =>
+        getRequestor(Object.assign(store, { id: mockedGConsentGrant.id })),
+      ).toThrow("Too many requestors found.");
+    });
+
     it("errors if there are multiple consent objects", async () => {
       const store = new Store([...mockedGConsentGrant]);
 

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -295,8 +295,36 @@ export function getRequestor(vc: DatasetWithId): string {
 
   if (!providedConsent) return credentialSubject.value;
 
-  return getSingleObject(vc, providedConsent, gc.isProvidedTo, "NamedNode")
-    .value;
+  const supportedPredicates = [
+    gc.isProvidedTo,
+    gc.isProvidedToPerson,
+    gc.isProvidedToController,
+  ];
+  const candidateResults: Array<string> = [];
+  supportedPredicates.forEach((predicate) => {
+    const candidate = getSingleObject(
+      vc,
+      providedConsent,
+      predicate,
+      "NamedNode",
+      false,
+    );
+    if (candidate !== undefined) {
+      candidateResults.push(candidate.value);
+    }
+  });
+
+  if (candidateResults.length === 1) {
+    return candidateResults[0];
+  }
+
+  if (candidateResults.length > 1) {
+    throw new Error(
+      `Too many requestors found. Expected one, found ${candidateResults}`,
+    );
+  }
+
+  throw new Error(`No requestor found.`);
 }
 
 /**


### PR DESCRIPTION
The Access Grant data model allows three alternate predicates in their shape to link an Access Grant to the Agent being granted Access:
- gc:isProvidedTo
- gc:isProvidedToPerson
- gc:isProvidedToController

The latter two are now supported by the library.