### PR TITLE
Fix for e2e blocking tests

### DIFF
--- a/e2e/browser/test/e2e.playwright.ts
+++ b/e2e/browser/test/e2e.playwright.ts
@@ -65,6 +65,10 @@ test("Redirect to AMC to accept Access Request", async ({
 
   // At this point, the user is already logged into the OpenID Provider.
   await clickOpenIdPrompt(page);
+  // select the first toggle purpose (all deselected by default)
+  await page.click('[data-testid="toggle-purpose"]');
+  // Select all modes (all deselected by default)
+  await page.getByTestId("select-all-modes-button").click();
   await page.getByTestId("confirm-access").click();
 
   // The test user confirms the access they selected and is redirected back to app


### PR DESCRIPTION
This PR fixes browser based e2e tests.
The tests for the approval of an access request were updated to be compliant with the changes that had been made to that page.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
