### PR TITLE
Fix/base64url btoa dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The following changes are pending, and will be applied on the next major release
 
 ## Unreleased
 
+### Bugfixes
+
+- Removed base64url dependency due to potential issues with the browser environment.
+
 ## [3.0.4](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v3.0.4) - 2024-02-12
 
 ### Bugfixes

--- a/e2e/env/.env.example
+++ b/e2e/env/.env.example
@@ -23,7 +23,7 @@ E2E_TEST_REQUESTOR_CLIENT_SECRET=<client secret>
 E2E_TEST_OWNER_CLIENT_ID=<client id>
 E2E_TEST_OWNER_CLIENT_SECRET=<client secret>
 
-E2E_TEST_LOGIN=<a login for the UI tests>
+E2E_TEST_USER=<a login for the UI tests>
 E2E_TEST_PASSWORD=<a password for the UI tests>
 
 E2E_TEST_FEATURE_RECURSIVE_ACCESS_GRANTS=true

--- a/src/fetch/index.test.ts
+++ b/src/fetch/index.test.ts
@@ -26,7 +26,6 @@ import type {
 } from "@inrupt/solid-client-vc";
 import { verifiableCredentialToDataset } from "@inrupt/solid-client-vc";
 
-import base64url from "base64url";
 import {
   parseUMAAuthTicket,
   parseUMAAuthIri,
@@ -34,6 +33,7 @@ import {
   exchangeTicketForAccessToken,
   boundFetch,
   fetchWithVc,
+  isomorphicBtoa,
 } from "./index";
 
 const MOCK_VC_BASE = {
@@ -166,7 +166,7 @@ describe("exchangeTicketForAccessToken", () => {
         "Content-Type": "application/x-www-form-urlencoded",
       },
       body: new URLSearchParams({
-        claim_token: base64url.encode(
+        claim_token: isomorphicBtoa(
           JSON.stringify({
             "@context": [
               "https://www.w3.org/2018/credentials/v1",

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -18,8 +18,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
-import base64url from "base64url";
 import type { UrlString } from "@inrupt/solid-client";
 import type {
   DatasetWithId,
@@ -84,6 +82,16 @@ export async function getUmaConfiguration(
 }
 
 /**
+ * @hidden Internal utility isomorphic function to encode in base64.
+ */
+export function isomorphicBtoa(stringToEncode: string): string {
+  if (typeof window === "object") {
+    return btoa(stringToEncode);
+  }
+  return Buffer.from(stringToEncode).toString("base64");
+}
+
+/**
  * @hidden This is just an internal utility function to exchange a VC and ticket for an auth token.
  */
 export async function exchangeTicketForAccessToken(
@@ -103,7 +111,7 @@ export async function exchangeTicketForAccessToken(
       "Content-Type": "application/x-www-form-urlencoded",
     },
     body: new URLSearchParams({
-      claim_token: base64url.encode(JSON.stringify(credentialPresentation)),
+      claim_token: isomorphicBtoa(JSON.stringify(credentialPresentation)),
       claim_token_format: VC_CLAIM_TOKEN_TYPE,
       grant_type: UMA_GRANT_TYPE,
       ticket: authTicket,


### PR DESCRIPTION
# New feature description
Added new isomorphic function btoa to replace the base64url dependency of solid-client-access-grants. If the environment is a browser the global btoa function is invoked, Buffer is called otherwise.

# Checklist

- [ ] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).