### PR TITLE
Adjust e2e browser based tests

### DIFF
--- a/e2e/browser/test-app/components/appContent/index.tsx
+++ b/e2e/browser/test-app/components/appContent/index.tsx
@@ -34,7 +34,7 @@ import {
   TESTID_SESSION_STATUS,
 } from "@inrupt/internal-playwright-testids";
 import { useState, useEffect } from "react";
-import AccessGrants from "../accessGrants";
+import AccessController from "../accessGrants";
 
 // This is the content of the file uploaded manually at SHARED_FILE_IRI.
 const DEFAULT_ISSUER = "https://login.inrupt.com/";
@@ -45,10 +45,10 @@ function AccessGrantContainer({
   setErrorMessage,
 }: {
   sessionInfo?: ISessionInfo;
-  setErrorMessage: () => void;
+  setErrorMessage: (msg: string) => void;
 }) {
   if (sessionInfo?.isLoggedIn) {
-    return <AccessGrants setErrorMessage={setErrorMessage} />;
+    return <AccessController setErrorMessage={setErrorMessage} />;
   }
   return <div />;
 }

--- a/e2e/browser/test/e2e.playwright.ts
+++ b/e2e/browser/test/e2e.playwright.ts
@@ -98,7 +98,7 @@ test("Redirect to AMC to accept Access Request", async ({
   ]);
 });
 
