### PR TITLE
Ignore major version updates to typedoc-plugin-markdown and eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,17 @@ updates:
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory.
     directory: "/"
-    # Check the npm registry for updates every day (weekdays).
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typedoc-plugin-markdown"
+        update-types: ["version-update:semver-major"]
   # Enable version updates for the website tooling.
   - package-ecosystem: "pip"
     # Look for `package.json` and `lock` files in the `root` directory.
     directory: "/docs"
-    # Check the npm registry for updates every day (weekdays).
     schedule:
       interval: "weekly"
   # Enable version updates for our CI tooling.
@@ -19,13 +22,11 @@ updates:
     # For GitHub Actions, setting the directory to / will check for workflow
     # files in .github/workflows.
     directory: "/"
-    # Check the npm registry for updates every day (weekdays).
     schedule:
       interval: "weekly"
   # Enable version updates for embedded demo app
   - package-ecosystem: "npm"
     # Look for `package.json` and `package-lock.json` files in the `e2e/browser/test-app` directory.
     directory: "/e2e/browser/test-app"
-    # Check the npm registry for updates every day (weekdays).
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The major version upgrades to the `eslint` and `typedoc-plugin-markdown` dependencies require some more significant refactors of the existing code. For now, these updates will be turned off to produce less dependabot noise.