### PR TITLE
SDK-3370: Support latest inrupt VC JSON-LD context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The following changes are pending, and will be applied on the next major release
 
 ## Unreleased
 
+### Patch change
+
+- Added support for the `https://schema.inrupt.com/credentials/v2.jsonld` JSON-LD context.
+
 ## [3.1.0](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v3.1.0) - 2024-09-16
 
 ### New Feature

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^2.0.0",
-        "@inrupt/solid-client-vc": "^1.0.3",
+        "@inrupt/solid-client-vc": "^1.1.2",
         "@types/rdfjs__dataset": "^2.0.7",
         "auth-header": "^1.0.0",
         "base64url": "^3.0.1",
@@ -1253,9 +1253,10 @@
       }
     },
     "node_modules/@inrupt/solid-client-vc": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-1.1.1.tgz",
-      "integrity": "sha512-Jn0yFbNrgg5RoBV91gr8muqqol9rciOPmPT4N6R57tinP8viXFXqv0sjLiYqPN91hcuxRXQ4cDWFQR7WSjMISw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-vc/-/solid-client-vc-1.1.2.tgz",
+      "integrity": "sha512-+wwf16IzbiRoLYBtEcrBz9pmvdW3oWmHp5k9fRPNZZwB27N78DRSM0ietvfO9XeIzqfiWTLO4N1gm5uSgpIxOA==",
+      "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^2.0.0",
         "@inrupt/solid-client-errors": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
   },
   "dependencies": {
     "@inrupt/solid-client": "^2.0.0",
-    "@inrupt/solid-client-vc": "^1.0.3",
+    "@inrupt/solid-client-vc": "^1.1.2",
     "@types/rdfjs__dataset": "^2.0.7",
     "auth-header": "^1.0.0",
     "base64url": "^3.0.1",


### PR DESCRIPTION
Added support for the `https://schema.inrupt.com/credentials/v2.jsonld` JSON-LD context.