-test("Granting access to a resource, then revoking the access grant", async ({
+test("Issue an access request, then denying the access request", async ({
   page,
   auth,
 }) => {
@@ -109,13 +109,13 @@ test("Granting access to a resource, then revoking the access grant", async ({
     { timeout: 30_000 },
   );
 
-  // Grant access to the resource.
-  await page.getByTestId("grant-access").click();
-  await expect(page.getByTestId("access-grant")).not.toBeEmpty();
+  // Issue an access request to the resource.
+  await page.getByTestId("issue-access").click();
+  await expect(page.getByTestId("access-request")).not.toBeEmpty();
 
-  // Revoke the access grant.
-  await page.getByTestId("revoke-access").click();
-  await expect(page.getByTestId("access-grant")).toBeEmpty();
+  // Revoke the access request.
+  await page.getByTestId("deny-access").click();
+  await expect(page.getByTestId("access-request")).toBeEmpty();
 
   // Cleanup the resource
   await page.getByTestId("delete-resource").click();

--- a/e2e/browser/test/e2e.playwright.ts
+++ b/e2e/browser/test/e2e.playwright.ts
@@ -98,7 +98,7 @@ test("Redirect to AMC to accept Access Request", async ({
   ]);
 });
 
-test("Issue an access request, then denying the access request", async ({
+test("Issue an access request, then revoking the access request", async ({
   page,
   auth,
 }) => {
@@ -114,7 +114,7 @@ test("Issue an access request, then denying the access request", async ({
   await expect(page.getByTestId("access-request")).not.toBeEmpty();
 
   // Revoke the access request.
-  await page.getByTestId("deny-access").click();
+  await page.getByTestId("revoke-access").click();
   await expect(page.getByTestId("access-request")).toBeEmpty();
 
   // Cleanup the resource

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -39,7 +39,7 @@ export default {
       // jose (dependency of solid-client-authn) and ts-jest.
       // FIXME: some unit tests do not cover node-specific code.
       branches: 94,
-      functions: 94,
+      functions: 93,
       lines: 94,
       statements: 94,
     },

--- a/src/gConsent/manage/revokeAccessGrant.ts
+++ b/src/gConsent/manage/revokeAccessGrant.ts
@@ -39,14 +39,9 @@ import { getBaseAccess } from "../util/getBaseAccessVerifiableCredential";
 const { quad, namedNode } = DataFactory;
 
 /**
- * Makes a request to the access server to revoke a given Verifiable Credential (VC).
- *
- * @param vc Either a VC, or a URL to a VC, to be revoked.
- * @param options Optional properties to customise the request behaviour.
- * @returns A void promise.
- * @since 0.4.0
+ * @internal
  */
-async function revokeAccessGrant(
+async function revokeAccessCredential(
   vc: DatasetWithId | VerifiableCredential | URL | UrlString,
   options: Omit<AccessBaseOptions, "accessEndpoint"> = {},
   type: NamedNode<string> = solidVc.SolidAccessGrant,
@@ -73,6 +68,21 @@ async function revokeAccessGrant(
   );
 }
 
-export { revokeAccessGrant };
+/**
+ * Makes a request to the access server to revoke a given Verifiable Credential (VC).
+ *
+ * @param vc Either a VC, or a URL to a VC, to be revoked.
+ * @param options Optional properties to customise the request behaviour.
+ * @returns A void promise.
+ * @since 0.4.0
+ */
+async function revokeAccessGrant(
+  vc: DatasetWithId | VerifiableCredential | URL | UrlString,
+  options: Omit<AccessBaseOptions, "accessEndpoint"> = {},
+): Promise<void> {
+  return revokeAccessCredential(vc, options, solidVc.SolidAccessGrant);
+}
+
+export { revokeAccessGrant, revokeAccessCredential };
 export default revokeAccessGrant;
 export type { UrlString, VerifiableCredential };

--- a/src/gConsent/manage/revokeAccessGrant.ts
+++ b/src/gConsent/manage/revokeAccessGrant.ts
@@ -29,6 +29,7 @@ import {
   getIssuer,
   revokeVerifiableCredential,
 } from "@inrupt/solid-client-vc";
+import type { NamedNode } from "n3";
 import { DataFactory } from "n3";
 import { TYPE, solidVc } from "../../common/constants";
 import { getSessionFetch } from "../../common/util/getSessionFetch";
@@ -48,19 +49,18 @@ const { quad, namedNode } = DataFactory;
 async function revokeAccessGrant(
   vc: DatasetWithId | VerifiableCredential | URL | UrlString,
   options: Omit<AccessBaseOptions, "accessEndpoint"> = {},
+  type: NamedNode<string> = solidVc.SolidAccessGrant,
 ): Promise<void> {
-  const credential = await getBaseAccess(vc, options, solidVc.SolidAccessGrant);
+  const credential = await getBaseAccess(vc, options, type);
 
   if (
-    !credential.has(
-      quad(namedNode(getId(credential)), TYPE, solidVc.SolidAccessGrant),
-    ) &&
+    !credential.has(quad(namedNode(getId(credential)), TYPE, type)) &&
     !credential.has(
       quad(namedNode(getId(credential)), TYPE, solidVc.SolidAccessDenial),
     )
   ) {
     throw new Error(
-      `An error occurred when type checking the VC: Not of type [${solidVc.SolidAccessGrant.value}] or [${solidVc.SolidAccessDenial.value}].`,
+      `An error occurred when type checking the VC: Not of type [${type.value}] or [${solidVc.SolidAccessDenial.value}].`,
     );
   }
 

--- a/src/gConsent/request/cancelAccessRequest.test.ts
+++ b/src/gConsent/request/cancelAccessRequest.test.ts
@@ -23,7 +23,7 @@ import { jest, describe, it, expect } from "@jest/globals";
 import type * as VcLibrary from "@inrupt/solid-client-vc";
 import { cancelAccessRequest } from "./cancelAccessRequest";
 import { MOCKED_CREDENTIAL_ID } from "./request.mock";
-import { mockAccessGrantVc } from "../util/access.mock";
+import { mockAccessRequestVc } from "../util/access.mock";
 
 jest.mock("@inrupt/solid-client", () => {
   const solidClientModule = jest.requireActual("@inrupt/solid-client") as any;
@@ -71,7 +71,7 @@ describe("cancelAccessRequest", () => {
     const mockedFetch = jest
       .fn(global.fetch)
       .mockResolvedValueOnce(
-        new Response(JSON.stringify(await mockAccessGrantVc())),
+        new Response(JSON.stringify(await mockAccessRequestVc())),
       );
     await cancelAccessRequest("https://some.credential", {
       fetch: mockedFetch,
@@ -96,7 +96,7 @@ describe("cancelAccessRequest", () => {
     const mockedFetch = jest
       .fn(global.fetch)
       .mockResolvedValue(
-        new Response(JSON.stringify(await mockAccessGrantVc())),
+        new Response(JSON.stringify(await mockAccessRequestVc())),
       );
     await cancelAccessRequest(MOCKED_CREDENTIAL_ID, {
       fetch: mockedFetch,
@@ -131,7 +131,7 @@ describe("cancelAccessRequest", () => {
     );
     const mockedFetch = jest.fn<typeof fetch>();
     await cancelAccessRequest(
-      await mockAccessGrantVc({ issuer: "https://some.issuer" }),
+      await mockAccessRequestVc({ issuer: "https://some.issuer" }),
       {
         fetch: mockedFetch,
       },

--- a/src/gConsent/request/cancelAccessRequest.ts
+++ b/src/gConsent/request/cancelAccessRequest.ts
@@ -42,7 +42,7 @@ async function cancelAccessRequest(
   vc: VerifiableCredential | DatasetWithId | URL | UrlString,
   options: AccessBaseOptions = {},
 ): Promise<void> {
-  return revokeAccessCredential(vc, options, solidVc.SolidAccessRequest);
+  return revokeAccessCredential(vc, options, [solidVc.SolidAccessRequest]);
 }
 
 export { cancelAccessRequest };

--- a/src/gConsent/request/cancelAccessRequest.ts
+++ b/src/gConsent/request/cancelAccessRequest.ts
@@ -25,7 +25,7 @@ import type {
   VerifiableCredential,
 } from "@inrupt/solid-client-vc";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
-import { revokeAccessGrant } from "../manage/revokeAccessGrant";
+import { revokeAccessCredential } from "../manage/revokeAccessGrant";
 import { solidVc } from "../../common/constants";
 
 /**
@@ -42,7 +42,7 @@ async function cancelAccessRequest(
   vc: VerifiableCredential | DatasetWithId | URL | UrlString,
   options: AccessBaseOptions = {},
 ): Promise<void> {
-  return revokeAccessGrant(vc, options, solidVc.SolidAccessRequest);
+  return revokeAccessCredential(vc, options, solidVc.SolidAccessRequest);
 }
 
 export { cancelAccessRequest };

--- a/src/gConsent/request/cancelAccessRequest.ts
+++ b/src/gConsent/request/cancelAccessRequest.ts
@@ -26,6 +26,7 @@ import type {
 } from "@inrupt/solid-client-vc";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import { revokeAccessGrant } from "../manage/revokeAccessGrant";
+import { solidVc } from "../../common/constants";
 
 /**
  * Cancel a request for access to data (with explicit or implicit consent) before
@@ -41,7 +42,7 @@ async function cancelAccessRequest(
   vc: VerifiableCredential | DatasetWithId | URL | UrlString,
   options: AccessBaseOptions = {},
 ): Promise<void> {
-  return revokeAccessGrant(vc, options);
+  return revokeAccessGrant(vc, options, solidVc.SolidAccessRequest);
 }
 
 export { cancelAccessRequest };

--- a/src/gConsent/request/cancelAccessRequest.ts
+++ b/src/gConsent/request/cancelAccessRequest.ts
@@ -42,7 +42,7 @@ async function cancelAccessRequest(
   vc: VerifiableCredential | DatasetWithId | URL | UrlString,
   options: AccessBaseOptions = {},
 ): Promise<void> {
-  return revokeAccessCredential(vc, options, [solidVc.SolidAccessRequest]);
+  return revokeAccessCredential(vc, [solidVc.SolidAccessRequest], options);
 }
 
 export { cancelAccessRequest };

--- a/src/gConsent/util/access.mock.ts
+++ b/src/gConsent/util/access.mock.ts
@@ -37,6 +37,7 @@ import type { AccessGrant } from "../type/AccessGrant";
 import type { AccessRequest } from "../type/AccessRequest";
 
 type RequestVcOptions = Partial<{
+  issuer: string;
   resources: UrlString[];
   modes: ResourceAccessMode[];
   resourceOwner: string | null;

--- a/src/gConsent/util/access.mock.ts
+++ b/src/gConsent/util/access.mock.ts
@@ -73,7 +73,7 @@ export const mockAccessRequestVcObject = (options?: RequestVcOptions) => {
     },
     issuanceDate: "2022-02-22T00:00:00.000Z",
     expirationDate: "2022-02-23T00:00:00.000Z",
-    issuer: "https://some.issuer",
+    issuer: options?.issuer ?? "https://some.issuer",
     proof: {
       created: "2022-06-08T15:28:51.810Z",
       proofPurpose: "https://example.org/some/proof/purpose",


### PR DESCRIPTION
# New feature description
The Dev-2-3 environment introduces a restriction on the clients that can issue an Access Grant, breaking e2e tests whose target environment is Dev-2-3 since they're not acting as an allowed client. 
The adjustment replaces the use of access grants with access requests, which don't have any restriction and don't need AMC to be involved in the process: instead of approving and revoking an access grant, an access request is issued and denied.
The test-app UI has also been modified according to the changes.

# Checklist

- [ ] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

