### PR TITLE
issueAccessVc checks size of the resources array before grabbing a va…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The following changes are pending, and will be applied on the next major release
 ### Bugfixes
 
 - Removed base64url dependency due to potential issues with the browser environment.
+- Descriptive error shown when trying to create an access request/approve an access grant for no resources.
+- Comprehensive error shown when the issuer endpoint for an access grant/request can't be computed.
 
 ## [3.0.4](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v3.0.4) - 2024-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ The following changes are pending, and will be applied on the next major release
 ### Bugfixes
 
 - Removed base64url dependency due to potential issues with the browser environment.
-- Descriptive error shown when trying to create an access request/approve an access grant for no resources.
-- Comprehensive error shown when the issuer endpoint for an access grant/request can't be computed.
+- A descriptive error is now thrown when trying to create an access request/approve an access grant for no resources. Note that previously, such call may not have thrown, but it resulted in an Access Grant granting access to nothing, which would have caused confusion when trying to use it.
+- The error thrown when the issuer endpoint for an access grant/request cannot be computed is more comprehensive.
 
 ## [3.0.4](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v3.0.4) - 2024-02-12
 

--- a/src/gConsent/discover/getAccessApiEndpoint.ts
+++ b/src/gConsent/discover/getAccessApiEndpoint.ts
@@ -77,7 +77,7 @@ async function getAccessApiEndpoint(
     return await getAccessEndpointForResource(resource.toString());
   } catch (e: unknown) {
     throw new Error(
-      `Couldn't figure out the VC issuer from the resources: ${e}`,
+      `Couldn't figure out the Access Grant issuer from the resources: ${e}`,
     );
   }
 }

--- a/src/gConsent/discover/getAccessApiEndpoint.ts
+++ b/src/gConsent/discover/getAccessApiEndpoint.ts
@@ -73,8 +73,13 @@ async function getAccessApiEndpoint(
   if (options.accessEndpoint !== undefined) {
     return options.accessEndpoint.toString();
   }
-
-  return getAccessEndpointForResource(resource.toString());
+  try {
+    return await getAccessEndpointForResource(resource.toString());
+  } catch (e: unknown) {
+    throw new Error(
+      `Couldn't figure out the VC issuer from the resources: ${e}`,
+    );
+  }
 }
 
 export { getAccessApiEndpoint };

--- a/src/gConsent/util/issueAccessVc.ts
+++ b/src/gConsent/util/issueAccessVc.ts
@@ -33,7 +33,6 @@ import {
 } from "../constants";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import { getSessionFetch } from "../../common/util/getSessionFetch";
-import { getResources } from "../../common/getters";
 import type {
   AccessGrantBody,
   AccessRequestBody,

--- a/src/gConsent/util/issueAccessVc.ts
+++ b/src/gConsent/util/issueAccessVc.ts
@@ -191,10 +191,11 @@ export async function issueAccessVc(
   const fetcher = await getSessionFetch(options);
 
   const hasConsent = isBaseRequest(vcBody);
-  if (hasConsent) {
-    if (vcBody.credentialSubject.hasConsent.forPersonalData.length <= 0) {
-      throw new Error("There are no resources in the access request!");
-    }
+  if (
+    hasConsent &&
+    vcBody.credentialSubject.hasConsent.forPersonalData.length <= 0
+  ) {
+    throw new Error("There are no resources in the access request!");
   } else if (
     (vcBody as BaseGrantBody).credentialSubject.providedConsent.forPersonalData
       .length <= 0

--- a/src/gConsent/util/issueAccessVc.ts
+++ b/src/gConsent/util/issueAccessVc.ts
@@ -33,6 +33,7 @@ import {
 } from "../constants";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import { getSessionFetch } from "../../common/util/getSessionFetch";
+import { getResources } from "../../common/getters";
 import type {
   AccessGrantBody,
   AccessRequestBody,
@@ -197,6 +198,7 @@ export async function issueAccessVc(
   ) {
     throw new Error("There are no resources in the access request!");
   } else if (
+    !hasConsent &&
     (vcBody as BaseGrantBody).credentialSubject.providedConsent.forPersonalData
       .length <= 0
   ) {

--- a/src/gConsent/util/issueAccessVc.ts
+++ b/src/gConsent/util/issueAccessVc.ts
@@ -189,6 +189,19 @@ export async function issueAccessVc(
   } = {},
 ): Promise<DatasetWithId> {
   const fetcher = await getSessionFetch(options);
+
+  const hasConsent = isBaseRequest(vcBody);
+  if (hasConsent) {
+    if (vcBody.credentialSubject.hasConsent.forPersonalData.length <= 0) {
+      throw new Error("There are no resources in the access request!");
+    }
+  } else if (
+    (vcBody as BaseGrantBody).credentialSubject.providedConsent.forPersonalData
+      .length <= 0
+  ) {
+    throw new Error("There are no resources in the access grant!");
+  }
+
   const targetResourceIri = isBaseRequest(vcBody)
     ? vcBody.credentialSubject.hasConsent.forPersonalData[0]
     : (vcBody as BaseGrantBody).credentialSubject.providedConsent


### PR DESCRIPTION
`issueAccessVc` checks now the size of the resources array before grabbing a value from it, consequently showing a comprehensive error when no resources are linked to the access grant or request. 

Also, a comprehensive error is shown when no `accessEndpoint` is provided and hence its discovery fails.

This PR fixes #SDK-3041.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

