### PR TITLE
Get custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,8 @@ The following changes are pending, and will be applied on the next major release
   into Access Credentials (both Access Requests and Access Grants). This feature is available
   via a new option introduced in `issueAccessRequest` and `approveAccessRequest` to write the
   custom fields, and via a set of dedicated getters in the `getters/` module. A generic getter
-  is introduced, `getCustomFields`, as well as a set of typed helpers, such as `getCustomInteger`
-  and `getCustomIntegers`. Typed helpers are available for integers, floats, strings and booleans,
-  with a scalar and array version of each.
+  is introduced, `getCustomFields`, as well as a set of typed helpers, such as `getCustomInteger`.
+  Typed helpers are available for integers, floats, strings and booleans.
 
 ## [3.1.1](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v3.1.1) - 2024-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The following changes are pending, and will be applied on the next major release
   custom fields, and via a set of dedicated getters in the `getters/` module. A generic getter
   is introduced, `getCustomFields`, as well as a set of typed helpers, such as `getCustomInteger`
   and `getCustomIntegers`. Typed helpers are available for integers, floats, strings and booleans,
-  with a scalar and array value for each.
+  with a scalar and array version of each.
 
 ## [3.1.1](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v3.1.1) - 2024-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ The following changes are pending, and will be applied on the next major release
 ### New feature (alpha)
 
 - Add support for custom fields. Applications are now able to read and write custom fields
-  into Access Credentials (both Access Requests and Access Grants).
+  into Access Credentials (both Access Requests and Access Grants). This feature is available
+  via a new option introduced in `issueAccessRequest` and `approveAccessRequest` to write the
+  custom fields, and via a set of dedicated getters in the `getters/` module. A generic getter
+  is introduced, `getCustomFields`, as well as a set of typed helpers, such as `getCustomInteger`
+  and `getCustomIntegers`. Typed helpers are available for integers, floats, strings and booleans,
+  with a scalar and array value for each.
 
 ## [3.1.1](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v3.1.1) - 2024-10-23
 

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -625,9 +625,10 @@ describe("getters", () => {
     });
 
     it("throws if more than one value is available", async () => {
-      const gConsentRequest = await mockGConsentRequest();
-      Object.assign(gConsentRequest.credentialSubject.hasConsent, {
-        "https://example.org/ns/customInt": [1, 2],
+      const gConsentRequest = await mockGConsentRequest({}, (r) => {
+        Object.assign(r.credentialSubject.hasConsent, {
+          "https://example.org/ns/customInt": [1, 2],
+        });
       });
       expect(() =>
         getCustomInteger(
@@ -704,9 +705,10 @@ describe("getters", () => {
     });
 
     it("throws if more than one value is available", async () => {
-      const gConsentRequest = await mockGConsentRequest();
-      Object.assign(gConsentRequest.credentialSubject.hasConsent, {
-        "https://example.org/ns/customBoolean": [true, false],
+      const gConsentRequest = await mockGConsentRequest({}, (r) => {
+        Object.assign(r.credentialSubject.hasConsent, {
+          "https://example.org/ns/customBoolean": [true, false],
+        });
       });
       expect(() =>
         getCustomBoolean(
@@ -783,9 +785,10 @@ describe("getters", () => {
     });
 
     it("throws if more than one value is available", async () => {
-      const gConsentRequest = await mockGConsentRequest();
-      Object.assign(gConsentRequest.credentialSubject.hasConsent, {
-        "https://example.org/ns/customFloat": [1.1, 2.2],
+      const gConsentRequest = await mockGConsentRequest({}, (r) => {
+        Object.assign(r.credentialSubject.hasConsent, {
+          "https://example.org/ns/customFloat": [1.1, 2.2],
+        });
       });
       expect(() =>
         getCustomFloat(
@@ -862,12 +865,13 @@ describe("getters", () => {
     });
 
     it("throws if more than one value is available", async () => {
-      const gConsentRequest = await mockGConsentRequest();
-      Object.assign(gConsentRequest.credentialSubject.hasConsent, {
-        "https://example.org/ns/customString": [
-          "some value",
-          "some other value",
-        ],
+      const gConsentRequest = await mockGConsentRequest({}, (r) => {
+        Object.assign(r.credentialSubject.hasConsent, {
+          "https://example.org/ns/customString": [
+            "some value",
+            "some other value",
+          ],
+        });
       });
       expect(() =>
         getCustomString(

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -47,10 +47,6 @@ import {
   getResources,
   getCustomString,
   getTypes,
-  getCustomIntegers,
-  getCustomBooleans,
-  getCustomFloats,
-  getCustomStrings,
 } from "./getters";
 import type { AccessGrant, AccessRequest } from "../gConsent";
 import { TYPE, gc } from "./constants";
@@ -564,22 +560,6 @@ describe("getters", () => {
           key: new URL("https://example.org/ns/customFloat"),
           value: 1.1,
         },
-        {
-          key: new URL("https://example.org/ns/customStringArray"),
-          value: ["customValue", "otherCustomValue"],
-        },
-        {
-          key: new URL("https://example.org/ns/customBooleanArray"),
-          value: [true, false],
-        },
-        {
-          key: new URL("https://example.org/ns/customIntArray"),
-          value: [1, 2],
-        },
-        {
-          key: new URL("https://example.org/ns/customFloatArray"),
-          value: [1.1, 2.2],
-        },
       ];
       const gConsentRequest = await mockGConsentRequest({
         custom: customFields,
@@ -589,322 +569,11 @@ describe("getters", () => {
         "https://example.org/ns/customBoolean": true,
         "https://example.org/ns/customInt": 1,
         "https://example.org/ns/customFloat": 1.1,
-        "https://example.org/ns/customStringArray": [
-          "customValue",
-          "otherCustomValue",
-        ],
-        "https://example.org/ns/customBooleanArray": [true, false],
-        "https://example.org/ns/customIntArray": [1, 2],
-        "https://example.org/ns/customFloatArray": [1.1, 2.2],
       });
     });
 
     it("returns an empty object if no custom fields are found", async () => {
       expect(getCustomFields(await mockGConsentRequest())).toStrictEqual({});
-    });
-
-    it("supports the custom fields being arrays of mixed types", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customField"),
-          value: "customValue",
-        },
-        {
-          key: new URL("https://example.org/ns/customField"),
-          value: true,
-        },
-        {
-          key: new URL("https://example.org/ns/customField"),
-          value: 1,
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
-      });
-      expect(getCustomFields(gConsentRequest)).toEqual({
-        "https://example.org/ns/customField": ["customValue", true, 1],
-      });
-    });
-  });
-
-  describe("getCustomIntegers", () => {
-    it("gets an integer array value from an access grant custom field", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customInt"),
-          value: [1],
-        },
-      ];
-      const gConsentRequest = await mockGConsentGrant({
-        custom: customFields,
-      });
-      // This shows the typing of the return is correct.
-      const i: number[] = getCustomIntegers(
-        gConsentRequest,
-        new URL("https://example.org/ns/customInt"),
-      );
-      expect(i).toEqual([1]);
-    });
-
-    it("does not collapse similar values", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customInt"),
-          value: [1, 1, 1],
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
-      });
-      // This shows the typing of the return is correct.
-      const i: number[] = getCustomIntegers(
-        gConsentRequest,
-        new URL("https://example.org/ns/customInt"),
-      );
-      expect(i).toEqual([1, 1, 1]);
-    });
-
-    it("throws on mixed types", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customInt"),
-          value: [1],
-        },
-        {
-          key: new URL("https://example.org/ns/customInt"),
-          value: "not an int",
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
-      });
-      expect(() =>
-        getCustomIntegers(
-          gConsentRequest,
-          new URL("https://example.org/ns/customInt"),
-        ),
-      ).toThrow();
-    });
-
-    it("gets an empty value from an access request without custom field", async () => {
-      const gConsentRequest = await mockGConsentRequest();
-      // This shows the typing of the return is correct.
-      const i: number[] = getCustomIntegers(
-        gConsentRequest,
-        new URL("https://example.org/ns/customInt"),
-      );
-      expect(i).toHaveLength(0);
-    });
-  });
-
-  describe("getCustomBooleans", () => {
-    it("gets a boolean array value from an access request custom field", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customBoolean"),
-          value: [true],
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
-      });
-      // This shows the typing of the return is correct.
-      const b: boolean[] = getCustomBooleans(
-        gConsentRequest,
-        new URL("https://example.org/ns/customBoolean"),
-      );
-      expect(b).toEqual([true]);
-    });
-
-    it("does not collapse similar values", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customBoolean"),
-          value: [true, true, true],
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
-      });
-      // This shows the typing of the return is correct.
-      const b: boolean[] = getCustomBooleans(
-        gConsentRequest,
-        new URL("https://example.org/ns/customBoolean"),
-      );
-      expect(b).toEqual([true, true, true]);
-    });
-
-    it("throws on mixed types", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customBoolean"),
-          value: true,
-        },
-        {
-          key: new URL("https://example.org/ns/customBoolean"),
-          value: "not a boolean",
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
-      });
-      expect(() =>
-        getCustomBooleans(
-          gConsentRequest,
-          new URL("https://example.org/ns/customBoolean"),
-        ),
-      ).toThrow();
-    });
-
-    it("gets an empty value from an access request without custom field", async () => {
-      const gConsentRequest = await mockGConsentRequest();
-      // This shows the typing of the return is correct.
-      const b: boolean[] = getCustomBooleans(
-        gConsentRequest,
-        new URL("https://example.org/ns/customBoolean"),
-      );
-      expect(b).toHaveLength(0);
-    });
-  });
-
-  describe("getCustomFloats", () => {
-    it("gets a float array value from an access request custom field", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customFloat"),
-          value: [1.1],
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
-      });
-      // This shows the typing of the return is correct.
-      const d: number[] = getCustomFloats(
-        gConsentRequest,
-        new URL("https://example.org/ns/customFloat"),
-      );
-      expect(d).toEqual([1.1]);
-    });
-
-    it("does not collapse similar values", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customFloat"),
-          value: [1.1, 1.1, 1.1],
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
-      });
-      // This shows the typing of the return is correct.
-      const d: number[] = getCustomFloats(
-        gConsentRequest,
-        new URL("https://example.org/ns/customFloat"),
-      );
-      expect(d).toEqual([1.1, 1.1, 1.1]);
-    });
-
-    it("throws on mixed types", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customFloat"),
-          value: 1.1,
-        },
-        {
-          key: new URL("https://example.org/ns/customFloat"),
-          value: "not a float",
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
-      });
-      expect(() =>
-        getCustomFloats(
-          gConsentRequest,
-          new URL("https://example.org/ns/customFloat"),
-        ),
-      ).toThrow();
-    });
-
-    it("gets an empty value from an access request without custom field", async () => {
-      const gConsentRequest = await mockGConsentRequest();
-      // This shows the typing of the return is correct.
-      const d: number[] = getCustomFloats(
-        gConsentRequest,
-        new URL("https://example.org/ns/customFloat"),
-      );
-      expect(d).toHaveLength(0);
-    });
-  });
-
-  describe("getCustomStrings", () => {
-    it("gets a string array value from an access request custom field", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customString"),
-          value: ["custom value"],
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
-      });
-      // This shows the typing of the return is correct.
-      const s: string[] = getCustomStrings(
-        gConsentRequest,
-        new URL("https://example.org/ns/customString"),
-      );
-      expect(s).toEqual(["custom value"]);
-    });
-
-    it("does not collapse similar values", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customString"),
-          value: ["some value", "some value", "some value"],
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
-      });
-      // This shows the typing of the return is correct.
-      const s: string[] = getCustomStrings(
-        gConsentRequest,
-        new URL("https://example.org/ns/customString"),
-      );
-      expect(s).toEqual(["some value", "some value", "some value"]);
-    });
-
-    it("throws on mixed types", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customString"),
-          value: "some value",
-        },
-        {
-          key: new URL("https://example.org/ns/customString"),
-          // Not a string
-          value: false,
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
-      });
-      expect(() =>
-        getCustomFloats(
-          gConsentRequest,
-          new URL("https://example.org/ns/customString"),
-        ),
-      ).toThrow();
-    });
-
-    it("gets an empty value from an access request without custom field", async () => {
-      const gConsentRequest = await mockGConsentRequest();
-      // This shows the typing of the return is correct.
-      const s: string[] = getCustomStrings(
-        gConsentRequest,
-        new URL("https://example.org/ns/customString"),
-      );
-      expect(s).toHaveLength(0);
     });
   });
 
@@ -956,14 +625,9 @@ describe("getters", () => {
     });
 
     it("throws if more than one value is available", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customInt"),
-          value: [1, 2],
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
+      const gConsentRequest = await mockGConsentRequest();
+      Object.assign(gConsentRequest.credentialSubject.hasConsent, {
+        "https://example.org/ns/customInt": [1, 2],
       });
       expect(() =>
         getCustomInteger(
@@ -1040,14 +704,9 @@ describe("getters", () => {
     });
 
     it("throws if more than one value is available", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customBoolean"),
-          value: [true, false],
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
+      const gConsentRequest = await mockGConsentRequest();
+      Object.assign(gConsentRequest.credentialSubject.hasConsent, {
+        "https://example.org/ns/customBoolean": [true, false],
       });
       expect(() =>
         getCustomBoolean(
@@ -1124,14 +783,9 @@ describe("getters", () => {
     });
 
     it("throws if more than one value is available", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customFloat"),
-          value: [1.1, 2.2],
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
+      const gConsentRequest = await mockGConsentRequest();
+      Object.assign(gConsentRequest.credentialSubject.hasConsent, {
+        "https://example.org/ns/customFloat": [1.1, 2.2],
       });
       expect(() =>
         getCustomFloat(
@@ -1208,14 +862,12 @@ describe("getters", () => {
     });
 
     it("throws if more than one value is available", async () => {
-      const customFields = [
-        {
-          key: new URL("https://example.org/ns/customString"),
-          value: ["some value", "some other value"],
-        },
-      ];
-      const gConsentRequest = await mockGConsentRequest({
-        custom: customFields,
+      const gConsentRequest = await mockGConsentRequest();
+      Object.assign(gConsentRequest.credentialSubject.hasConsent, {
+        "https://example.org/ns/customString": [
+          "some value",
+          "some other value",
+        ],
       });
       expect(() =>
         getCustomString(

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -628,14 +628,14 @@ describe("getters", () => {
   });
 
   describe("getCustomIntegers", () => {
-    it("gets an integer array value from an access request custom field", async () => {
+    it("gets an integer array value from an access grant custom field", async () => {
       const customFields = [
         {
           key: new URL("https://example.org/ns/customInt"),
           value: [1],
         },
       ];
-      const gConsentRequest = await mockGConsentRequest({
+      const gConsentRequest = await mockGConsentGrant({
         custom: customFields,
       });
       // This shows the typing of the return is correct.
@@ -716,6 +716,24 @@ describe("getters", () => {
       expect(b).toEqual([true]);
     });
 
+    it("does not collapse similar values", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customBoolean"),
+          value: [true, true, true],
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      // This shows the typing of the return is correct.
+      const b: boolean[] = getCustomBooleans(
+        gConsentRequest,
+        new URL("https://example.org/ns/customBoolean"),
+      );
+      expect(b).toEqual([true, true, true]);
+    });
+
     it("throws on mixed types", async () => {
       const customFields = [
         {
@@ -768,6 +786,24 @@ describe("getters", () => {
       expect(d).toEqual([1.1]);
     });
 
+    it("does not collapse similar values", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customFloat"),
+          value: [1.1, 1.1, 1.1],
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      // This shows the typing of the return is correct.
+      const d: number[] = getCustomDoubles(
+        gConsentRequest,
+        new URL("https://example.org/ns/customFloat"),
+      );
+      expect(d).toEqual([1.1, 1.1, 1.1]);
+    });
+
     it("throws on mixed types", async () => {
       const customFields = [
         {
@@ -818,6 +854,24 @@ describe("getters", () => {
         new URL("https://example.org/ns/customString"),
       );
       expect(s).toEqual(["custom value"]);
+    });
+
+    it("does not collapse similar values", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customString"),
+          value: ["some value", "some value", "some value"],
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      // This shows the typing of the return is correct.
+      const s: string[] = getCustomStrings(
+        gConsentRequest,
+        new URL("https://example.org/ns/customString"),
+      );
+      expect(s).toEqual(["some value", "some value", "some value"]);
     });
 
     it("throws on mixed types", async () => {

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -33,7 +33,7 @@ import {
   getConsent,
   getCredentialSubject,
   getCustomFields,
-  getCustomDouble,
+  getCustomFloat,
   getExpirationDate,
   getId,
   getInbox,
@@ -49,7 +49,7 @@ import {
   getTypes,
   getCustomIntegers,
   getCustomBooleans,
-  getCustomDoubles,
+  getCustomFloats,
   getCustomStrings,
 } from "./getters";
 import type { AccessGrant, AccessRequest } from "../gConsent";
@@ -767,11 +767,11 @@ describe("getters", () => {
     });
   });
 
-  describe("getCustomDoubles", () => {
-    it("gets a double array value from an access request custom field", async () => {
+  describe("getCustomFloats", () => {
+    it("gets a float array value from an access request custom field", async () => {
       const customFields = [
         {
-          key: new URL("https://example.org/ns/customDouble"),
+          key: new URL("https://example.org/ns/customFloat"),
           value: [1.1],
         },
       ];
@@ -779,9 +779,9 @@ describe("getters", () => {
         custom: customFields,
       });
       // This shows the typing of the return is correct.
-      const d: number[] = getCustomDoubles(
+      const d: number[] = getCustomFloats(
         gConsentRequest,
-        new URL("https://example.org/ns/customDouble"),
+        new URL("https://example.org/ns/customFloat"),
       );
       expect(d).toEqual([1.1]);
     });
@@ -797,7 +797,7 @@ describe("getters", () => {
         custom: customFields,
       });
       // This shows the typing of the return is correct.
-      const d: number[] = getCustomDoubles(
+      const d: number[] = getCustomFloats(
         gConsentRequest,
         new URL("https://example.org/ns/customFloat"),
       );
@@ -807,21 +807,21 @@ describe("getters", () => {
     it("throws on mixed types", async () => {
       const customFields = [
         {
-          key: new URL("https://example.org/ns/customDouble"),
+          key: new URL("https://example.org/ns/customFloat"),
           value: 1.1,
         },
         {
-          key: new URL("https://example.org/ns/customDouble"),
-          value: "not a double",
+          key: new URL("https://example.org/ns/customFloat"),
+          value: "not a float",
         },
       ];
       const gConsentRequest = await mockGConsentRequest({
         custom: customFields,
       });
       expect(() =>
-        getCustomDoubles(
+        getCustomFloats(
           gConsentRequest,
-          new URL("https://example.org/ns/customDouble"),
+          new URL("https://example.org/ns/customFloat"),
         ),
       ).toThrow();
     });
@@ -829,9 +829,9 @@ describe("getters", () => {
     it("gets an empty value from an access request without custom field", async () => {
       const gConsentRequest = await mockGConsentRequest();
       // This shows the typing of the return is correct.
-      const d: number[] = getCustomDoubles(
+      const d: number[] = getCustomFloats(
         gConsentRequest,
-        new URL("https://example.org/ns/customDouble"),
+        new URL("https://example.org/ns/customFloat"),
       );
       expect(d).toHaveLength(0);
     });
@@ -890,7 +890,7 @@ describe("getters", () => {
         custom: customFields,
       });
       expect(() =>
-        getCustomDoubles(
+        getCustomFloats(
           gConsentRequest,
           new URL("https://example.org/ns/customString"),
         ),
@@ -1076,11 +1076,11 @@ describe("getters", () => {
     });
   });
 
-  describe("getCustomDouble", () => {
-    it("gets a double value from an access request custom field", async () => {
+  describe("getCustomFloat", () => {
+    it("gets a float value from an access request custom field", async () => {
       const customFields = [
         {
-          key: new URL("https://example.org/ns/customDouble"),
+          key: new URL("https://example.org/ns/customFloat"),
           value: 1.1,
         },
       ];
@@ -1088,9 +1088,9 @@ describe("getters", () => {
         custom: customFields,
       });
       // This shows the typing of the return is correct.
-      const d: number | undefined = getCustomDouble(
+      const d: number | undefined = getCustomFloat(
         gConsentRequest,
-        new URL("https://example.org/ns/customDouble"),
+        new URL("https://example.org/ns/customFloat"),
       );
       expect(d).toBe(1.1);
     });
@@ -1098,7 +1098,7 @@ describe("getters", () => {
     it("returns undefined if no matching custom field is available", async () => {
       const customFields = [
         {
-          key: new URL("https://example.org/ns/customDouble"),
+          key: new URL("https://example.org/ns/customFloat"),
           value: true,
         },
       ];
@@ -1106,9 +1106,9 @@ describe("getters", () => {
         custom: customFields,
       });
       // This shows the typing of the return is correct.
-      const d: number | undefined = getCustomDouble(
+      const d: number | undefined = getCustomFloat(
         gConsentRequest,
-        new URL("https://example.org/ns/anotherCustomDouble"),
+        new URL("https://example.org/ns/anotherCustomFloat"),
       );
       expect(d).toBeUndefined();
     });
@@ -1116,9 +1116,9 @@ describe("getters", () => {
     it("returns undefined if no custom field is available", async () => {
       const gConsentRequest = await mockGConsentRequest();
       // This shows the typing of the return is correct.
-      const d: number | undefined = getCustomDouble(
+      const d: number | undefined = getCustomFloat(
         gConsentRequest,
-        new URL("https://example.org/ns/customDouble"),
+        new URL("https://example.org/ns/customFloat"),
       );
       expect(d).toBeUndefined();
     });
@@ -1126,7 +1126,7 @@ describe("getters", () => {
     it("throws if more than one value is available", async () => {
       const customFields = [
         {
-          key: new URL("https://example.org/ns/customDouble"),
+          key: new URL("https://example.org/ns/customFloat"),
           value: [1.1, 2.2],
         },
       ];
@@ -1134,9 +1134,9 @@ describe("getters", () => {
         custom: customFields,
       });
       expect(() =>
-        getCustomDouble(
+        getCustomFloat(
           gConsentRequest,
-          new URL("https://example.org/ns/customDouble"),
+          new URL("https://example.org/ns/customFloat"),
         ),
       ).toThrow();
     });
@@ -1144,17 +1144,17 @@ describe("getters", () => {
     it("throws on type mismatch", async () => {
       const customFields = [
         {
-          key: new URL("https://example.org/ns/customDouble"),
-          value: "not a double",
+          key: new URL("https://example.org/ns/customFloat"),
+          value: "not a float",
         },
       ];
       const gConsentRequest = await mockGConsentRequest({
         custom: customFields,
       });
       expect(() =>
-        getCustomDouble(
+        getCustomFloat(
           gConsentRequest,
-          new URL("https://example.org/ns/customDouble"),
+          new URL("https://example.org/ns/customFloat"),
         ),
       ).toThrow();
     });

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -646,6 +646,24 @@ describe("getters", () => {
       expect(i).toEqual([1]);
     });
 
+    it("does not collapse similar values", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customInt"),
+          value: [1, 1, 1],
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      // This shows the typing of the return is correct.
+      const i: number[] = getCustomIntegers(
+        gConsentRequest,
+        new URL("https://example.org/ns/customInt"),
+      );
+      expect(i).toEqual([1, 1, 1]);
+    });
+
     it("throws on mixed types", async () => {
       const customFields = [
         {

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -47,6 +47,7 @@ import {
   getResources,
   getCustomString,
   getTypes,
+  getCustomIntegers,
 } from "./getters";
 import type { AccessGrant, AccessRequest } from "../gConsent";
 import { TYPE, gc } from "./constants";
@@ -560,20 +561,81 @@ describe("getters", () => {
           key: new URL("https://example.org/ns/customFloat"),
           value: 1.1,
         },
+        {
+          key: new URL("https://example.org/ns/customStringArray"),
+          value: ["customValue", "otherCustomValue"],
+        },
+        {
+          key: new URL("https://example.org/ns/customBooleanArray"),
+          value: [true, false],
+        },
+        {
+          key: new URL("https://example.org/ns/customIntArray"),
+          value: [1, 2],
+        },
+        {
+          key: new URL("https://example.org/ns/customFloatArray"),
+          value: [1.1, 2.2],
+        },
       ];
       const gConsentRequest = await mockGConsentRequest({
         custom: customFields,
       });
-      expect(getCustomFields(gConsentRequest)).toStrictEqual({
+      expect(getCustomFields(gConsentRequest)).toEqual({
         "https://example.org/ns/customString": "customValue",
         "https://example.org/ns/customBoolean": true,
         "https://example.org/ns/customInt": 1,
         "https://example.org/ns/customFloat": 1.1,
+        "https://example.org/ns/customStringArray": [
+          "customValue",
+          "otherCustomValue",
+        ],
+        "https://example.org/ns/customBooleanArray": [true, false],
+        "https://example.org/ns/customIntArray": [1, 2],
+        "https://example.org/ns/customFloatArray": [1.1, 2.2],
       });
     });
 
     it("returns an empty object if no custom fields are found", async () => {
       expect(getCustomFields(await mockGConsentRequest())).toStrictEqual({});
+    });
+  });
+
+  describe("getCustomIntegers", () => {
+    it("gets an integer array value from an access request custom field", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customInt"),
+          value: [1],
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      // This shows the typing of the return is correct.
+      const i: number[] = getCustomIntegers(
+        gConsentRequest,
+        new URL("https://example.org/ns/customInt"),
+      );
+      expect(i).toEqual([1]);
+    });
+
+    it("gets an empty value from an access request without custom field", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customInt"),
+          value: [1],
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      // This shows the typing of the return is correct.
+      const i: number[] = getCustomIntegers(
+        gConsentRequest,
+        new URL("https://example.org/ns/customInt"),
+      );
+      expect(i).toEqual([1]);
     });
   });
 

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -48,6 +48,9 @@ import {
   getCustomString,
   getTypes,
   getCustomIntegers,
+  getCustomBooleans,
+  getCustomDoubles,
+  getCustomStrings,
 } from "./getters";
 import type { AccessGrant, AccessRequest } from "../gConsent";
 import { TYPE, gc } from "./constants";
@@ -673,6 +676,163 @@ describe("getters", () => {
         new URL("https://example.org/ns/customInt"),
       );
       expect(i).toHaveLength(0);
+    });
+  });
+
+  describe("getCustomBooleans", () => {
+    it("gets a boolean array value from an access request custom field", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customBoolean"),
+          value: [true],
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      // This shows the typing of the return is correct.
+      const b: boolean[] = getCustomBooleans(
+        gConsentRequest,
+        new URL("https://example.org/ns/customBoolean"),
+      );
+      expect(b).toEqual([true]);
+    });
+
+    it("throws on mixed types", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customBoolean"),
+          value: true,
+        },
+        {
+          key: new URL("https://example.org/ns/customBoolean"),
+          value: "not a boolean",
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      expect(() =>
+        getCustomBooleans(
+          gConsentRequest,
+          new URL("https://example.org/ns/customBoolean"),
+        ),
+      ).toThrow();
+    });
+
+    it("gets an empty value from an access request without custom field", async () => {
+      const gConsentRequest = await mockGConsentRequest();
+      // This shows the typing of the return is correct.
+      const b: boolean[] = getCustomBooleans(
+        gConsentRequest,
+        new URL("https://example.org/ns/customBoolean"),
+      );
+      expect(b).toHaveLength(0);
+    });
+  });
+
+  describe("getCustomDoubles", () => {
+    it("gets a double array value from an access request custom field", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customDouble"),
+          value: [1.1],
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      // This shows the typing of the return is correct.
+      const d: number[] = getCustomDoubles(
+        gConsentRequest,
+        new URL("https://example.org/ns/customDouble"),
+      );
+      expect(d).toEqual([1.1]);
+    });
+
+    it("throws on mixed types", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customDouble"),
+          value: 1.1,
+        },
+        {
+          key: new URL("https://example.org/ns/customDouble"),
+          value: "not a double",
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      expect(() =>
+        getCustomDoubles(
+          gConsentRequest,
+          new URL("https://example.org/ns/customDouble"),
+        ),
+      ).toThrow();
+    });
+
+    it("gets an empty value from an access request without custom field", async () => {
+      const gConsentRequest = await mockGConsentRequest();
+      // This shows the typing of the return is correct.
+      const d: number[] = getCustomDoubles(
+        gConsentRequest,
+        new URL("https://example.org/ns/customDouble"),
+      );
+      expect(d).toHaveLength(0);
+    });
+  });
+
+  describe("getCustomStrings", () => {
+    it("gets a string array value from an access request custom field", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customString"),
+          value: ["custom value"],
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      // This shows the typing of the return is correct.
+      const s: string[] = getCustomStrings(
+        gConsentRequest,
+        new URL("https://example.org/ns/customString"),
+      );
+      expect(s).toEqual(["custom value"]);
+    });
+
+    it("throws on mixed types", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customString"),
+          value: "some value",
+        },
+        {
+          key: new URL("https://example.org/ns/customString"),
+          // Not a string
+          value: false,
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      expect(() =>
+        getCustomDoubles(
+          gConsentRequest,
+          new URL("https://example.org/ns/customString"),
+        ),
+      ).toThrow();
+    });
+
+    it("gets an empty value from an access request without custom field", async () => {
+      const gConsentRequest = await mockGConsentRequest();
+      // This shows the typing of the return is correct.
+      const s: string[] = getCustomStrings(
+        gConsentRequest,
+        new URL("https://example.org/ns/customString"),
+      );
+      expect(s).toHaveLength(0);
     });
   });
 

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -778,6 +778,70 @@ describe("getters", () => {
       );
       expect(bool).toBe(true);
     });
+
+    it("returns undefined if no matching custom field is available", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customBoolean"),
+          value: true,
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      // This shows the typing of the return is correct.
+      const b: boolean | undefined = getCustomBoolean(
+        gConsentRequest,
+        new URL("https://example.org/ns/anotherCustomBoolean"),
+      );
+      expect(b).toBeUndefined();
+    });
+
+    it("returns undefined if no custom field is available", async () => {
+      const gConsentRequest = await mockGConsentRequest();
+      // This shows the typing of the return is correct.
+      const b: boolean | undefined = getCustomBoolean(
+        gConsentRequest,
+        new URL("https://example.org/ns/customBoolean"),
+      );
+      expect(b).toBeUndefined();
+    });
+
+    it("throws if more than one value is available", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customBoolean"),
+          value: [true, false],
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      expect(() =>
+        getCustomBoolean(
+          gConsentRequest,
+          new URL("https://example.org/ns/customBoolean"),
+        ),
+      ).toThrow();
+    });
+
+    it("throws on type mismatch", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customBoolean"),
+          value: "not a boolean",
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      expect(() =>
+        getCustomBoolean(
+          gConsentRequest,
+          new URL("https://example.org/ns/customBoolean"),
+        ),
+      ).toThrow();
+    });
   });
 
   describe("getCustomDouble", () => {
@@ -798,6 +862,70 @@ describe("getters", () => {
       );
       expect(d).toBe(1.1);
     });
+
+    it("returns undefined if no matching custom field is available", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customDouble"),
+          value: true,
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      // This shows the typing of the return is correct.
+      const d: number | undefined = getCustomDouble(
+        gConsentRequest,
+        new URL("https://example.org/ns/anotherCustomDouble"),
+      );
+      expect(d).toBeUndefined();
+    });
+
+    it("returns undefined if no custom field is available", async () => {
+      const gConsentRequest = await mockGConsentRequest();
+      // This shows the typing of the return is correct.
+      const d: number | undefined = getCustomDouble(
+        gConsentRequest,
+        new URL("https://example.org/ns/customDouble"),
+      );
+      expect(d).toBeUndefined();
+    });
+
+    it("throws if more than one value is available", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customDouble"),
+          value: [1.1, 2.2],
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      expect(() =>
+        getCustomDouble(
+          gConsentRequest,
+          new URL("https://example.org/ns/customDouble"),
+        ),
+      ).toThrow();
+    });
+
+    it("throws on type mismatch", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customDouble"),
+          value: "not a double",
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      expect(() =>
+        getCustomDouble(
+          gConsentRequest,
+          new URL("https://example.org/ns/customDouble"),
+        ),
+      ).toThrow();
+    });
   });
 
   describe("getCustomString", () => {
@@ -817,6 +945,71 @@ describe("getters", () => {
         new URL("https://example.org/ns/customString"),
       );
       expect(s).toBe("some value");
+    });
+
+    it("returns undefined if no matching custom field is available", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customString"),
+          value: true,
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      // This shows the typing of the return is correct.
+      const s: string | undefined = getCustomString(
+        gConsentRequest,
+        new URL("https://example.org/ns/anotherCustomString"),
+      );
+      expect(s).toBeUndefined();
+    });
+
+    it("returns undefined if no custom field is available", async () => {
+      const gConsentRequest = await mockGConsentRequest();
+      // This shows the typing of the return is correct.
+      const s: string | undefined = getCustomString(
+        gConsentRequest,
+        new URL("https://example.org/ns/customString"),
+      );
+      expect(s).toBeUndefined();
+    });
+
+    it("throws if more than one value is available", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customString"),
+          value: ["some value", "some other value"],
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      expect(() =>
+        getCustomString(
+          gConsentRequest,
+          new URL("https://example.org/ns/customString"),
+        ),
+      ).toThrow();
+    });
+
+    it("throws on type mismatch", async () => {
+      const customFields = [
+        {
+          key: new URL("https://example.org/ns/customString"),
+          // Not a string
+          value: false,
+        },
+      ];
+      const gConsentRequest = await mockGConsentRequest({
+        custom: customFields,
+      });
+      expect(() =>
+        getCustomString(
+          gConsentRequest,
+          new URL("https://example.org/ns/customString"),
+        ),
+      ).toThrow();
     });
   });
 

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -575,6 +575,15 @@ describe("getters", () => {
     it("returns an empty object if no custom fields are found", async () => {
       expect(getCustomFields(await mockGConsentRequest())).toStrictEqual({});
     });
+
+    it("throws on multiple values for a single key", async () => {
+      const gConsentRequest = await mockGConsentRequest({}, (r) => {
+        Object.assign(r.credentialSubject.hasConsent, {
+          "https://example.org/ns/customBoolean": [true, false],
+        });
+      });
+      expect(() => getCustomFields(gConsentRequest)).toThrow();
+    });
   });
 
   describe("getCustomInteger", () => {

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -790,7 +790,8 @@ export function getCustomString(
   return deserializeField(
     accessCredential,
     field,
-    (str: Literal) => str.value,
+    (str: Literal) =>
+      str.datatype.equals(xmlSchemaTypes.string) ? str.value : undefined,
     "string",
   );
 }

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -563,41 +563,6 @@ function deserializeField<T>(
 }
 
 /**
- * Reads the custom boolean array with the provided name in the consent section of the provided Access Credential.
- * Throws on type mismatch, and returns an empty array if no values are found.
- *
- * @example
- * ```
- * const accessRequest = await issueAccessRequest({...}, {
- *  ...,
- *  customFields: new Set([
- *     {
- *       key: new URL("https://example.org/ns/customBoolean"),
- *       value: [true, false, true],
- *     },
- *   ]),
- * });
- * // s is [true, false, true]
- * const s = getCustomBooleans(accessRequest, new URL("https://example.org/ns/customBoolean"));
- * ```
- *
- * @param accessCredential The Access Credential (Access Grant or Access Request)
- * @returns the custom boolean array field with the provided name
- * @since unreleased
- */
-export function getCustomBooleans(
-  accessCredential: DatasetWithId,
-  field: URL,
-): boolean[] {
-  return deserializeFields(
-    accessCredential,
-    field,
-    (b) => typeof b === "boolean",
-    "boolean",
-  );
-}
-
-/**
  * Reads the custom boolean value with the provided name in the consent section of the provided Access Credential.
  * Throws on type mismatch, and returns `undefined` if no values are found.
  *
@@ -629,41 +594,6 @@ export function getCustomBoolean(
     field,
     (b) => typeof b === "boolean",
     "boolean",
-  );
-}
-
-/**
- * Reads the custom float array with the provided name in the consent section of the provided Access Credential.
- * Throws on type mismatch, and returns an empty array if no values are found.
- *
- * @example
- * ```
- * const accessRequest = await issueAccessRequest({...}, {
- *  ...,
- *  customFields: new Set([
- *     {
- *       key: new URL("https://example.org/ns/customFloat"),
- *       value: [1.1, 2.2, 3.3],
- *     },
- *   ]),
- * });
- * // d is [1.1, 2.2, 3.3]
- * const d = getCustomFloats(accessRequest, new URL("https://example.org/ns/customFloat"));
- * ```
- *
- * @param accessCredential The Access Credential (Access Grant or Access Request)
- * @returns the custom float array field with the provided name
- * @since unreleased
- */
-export function getCustomFloats(
-  accessCredential: DatasetWithId,
-  field: URL,
-): number[] {
-  return deserializeFields(
-    accessCredential,
-    field,
-    (d: unknown): d is number => typeof d === "number" && !Number.isInteger(d),
-    "float",
   );
 }
 
@@ -703,41 +633,6 @@ export function getCustomFloat(
 }
 
 /**
- * Reads the custom integer array with the provided name in the consent section of the provided Access Credential.
- * Throws on type mismatch, and returns an empty array if no values are found.
- *
- * @example
- * ```
- * const accessRequest = await issueAccessRequest({...}, {
- *  ...,
- *  customFields: new Set([
- *     {
- *       key: new URL("https://example.org/ns/customInteger"),
- *       value: [1, 2, 3],
- *     },
- *   ]),
- * });
- * // i is [1, 2, 3]
- * const i = getCustomIntegers(accessRequest, new URL("https://example.org/ns/customInteger"));
- * ```
- *
- * @param accessCredential The Access Credential (Access Grant or Access Request)
- * @returns the custom integer array field with the provided name
- * @since unreleased
- */
-export function getCustomIntegers(
-  accessCredential: DatasetWithId,
-  field: URL,
-): number[] {
-  return deserializeFields(
-    accessCredential,
-    field,
-    (i: unknown): i is number => typeof i === "number" && Number.isInteger(i),
-    "integer",
-  );
-}
-
-/**
  * Reads the custom integer value with the provided name in the consent section of the provided Access Credential.
  * Throws on type mismatch, and returns `undefined` if no values are found.
  *
@@ -770,38 +665,6 @@ export function getCustomInteger(
     (i: unknown): i is number => typeof i === "number" && Number.isInteger(i),
     "integer",
   );
-}
-
-/**
- * Reads the custom string array with the provided name in the consent section of the provided Access Credential.
- * Throws on type mismatch, and returns an empty array if no values are found.
- *
- * @example
- * ```
- * const accessRequest = await issueAccessRequest({...}, {
- *  ...,
- *  customFields: new Set([
- *     {
- *       key: new URL("https://example.org/ns/customString"),
- *       value: ["custom value", "another value"],
- *     },
- *   ]),
- * });
- * // s is ["custom value", "another value"]
- * const s = getCustomStrings(accessRequest, new URL("https://example.org/ns/customString"));
- * ```
- *
- * @param accessCredential The Access Credential (Access Grant or Access Request)
- * @returns the custom string array field with the provided name
- * @since unreleased
- */
-export function getCustomStrings(accessCredential: DatasetWithId, field: URL): string[] {
-  return deserializeFields(
-    accessCredential,
-    field,
-    (s) => typeof s === "string",
-    "string",
-  );  
 }
 
 /**

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -448,7 +448,7 @@ function deserializeFields<T>(
   field: URL,
   deserializer: (value: Literal) => T | undefined,
   type: string,
-): NonNullable<T>[] {
+): T[] {
   return Array.from(
     vc.match(getConsent(vc), namedNode(field.href), null, defaultGraph()),
   )
@@ -469,8 +469,7 @@ function deserializeFields<T>(
         );
       }
       return result;
-      // FIXME why isn't TS happy about the filtering out of undefined?
-    }) as NonNullable<T>[];
+    });
 }
 
 function deserializeField<T>(

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -569,7 +569,7 @@ export function getCustomBooleans(
  * const s = getCustomBoolean(accessRequest, new URL("https://example.org/ns/customBoolean"));
  * ```
  *
- * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @param accessCredential The Access Credential (Access Grant or Access Request)
  * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
  * @since unreleased
  */
@@ -611,7 +611,7 @@ function deserizalizeDouble(serialized: Literal): number | undefined {
  * const d = getCustomDoubles(accessRequest, new URL("https://example.org/ns/customDouble"));
  * ```
  *
- * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @param accessCredential The Access Credential (Access Grant or Access Request)
  * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
  * @since unreleased
  */
@@ -645,7 +645,7 @@ export function getCustomDoubles(
  * const d = getCustomDouble(accessRequest, new URL("https://example.org/ns/customDouble"));
  * ```
  *
- * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @param accessCredential The Access Credential (Access Grant or Access Request)
  * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
  * @since unreleased
  */
@@ -687,7 +687,7 @@ function deserizalizeInteger(serialized: Literal): number | undefined {
  * const i = getCustomIntegers(accessRequest, new URL("https://example.org/ns/customInteger"));
  * ```
  *
- * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @param accessCredential The Access Credential (Access Grant or Access Request)
  * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
  * @since unreleased
  */
@@ -721,7 +721,7 @@ export function getCustomIntegers(
  * const i = getCustomString(accessRequest, new URL("https://example.org/ns/customInteger"));
  * ```
  *
- * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @param accessCredential The Access Credential (Access Grant or Access Request)
  * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
  * @since unreleased
  */
@@ -755,7 +755,7 @@ export function getCustomInteger(
  * const s = getCustomStrings(accessRequest, new URL("https://example.org/ns/customString"));
  * ```
  *
- * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @param accessCredential The Access Credential (Access Grant or Access Request)
  * @returns the value of the custom field with the provided name if it is a string, undefined otherwise.
  * @since unreleased
  */
@@ -781,7 +781,7 @@ export function getCustomStrings(vc: DatasetWithId, field: URL): string[] {
  * const s = getCustomString(accessRequest, new URL("https://example.org/ns/customString"));
  * ```
  *
- * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @param accessCredential The Access Credential (Access Grant or Access Request)
  * @returns the value of the custom field with the provided name if it is a string, undefined otherwise.
  * @since unreleased
  */
@@ -843,7 +843,7 @@ const WELL_KNOWN_KEYS = [
  * const i = customFields["https://example.org/ns/custominteger"];
  * ```
  *
- * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @param accessCredential The Access Credential (Access Grant or Access Request)
  * @returns an object keyed by the custom fields names, associated to their values.
  * @since unreleased
  */

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -455,7 +455,7 @@ function deserializeFields<T>(
     .map((q) => {
       if (q.object.termType !== "Literal") {
         throw new Error(
-          `Expected value object for predicate ${field.href} to be a litteral, found ${q.object.termType}.`,
+          `Expected value object for predicate ${field.href} to be a literal, found ${q.object.termType}.`,
         );
       }
       return q.object as Literal;

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -630,7 +630,7 @@ export function getCustomBoolean(
 }
 
 /**
- * Reads the custom double array value with the provided name in the consent section of the provided Access Credential.
+ * Reads the custom float array value with the provided name in the consent section of the provided Access Credential.
  *
  * @example
  * ```
@@ -638,20 +638,20 @@ export function getCustomBoolean(
  *  ...,
  *  customFields: new Set([
  *     {
- *       key: new URL("https://example.org/ns/customDouble"),
+ *       key: new URL("https://example.org/ns/customFloat"),
  *       value: [1.1, 2.2, 3.3],
  *     },
  *   ]),
  * });
  * // d is [1.1, 2.2, 3.3]
- * const d = getCustomDoubles(accessRequest, new URL("https://example.org/ns/customDouble"));
+ * const d = getCustomFloats(accessRequest, new URL("https://example.org/ns/customFloat"));
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)
  * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
  * @since unreleased
  */
-export function getCustomDoubles(
+export function getCustomFloats(
   accessCredential: DatasetWithId,
   field: URL,
 ): number[] {
@@ -659,12 +659,12 @@ export function getCustomDoubles(
     accessCredential,
     field,
     (d: unknown): d is number => typeof d === "number" && !Number.isInteger(d),
-    "double",
+    "float",
   );
 }
 
 /**
- * Reads the custom double value with the provided name in the consent section of the provided Access Credential.
+ * Reads the custom float value with the provided name in the consent section of the provided Access Credential.
  *
  * @example
  * ```
@@ -672,20 +672,20 @@ export function getCustomDoubles(
  *  ...,
  *  customFields: new Set([
  *     {
- *       key: new URL("https://example.org/ns/customDouble"),
+ *       key: new URL("https://example.org/ns/customFloat"),
  *       value: 1.1,
  *     },
  *   ]),
  * });
  * // d is 1.1
- * const d = getCustomDouble(accessRequest, new URL("https://example.org/ns/customDouble"));
+ * const d = getCustomFloat(accessRequest, new URL("https://example.org/ns/customFloat"));
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)
  * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
  * @since unreleased
  */
-export function getCustomDouble(
+export function getCustomFloat(
   accessCredential: DatasetWithId,
   field: URL,
 ): number | undefined {
@@ -693,7 +693,7 @@ export function getCustomDouble(
     accessCredential,
     field,
     (d: unknown): d is number => typeof d === "number" && !Number.isInteger(d),
-    "double",
+    "float",
   );
 }
 

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -850,20 +850,23 @@ export function getCustomFields(
   accessCredential: DatasetWithId,
 ): Record<string, unknown> {
   const credentialObject = JSON.parse(JSON.stringify(accessCredential));
-  let consent: unknown;
+  let consent;
   if (isAccessGrant(credentialObject)) {
     consent = (credentialObject as AccessGrant).credentialSubject
       .providedConsent;
   } else if (isAccessRequest(credentialObject)) {
     consent = (credentialObject as AccessRequest).credentialSubject.hasConsent;
   }
-  const customFields = JSON.parse(
-    JSON.stringify(consent, (k, v) =>
+  return (
+    Object.entries(consent ?? {})
       // Filter out all well-known keys
-      WELL_KNOWN_KEYS.includes(k) ? undefined : v,
-    ),
+      .filter((entry) => !WELL_KNOWN_KEYS.includes(entry[0]))
+      .reduce(
+        (customFields, curEntry) =>
+          Object.assign(customFields, { [`${curEntry[0]}`]: curEntry[1] }),
+        {},
+      )
   );
-  return customFields;
 }
 
 /**

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -582,7 +582,7 @@ function deserializeField<T>(
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)
- * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
+ * @returns the custom boolean array field with the provided name
  * @since unreleased
  */
 export function getCustomBooleans(
@@ -617,7 +617,7 @@ export function getCustomBooleans(
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)
- * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
+ * @returns the custom boolean field with the provided name
  * @since unreleased
  */
 export function getCustomBoolean(
@@ -652,7 +652,7 @@ export function getCustomBoolean(
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)
- * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
+ * @returns the custom float array field with the provided name
  * @since unreleased
  */
 export function getCustomFloats(
@@ -687,7 +687,7 @@ export function getCustomFloats(
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)
- * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
+ * @returns the custom float field with the provided name
  * @since unreleased
  */
 export function getCustomFloat(
@@ -722,7 +722,7 @@ export function getCustomFloat(
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)
- * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
+ * @returns the custom integer array field with the provided name
  * @since unreleased
  */
 export function getCustomIntegers(
@@ -757,7 +757,7 @@ export function getCustomIntegers(
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)
- * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
+ * @returns the custom integer field with the provided name
  * @since unreleased
  */
 export function getCustomInteger(
@@ -792,7 +792,7 @@ export function getCustomInteger(
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)
- * @returns the value of the custom field with the provided name if it is a string, undefined otherwise.
+ * @returns the custom string array field with the provided name
  * @since unreleased
  */
 export function getCustomStrings(vc: DatasetWithId, field: URL): string[] {
@@ -819,7 +819,7 @@ export function getCustomStrings(vc: DatasetWithId, field: URL): string[] {
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)
- * @returns the value of the custom field with the provided name if it is a string, undefined otherwise.
+ * @returns the custom string field with the provided name
  * @since unreleased
  */
 export function getCustomString(

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -34,15 +34,9 @@ import type {
   Term,
 } from "@rdfjs/types";
 import { DataFactory } from "n3";
-import type {
-  AccessGrant,
-  AccessGrantGConsent,
-} from "../gConsent/type/AccessGrant";
+import type { AccessGrantGConsent } from "../gConsent/type/AccessGrant";
 import type { AccessModes } from "../type/AccessModes";
 import { INHERIT, TYPE, XSD_BOOLEAN, acl, gc, ldp } from "./constants";
-import { isAccessGrant } from "../gConsent/guard/isAccessGrant";
-import { isAccessRequest } from "../gConsent/guard/isAccessRequest";
-import type { AccessRequest } from "../gConsent";
 
 const { namedNode, defaultGraph, quad, literal } = DataFactory;
 

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -518,8 +518,8 @@ export function getCustomFields(
 
 /**
  * Internal function. Deserializes a literal using the provided function.
- * If the literal cannot be deserialized as expected (e.g. a string attempted
- * to be deserialized as an integer), an error is thrown.
+ * If the literal cannot be deserialized as expected (e.g. an attempt to
+ * deserialize a string as an integer), an error is thrown.
  *
  * @hidden
  */
@@ -578,7 +578,7 @@ function deserializeField<T>(
  *   ]),
  * });
  * // s is [true, false, true]
- * const s = getCustomBoolean(accessRequest, new URL("https://example.org/ns/customBoolean"));
+ * const s = getCustomBooleans(accessRequest, new URL("https://example.org/ns/customBoolean"));
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)
@@ -753,7 +753,7 @@ export function getCustomIntegers(
  *   ]),
  * });
  * // i is 1
- * const i = getCustomString(accessRequest, new URL("https://example.org/ns/customInteger"));
+ * const i = getCustomInteger(accessRequest, new URL("https://example.org/ns/customInteger"));
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)
@@ -795,8 +795,13 @@ export function getCustomInteger(
  * @returns the custom string array field with the provided name
  * @since unreleased
  */
-export function getCustomStrings(vc: DatasetWithId, field: URL): string[] {
-  return deserializeFields(vc, field, (s) => typeof s === "string", "string");
+export function getCustomStrings(accessCredential: DatasetWithId, field: URL): string[] {
+  return deserializeFields(
+    accessCredential,
+    field,
+    (s) => typeof s === "string",
+    "string",
+  );  
 }
 
 /**

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -44,8 +44,6 @@ import { isAccessGrant } from "../gConsent/guard/isAccessGrant";
 import { isAccessRequest } from "../gConsent/guard/isAccessRequest";
 import type { AccessRequest } from "../gConsent";
 
-src / type / CustomFields.ts;
-
 const { namedNode, defaultGraph, quad, literal } = DataFactory;
 
 /**

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -465,7 +465,7 @@ function deserializeFields<T>(
       if (result === undefined) {
         // FIXME use inrupt error library
         throw new Error(
-          `Error deserializing value ${object} for predicate ${field.href} as type ${type}.`,
+          `Failed to deserialize value ${object.value} for predicate ${field.href} as type ${type}.`,
         );
       }
       return result;

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -523,8 +523,8 @@ function deserializeBoolean(serialized: Literal): boolean | undefined {
  *     },
  *   ]),
  * });
- * // s is true
- * const s = getCustomBoolean(accessRequest, new URL("https://example.org/ns/customBoolean"));
+ * // b is true
+ * const b = getCustomBoolean(accessRequest, new URL("https://example.org/ns/customBoolean"));
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)
@@ -566,8 +566,8 @@ function deserizalizeDouble(serialized: Literal): number | undefined {
  *     },
  *   ]),
  * });
- * // d is 1.1
- * const d = getCustomFloat(accessRequest, new URL("https://example.org/ns/customFloat"));
+ * // f is 1.1
+ * const f = getCustomFloat(accessRequest, new URL("https://example.org/ns/customFloat"));
  * ```
  *
  * @param accessCredential The Access Credential (Access Grant or Access Request)

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -44,6 +44,8 @@ import { isAccessGrant } from "../gConsent/guard/isAccessGrant";
 import { isAccessRequest } from "../gConsent/guard/isAccessRequest";
 import type { AccessRequest } from "../gConsent";
 
+src / type / CustomFields.ts;
+
 const { namedNode, defaultGraph, quad, literal } = DataFactory;
 
 /**
@@ -533,12 +535,20 @@ function deserializeBoolean(serialized: Literal): boolean | undefined {
  * const s = getCustomBoolean(accessRequest, new URL("https://example.org/ns/customBoolean"));
  * ```
  *
- * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @param accessCredential The Access Credential (Access Grant or Access Request)
  * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
  * @since unreleased
  */
-export function getCustomBooleans(vc: DatasetWithId, field: URL): boolean[] {
-  return deserializeFields(vc, field, deserializeBoolean, "boolean");
+export function getCustomBooleans(
+  accessCredential: DatasetWithId,
+  field: URL,
+): boolean[] {
+  return deserializeFields(
+    accessCredential,
+    field,
+    deserializeBoolean,
+    "boolean",
+  );
 }
 
 /**
@@ -564,10 +574,15 @@ export function getCustomBooleans(vc: DatasetWithId, field: URL): boolean[] {
  * @since unreleased
  */
 export function getCustomBoolean(
-  vc: DatasetWithId,
+  accessCredential: DatasetWithId,
   field: URL,
 ): boolean | undefined {
-  return deserializeField(vc, field, deserializeBoolean, "boolean");
+  return deserializeField(
+    accessCredential,
+    field,
+    deserializeBoolean,
+    "boolean",
+  );
 }
 
 function deserizalizeDouble(serialized: Literal): number | undefined {
@@ -600,8 +615,16 @@ function deserizalizeDouble(serialized: Literal): number | undefined {
  * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
  * @since unreleased
  */
-export function getCustomDoubles(vc: DatasetWithId, field: URL): number[] {
-  return deserializeFields(vc, field, deserizalizeDouble, "double");
+export function getCustomDoubles(
+  accessCredential: DatasetWithId,
+  field: URL,
+): number[] {
+  return deserializeFields(
+    accessCredential,
+    field,
+    deserizalizeDouble,
+    "double",
+  );
 }
 
 /**
@@ -627,10 +650,15 @@ export function getCustomDoubles(vc: DatasetWithId, field: URL): number[] {
  * @since unreleased
  */
 export function getCustomDouble(
-  vc: DatasetWithId,
+  accessCredential: DatasetWithId,
   field: URL,
 ): number | undefined {
-  return deserializeField(vc, field, deserizalizeDouble, "double");
+  return deserializeField(
+    accessCredential,
+    field,
+    deserizalizeDouble,
+    "double",
+  );
 }
 
 function deserizalizeInteger(serialized: Literal): number | undefined {
@@ -663,8 +691,16 @@ function deserizalizeInteger(serialized: Literal): number | undefined {
  * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
  * @since unreleased
  */
-export function getCustomIntegers(vc: DatasetWithId, field: URL): number[] {
-  return deserializeFields(vc, field, deserizalizeInteger, "integer");
+export function getCustomIntegers(
+  accessCredential: DatasetWithId,
+  field: URL,
+): number[] {
+  return deserializeFields(
+    accessCredential,
+    field,
+    deserizalizeInteger,
+    "integer",
+  );
 }
 
 /**
@@ -690,10 +726,15 @@ export function getCustomIntegers(vc: DatasetWithId, field: URL): number[] {
  * @since unreleased
  */
 export function getCustomInteger(
-  vc: DatasetWithId,
+  accessCredential: DatasetWithId,
   field: URL,
 ): number | undefined {
-  return deserializeField(vc, field, deserizalizeInteger, "integer");
+  return deserializeField(
+    accessCredential,
+    field,
+    deserizalizeInteger,
+    "integer",
+  );
 }
 
 /**
@@ -745,10 +786,15 @@ export function getCustomStrings(vc: DatasetWithId, field: URL): string[] {
  * @since unreleased
  */
 export function getCustomString(
-  vc: DatasetWithId,
+  accessCredential: DatasetWithId,
   field: URL,
 ): string | undefined {
-  return deserializeField(vc, field, (str: Literal) => str.value, "string");
+  return deserializeField(
+    accessCredential,
+    field,
+    (str: Literal) => str.value,
+    "string",
+  );
 }
 
 const WELL_KNOWN_KEYS = [

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -465,6 +465,7 @@ const WELL_KNOWN_KEYS = [
 
 /**
  * Reads all the custom fields in the consent section of the provided Access Credential.
+ * An empty object will be returned if no custom fields are found.
  *
  * @example
  * ```
@@ -562,7 +563,8 @@ function deserializeField<T>(
 }
 
 /**
- * Reads the custom boolean value with the provided name in the consent section of the provided Access Credential.
+ * Reads the custom boolean array with the provided name in the consent section of the provided Access Credential.
+ * Throws on type mismatch, and returns an empty array if no values are found.
  *
  * @example
  * ```
@@ -596,7 +598,8 @@ export function getCustomBooleans(
 }
 
 /**
- * Reads the custom boolean array value with the provided name in the consent section of the provided Access Credential.
+ * Reads the custom boolean value with the provided name in the consent section of the provided Access Credential.
+ * Throws on type mismatch, and returns `undefined` if no values are found.
  *
  * @example
  * ```
@@ -630,7 +633,8 @@ export function getCustomBoolean(
 }
 
 /**
- * Reads the custom float array value with the provided name in the consent section of the provided Access Credential.
+ * Reads the custom float array with the provided name in the consent section of the provided Access Credential.
+ * Throws on type mismatch, and returns an empty array if no values are found.
  *
  * @example
  * ```
@@ -665,6 +669,7 @@ export function getCustomFloats(
 
 /**
  * Reads the custom float value with the provided name in the consent section of the provided Access Credential.
+ * Throws on type mismatch, and returns `undefined` if no values are found.
  *
  * @example
  * ```
@@ -698,7 +703,8 @@ export function getCustomFloat(
 }
 
 /**
- * Reads the custom integer array value with the provided name in the consent section of the provided Access Credential.
+ * Reads the custom integer array with the provided name in the consent section of the provided Access Credential.
+ * Throws on type mismatch, and returns an empty array if no values are found.
  *
  * @example
  * ```
@@ -733,6 +739,7 @@ export function getCustomIntegers(
 
 /**
  * Reads the custom integer value with the provided name in the consent section of the provided Access Credential.
+ * Throws on type mismatch, and returns `undefined` if no values are found.
  *
  * @example
  * ```
@@ -766,7 +773,8 @@ export function getCustomInteger(
 }
 
 /**
- * Reads the custom string array value with the provided name in the consent section of the provided Access Credential.
+ * Reads the custom string array with the provided name in the consent section of the provided Access Credential.
+ * Throws on type mismatch, and returns an empty array if no values are found.
  *
  * @example
  * ```
@@ -793,6 +801,7 @@ export function getCustomStrings(vc: DatasetWithId, field: URL): string[] {
 
 /**
  * Reads the custom string value with the provided name in the consent section of the provided Access Credential.
+ * Throws on type mismatch, and returns `undefined` if no values are found.
  *
  * @example
  * ```

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -543,7 +543,7 @@ export function getCustomBoolean(
   );
 }
 
-function deserizalizeDouble(serialized: Literal): number | undefined {
+function deserializeFloat(serialized: Literal): number | undefined {
   if (!serialized.datatype.equals(xmlSchemaTypes.double)) {
     return undefined;
   }
@@ -578,10 +578,10 @@ export function getCustomFloat(
   accessCredential: DatasetWithId,
   field: URL,
 ): number | undefined {
-  return deserializeField(accessCredential, field, deserizalizeDouble, "float");
+  return deserializeField(accessCredential, field, deserializeFloat, "float");
 }
 
-function deserizalizeInteger(serialized: Literal): number | undefined {
+function deserializeInteger(serialized: Literal): number | undefined {
   if (!serialized.datatype.equals(xmlSchemaTypes.integer)) {
     return undefined;
   }
@@ -619,7 +619,7 @@ export function getCustomInteger(
   return deserializeField(
     accessCredential,
     field,
-    deserizalizeInteger,
+    deserializeInteger,
     "integer",
   );
 }
@@ -665,10 +665,10 @@ function castLiteral(lit: Literal): unknown {
     return deserializeBoolean(lit);
   }
   if (lit.datatype.equals(xmlSchemaTypes.double)) {
-    return deserizalizeDouble(lit);
+    return deserializeFloat(lit);
   }
   if (lit.datatype.equals(xmlSchemaTypes.integer)) {
-    return deserizalizeInteger(lit);
+    return deserializeInteger(lit);
   }
   if (lit.datatype.equals(xmlSchemaTypes.string)) {
     return lit.value;

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -34,9 +34,15 @@ import type {
   Term,
 } from "@rdfjs/types";
 import { DataFactory } from "n3";
-import type { AccessGrantGConsent } from "../gConsent/type/AccessGrant";
+import type {
+  AccessGrant,
+  AccessGrantGConsent,
+} from "../gConsent/type/AccessGrant";
 import type { AccessModes } from "../type/AccessModes";
 import { INHERIT, TYPE, XSD_BOOLEAN, acl, gc, ldp } from "./constants";
+import { isAccessGrant } from "../gConsent/guard/isAccessGrant";
+import { isAccessRequest } from "../gConsent/guard/isAccessRequest";
+import type { AccessRequest } from "../gConsent";
 
 const { namedNode, defaultGraph, quad, literal } = DataFactory;
 
@@ -210,345 +216,6 @@ export function getPurposes(vc: DatasetWithId): string[] {
   }
 
   return purposes;
-}
-
-function deserializeFields<T>(
-  vc: DatasetWithId,
-  field: URL,
-  deserializer: (value: string) => T,
-): NonNullable<T>[] {
-  return Array.from(
-    vc.match(getConsent(vc), namedNode(field.href), null, defaultGraph()),
-  )
-    .map((q) => q.object.value)
-    .map(deserializer)
-    .filter((candidate) => candidate !== undefined) as NonNullable<T>[];
-}
-
-function deserializeBoolean(serialized: string): boolean | undefined {
-  if (serialized === "true") {
-    return true;
-  }
-  if (serialized === "false") {
-    return false;
-  }
-  return undefined;
-}
-
-/**
- * Reads the custom boolean value with the provided name in the consent section of the provided Access Credential.
- *
- * @example
- * ```
- * const accessRequest = await issueAccessRequest({...}, {
- *  ...,
- *  customFields: new Set([
- *     {
- *       key: new URL("https://example.org/ns/customBoolean"),
- *       value: [true, false, true],
- *     },
- *   ]),
- * });
- * // s is [true, false, true]
- * const s = getCustomBoolean(accessRequest, new URL("https://example.org/ns/customBoolean"));
- * ```
- *
- * @param accessCredential The Access Credential (Access Grant or Access request)
- * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
- * @since unreleased
- */
-export function getCustomBooleans(vc: DatasetWithId, field: URL): boolean[] {
-  return deserializeFields(vc, field, deserializeBoolean);
-}
-
-/**
- * Reads the custom boolean array value with the provided name in the consent section of the provided Access Credential.
- *
- * @example
- * ```
- * const accessRequest = await issueAccessRequest({...}, {
- *  ...,
- *  customFields: new Set([
- *     {
- *       key: new URL("https://example.org/ns/customBoolean"),
- *       value: true,
- *     },
- *   ]),
- * });
- * // s is true
- * const s = getCustomBoolean(accessRequest, new URL("https://example.org/ns/customBoolean"));
- * ```
- *
- * @param accessCredential The Access Credential (Access Grant or Access request)
- * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
- * @since unreleased
- */
-export function getCustomBoolean(
-  vc: DatasetWithId,
-  field: URL,
-): boolean | undefined {
-  // Unsure yet: should this throw if there are more than one value?
-  return getCustomBooleans(vc, field)[0];
-}
-
-function deserizalizeDouble(serialized: string): number | undefined {
-  const val = Number.parseFloat(serialized);
-  return Number.isNaN(val) ? undefined : val;
-}
-
-/**
- * Reads the custom double array value with the provided name in the consent section of the provided Access Credential.
- *
- * @example
- * ```
- * const accessRequest = await issueAccessRequest({...}, {
- *  ...,
- *  customFields: new Set([
- *     {
- *       key: new URL("https://example.org/ns/customDouble"),
- *       value: [1.1, 2.2, 3.3],
- *     },
- *   ]),
- * });
- * // d is [1.1, 2.2, 3.3]
- * const d = getCustomDoubles(accessRequest, new URL("https://example.org/ns/customDouble"));
- * ```
- *
- * @param accessCredential The Access Credential (Access Grant or Access request)
- * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
- * @since unreleased
- */
-export function getCustomDoubles(vc: DatasetWithId, field: URL): number[] {
-  return deserializeFields(vc, field, deserizalizeDouble);
-}
-
-/**
- * Reads the custom double value with the provided name in the consent section of the provided Access Credential.
- *
- * @example
- * ```
- * const accessRequest = await issueAccessRequest({...}, {
- *  ...,
- *  customFields: new Set([
- *     {
- *       key: new URL("https://example.org/ns/customDouble"),
- *       value: 1.1,
- *     },
- *   ]),
- * });
- * // d is 1.1
- * const d = getCustomDouble(accessRequest, new URL("https://example.org/ns/customDouble"));
- * ```
- *
- * @param accessCredential The Access Credential (Access Grant or Access request)
- * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
- * @since unreleased
- */
-export function getCustomDouble(
-  vc: DatasetWithId,
-  field: URL,
-): number | undefined {
-  // Unsure yet: should this throw if there are more than one value?
-  return getCustomDoubles(vc, field)[0];
-}
-
-function deserizalizeInteger(serialized: string): number | undefined {
-  const val = Number.parseInt(serialized, 10);
-  return Number.isNaN(val) ? undefined : val;
-}
-
-/**
- * Reads the custom integer array value with the provided name in the consent section of the provided Access Credential.
- *
- * @example
- * ```
- * const accessRequest = await issueAccessRequest({...}, {
- *  ...,
- *  customFields: new Set([
- *     {
- *       key: new URL("https://example.org/ns/customInteger"),
- *       value: [1, 2, 3],
- *     },
- *   ]),
- * });
- * // i is [1, 2, 3]
- * const i = getCustomIntegers(accessRequest, new URL("https://example.org/ns/customInteger"));
- * ```
- *
- * @param accessCredential The Access Credential (Access Grant or Access request)
- * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
- * @since unreleased
- */
-export function getCustomIntegers(vc: DatasetWithId, field: URL): number[] {
-  return deserializeFields(vc, field, deserizalizeInteger);
-}
-
-/**
- * Reads the custom integer value with the provided name in the consent section of the provided Access Credential.
- *
- * @example
- * ```
- * const accessRequest = await issueAccessRequest({...}, {
- *  ...,
- *  customFields: new Set([
- *     {
- *       key: new URL("https://example.org/ns/customInteger"),
- *       value: 1,
- *     },
- *   ]),
- * });
- * // i is 1
- * const i = getCustomString(accessRequest, new URL("https://example.org/ns/customInteger"));
- * ```
- *
- * @param accessCredential The Access Credential (Access Grant or Access request)
- * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
- * @since unreleased
- */
-export function getCustomInteger(
-  vc: DatasetWithId,
-  field: URL,
-): number | undefined {
-  // Unsure yet: should this throw if there are more than one value?
-  return getCustomIntegers(vc, field)[0];
-}
-
-/**
- * Reads the custom string array value with the provided name in the consent section of the provided Access Credential.
- *
- * @example
- * ```
- * const accessRequest = await issueAccessRequest({...}, {
- *  ...,
- *  customFields: new Set([
- *     {
- *       key: new URL("https://example.org/ns/customString"),
- *       value: ["custom value", "another value"],
- *     },
- *   ]),
- * });
- * // s is ["custom value", "another value"]
- * const s = getCustomStrings(accessRequest, new URL("https://example.org/ns/customString"));
- * ```
- *
- * @param accessCredential The Access Credential (Access Grant or Access request)
- * @returns the value of the custom field with the provided name if it is a string, undefined otherwise.
- * @since unreleased
- */
-export function getCustomStrings(vc: DatasetWithId, field: URL): string[] {
-  return deserializeFields(vc, field, (value: string) => value);
-}
-
-/**
- * Reads the custom string value with the provided name in the consent section of the provided Access Credential.
- *
- * @example
- * ```
- * const accessRequest = await issueAccessRequest({...}, {
- *  ...,
- *  customFields: new Set([
- *     {
- *       key: new URL("https://example.org/ns/customString"),
- *       value: "custom value",
- *     },
- *   ]),
- * });
- * // s is "custom value"
- * const s = getCustomString(accessRequest, new URL("https://example.org/ns/customString"));
- * ```
- *
- * @param accessCredential The Access Credential (Access Grant or Access request)
- * @returns the value of the custom field with the provided name if it is a string, undefined otherwise.
- * @since unreleased
- */
-export function getCustomString(
-  vc: DatasetWithId,
-  field: URL,
-): string | undefined {
-  // Unsure yet: should this throw if there are more than one value?
-  return getCustomStrings(vc, field)[0];
-}
-
-const xmlSchemaTypes = {
-  boolean: namedNode("http://www.w3.org/2001/XMLSchema#boolean"),
-  double: namedNode("http://www.w3.org/2001/XMLSchema#double"),
-  integer: namedNode("http://www.w3.org/2001/XMLSchema#integer"),
-  string: namedNode("http://www.w3.org/2001/XMLSchema#string"),
-} as const;
-
-function castLiteral(lit: Literal): unknown {
-  if (lit.datatype.equals(xmlSchemaTypes.boolean)) {
-    return deserializeBoolean(lit.value);
-  }
-  if (lit.datatype.equals(xmlSchemaTypes.double)) {
-    return deserizalizeDouble(lit.value);
-  }
-  if (lit.datatype.equals(xmlSchemaTypes.integer)) {
-    return deserizalizeInteger(lit.value);
-  }
-  if (lit.datatype.equals(xmlSchemaTypes.string)) {
-    return lit.value;
-  }
-  throw new Error(`Unsupported literal type ${lit.datatype.value}`);
-}
-
-const WELL_KNOWN_FIELDS = [
-  gc.forPersonalData,
-  gc.forPurpose,
-  gc.isProvidedTo,
-  gc.isProvidedToController,
-  gc.isProvidedToPerson,
-  acl.mode,
-  INHERIT,
-];
-
-/**
- * Reads all the custom fields in the consent section of the provided Access Credential.
- *
- * @example
- * ```
- * const accessRequest = await issueAccessRequest({...}, {
- *  ...,
- *  customFields: new Set([
- *     {
- *       key: new URL("https://example.org/ns/customString"),
- *       value: "custom value",
- *     },
- *     {
- *       key: new URL("https://example.org/ns/customInteger"),
- *       value: 1,
- *     },
- *   ]),
- * });
- * const customFields = getCustomFields(accessRequest);
- * // s is "custom value"
- * const s = customFields["https://example.org/ns/customString"];
- * // i is 1
- * const i = customFields["https://example.org/ns/custominteger"];
- * ```
- *
- * @param accessCredential The Access Credential (Access Grant or Access request)
- * @returns an object keyed by the custom fields names, associated to their values.
- * @since unreleased
- */
-export function getCustomFields(
-  accessCredential: DatasetWithId,
-): Record<string, unknown> {
-  const consent = getConsent(accessCredential);
-  return Array.from(accessCredential.match(consent, null, null, defaultGraph()))
-    .filter(
-      ({ predicate, object }) =>
-        // The Access Grant data model is known, so by elimination any unknown
-        // field is a custom one.
-        !WELL_KNOWN_FIELDS.some((wellKnown) => wellKnown.equals(predicate)) &&
-        // Nested objects are not supported.
-        object.termType === "Literal",
-    )
-    .map(({ predicate, object }) => ({
-      // The type assertion is okay, because we filter on the term type.
-      [`${predicate.value}`]: castLiteral(object as Literal),
-    }))
-    .reduce((acc, cur) => ({ ...acc, ...cur }), {} as Record<string, unknown>);
 }
 
 export function isGConsentAccessGrant(vc: DatasetWithId): boolean {
@@ -773,6 +440,385 @@ export function getInherit(vc: DatasetWithId): boolean {
       defaultGraph(),
     ),
   );
+}
+
+/**
+ * Internal function. Deserializes a literal using the provided function.
+ * If the literal cannot be deserialized as expected (e.g. a string attempted
+ * to be deserialized as an integer), an error is thrown.
+ *
+ * @hidden
+ */
+function deserializeFields<T>(
+  vc: DatasetWithId,
+  field: URL,
+  deserializer: (value: Literal) => T | undefined,
+  type: string,
+): NonNullable<T>[] {
+  return Array.from(
+    vc.match(getConsent(vc), namedNode(field.href), null, defaultGraph()),
+  )
+    .map((q) => {
+      if (q.object.termType !== "Literal") {
+        throw new Error(
+          `Expected value object for predicate ${field.href} to be a litteral, found ${q.object.termType}.`,
+        );
+      }
+      return q.object as Literal;
+    })
+    .map((object) => {
+      const result = deserializer(object);
+      if (result === undefined) {
+        // FIXME use inrupt error library
+        throw new Error(
+          `Error deserializing value ${object} for predicate ${field.href} as type ${type}.`,
+        );
+      }
+      return result;
+      // FIXME why isn't TS happy about the filtering out of undefined?
+    }) as NonNullable<T>[];
+}
+
+function deserializeField<T>(
+  vc: DatasetWithId,
+  field: URL,
+  deserializer: (value: Literal) => T | undefined,
+  type: string,
+): T | undefined {
+  const result = deserializeFields(vc, field, deserializer, type);
+  if (result.length > 1) {
+    // FIXME use inrupt error library
+    throw new Error(
+      `Expected one value for predicate ${field.href}, found many: ${result}`,
+    );
+  }
+  return result[0];
+}
+
+const xmlSchemaTypes = {
+  boolean: namedNode("http://www.w3.org/2001/XMLSchema#boolean"),
+  double: namedNode("http://www.w3.org/2001/XMLSchema#double"),
+  integer: namedNode("http://www.w3.org/2001/XMLSchema#integer"),
+  string: namedNode("http://www.w3.org/2001/XMLSchema#string"),
+} as const;
+
+function deserializeBoolean(serialized: Literal): boolean | undefined {
+  if (!serialized.datatype.equals(xmlSchemaTypes.boolean)) {
+    return undefined;
+  }
+  if (serialized.value === "true") {
+    return true;
+  }
+  if (serialized.value === "false") {
+    return false;
+  }
+  return undefined;
+}
+
+/**
+ * Reads the custom boolean value with the provided name in the consent section of the provided Access Credential.
+ *
+ * @example
+ * ```
+ * const accessRequest = await issueAccessRequest({...}, {
+ *  ...,
+ *  customFields: new Set([
+ *     {
+ *       key: new URL("https://example.org/ns/customBoolean"),
+ *       value: [true, false, true],
+ *     },
+ *   ]),
+ * });
+ * // s is [true, false, true]
+ * const s = getCustomBoolean(accessRequest, new URL("https://example.org/ns/customBoolean"));
+ * ```
+ *
+ * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
+ * @since unreleased
+ */
+export function getCustomBooleans(vc: DatasetWithId, field: URL): boolean[] {
+  return deserializeFields(vc, field, deserializeBoolean, "boolean");
+}
+
+/**
+ * Reads the custom boolean array value with the provided name in the consent section of the provided Access Credential.
+ *
+ * @example
+ * ```
+ * const accessRequest = await issueAccessRequest({...}, {
+ *  ...,
+ *  customFields: new Set([
+ *     {
+ *       key: new URL("https://example.org/ns/customBoolean"),
+ *       value: true,
+ *     },
+ *   ]),
+ * });
+ * // s is true
+ * const s = getCustomBoolean(accessRequest, new URL("https://example.org/ns/customBoolean"));
+ * ```
+ *
+ * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
+ * @since unreleased
+ */
+export function getCustomBoolean(
+  vc: DatasetWithId,
+  field: URL,
+): boolean | undefined {
+  return deserializeField(vc, field, deserializeBoolean, "boolean");
+}
+
+function deserizalizeDouble(serialized: Literal): number | undefined {
+  if (!serialized.datatype.equals(xmlSchemaTypes.double)) {
+    return undefined;
+  }
+  const val = Number.parseFloat(serialized.value);
+  return Number.isNaN(val) ? undefined : val;
+}
+
+/**
+ * Reads the custom double array value with the provided name in the consent section of the provided Access Credential.
+ *
+ * @example
+ * ```
+ * const accessRequest = await issueAccessRequest({...}, {
+ *  ...,
+ *  customFields: new Set([
+ *     {
+ *       key: new URL("https://example.org/ns/customDouble"),
+ *       value: [1.1, 2.2, 3.3],
+ *     },
+ *   ]),
+ * });
+ * // d is [1.1, 2.2, 3.3]
+ * const d = getCustomDoubles(accessRequest, new URL("https://example.org/ns/customDouble"));
+ * ```
+ *
+ * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
+ * @since unreleased
+ */
+export function getCustomDoubles(vc: DatasetWithId, field: URL): number[] {
+  return deserializeFields(vc, field, deserizalizeDouble, "double");
+}
+
+/**
+ * Reads the custom double value with the provided name in the consent section of the provided Access Credential.
+ *
+ * @example
+ * ```
+ * const accessRequest = await issueAccessRequest({...}, {
+ *  ...,
+ *  customFields: new Set([
+ *     {
+ *       key: new URL("https://example.org/ns/customDouble"),
+ *       value: 1.1,
+ *     },
+ *   ]),
+ * });
+ * // d is 1.1
+ * const d = getCustomDouble(accessRequest, new URL("https://example.org/ns/customDouble"));
+ * ```
+ *
+ * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
+ * @since unreleased
+ */
+export function getCustomDouble(
+  vc: DatasetWithId,
+  field: URL,
+): number | undefined {
+  return deserializeField(vc, field, deserizalizeDouble, "double");
+}
+
+function deserizalizeInteger(serialized: Literal): number | undefined {
+  if (!serialized.datatype.equals(xmlSchemaTypes.integer)) {
+    return undefined;
+  }
+  const val = Number.parseInt(serialized.value, 10);
+  return Number.isNaN(val) ? undefined : val;
+}
+
+/**
+ * Reads the custom integer array value with the provided name in the consent section of the provided Access Credential.
+ *
+ * @example
+ * ```
+ * const accessRequest = await issueAccessRequest({...}, {
+ *  ...,
+ *  customFields: new Set([
+ *     {
+ *       key: new URL("https://example.org/ns/customInteger"),
+ *       value: [1, 2, 3],
+ *     },
+ *   ]),
+ * });
+ * // i is [1, 2, 3]
+ * const i = getCustomIntegers(accessRequest, new URL("https://example.org/ns/customInteger"));
+ * ```
+ *
+ * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
+ * @since unreleased
+ */
+export function getCustomIntegers(vc: DatasetWithId, field: URL): number[] {
+  return deserializeFields(vc, field, deserizalizeInteger, "integer");
+}
+
+/**
+ * Reads the custom integer value with the provided name in the consent section of the provided Access Credential.
+ *
+ * @example
+ * ```
+ * const accessRequest = await issueAccessRequest({...}, {
+ *  ...,
+ *  customFields: new Set([
+ *     {
+ *       key: new URL("https://example.org/ns/customInteger"),
+ *       value: 1,
+ *     },
+ *   ]),
+ * });
+ * // i is 1
+ * const i = getCustomString(accessRequest, new URL("https://example.org/ns/customInteger"));
+ * ```
+ *
+ * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @returns the value of the custom field with the provided name if it is a boolean, undefined otherwise.
+ * @since unreleased
+ */
+export function getCustomInteger(
+  vc: DatasetWithId,
+  field: URL,
+): number | undefined {
+  return deserializeField(vc, field, deserizalizeInteger, "integer");
+}
+
+/**
+ * Reads the custom string array value with the provided name in the consent section of the provided Access Credential.
+ *
+ * @example
+ * ```
+ * const accessRequest = await issueAccessRequest({...}, {
+ *  ...,
+ *  customFields: new Set([
+ *     {
+ *       key: new URL("https://example.org/ns/customString"),
+ *       value: ["custom value", "another value"],
+ *     },
+ *   ]),
+ * });
+ * // s is ["custom value", "another value"]
+ * const s = getCustomStrings(accessRequest, new URL("https://example.org/ns/customString"));
+ * ```
+ *
+ * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @returns the value of the custom field with the provided name if it is a string, undefined otherwise.
+ * @since unreleased
+ */
+export function getCustomStrings(vc: DatasetWithId, field: URL): string[] {
+  return deserializeFields(vc, field, (str: Literal) => str.value, "string");
+}
+
+/**
+ * Reads the custom string value with the provided name in the consent section of the provided Access Credential.
+ *
+ * @example
+ * ```
+ * const accessRequest = await issueAccessRequest({...}, {
+ *  ...,
+ *  customFields: new Set([
+ *     {
+ *       key: new URL("https://example.org/ns/customString"),
+ *       value: "custom value",
+ *     },
+ *   ]),
+ * });
+ * // s is "custom value"
+ * const s = getCustomString(accessRequest, new URL("https://example.org/ns/customString"));
+ * ```
+ *
+ * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @returns the value of the custom field with the provided name if it is a string, undefined otherwise.
+ * @since unreleased
+ */
+export function getCustomString(
+  vc: DatasetWithId,
+  field: URL,
+): string | undefined {
+  return deserializeField(vc, field, (str: Literal) => str.value, "string");
+}
+
+const WELL_KNOWN_KEYS = [
+  "forPersonalData",
+  "forPurpose",
+  "isProvidedTo",
+  "isProvidedToController",
+  "isProvidedToPerson",
+  "mode",
+  "inherit",
+  "hasStatus",
+  "isConsentForDataSubject",
+  gc.forPersonalData.value,
+  gc.forPurpose.value,
+  gc.isProvidedTo.value,
+  gc.isProvidedToController.value,
+  gc.isProvidedToPerson.value,
+  gc.hasStatus.value,
+  gc.isConsentForDataSubject.value,
+  acl.mode.value,
+  INHERIT.value,
+] as const;
+
+/**
+ * Reads all the custom fields in the consent section of the provided Access Credential.
+ *
+ * @example
+ * ```
+ * const accessRequest = await issueAccessRequest({...}, {
+ *  ...,
+ *  customFields: new Set([
+ *     {
+ *       key: new URL("https://example.org/ns/customString"),
+ *       value: "custom value",
+ *     },
+ *     {
+ *       key: new URL("https://example.org/ns/customInteger"),
+ *       value: 1,
+ *     },
+ *   ]),
+ * });
+ * const customFields = getCustomFields(accessRequest);
+ * // s is "custom value"
+ * const s = customFields["https://example.org/ns/customString"];
+ * // i is 1
+ * const i = customFields["https://example.org/ns/custominteger"];
+ * ```
+ *
+ * @param accessCredential The Access Credential (Access Grant or Access request)
+ * @returns an object keyed by the custom fields names, associated to their values.
+ * @since unreleased
+ */
+export function getCustomFields(
+  accessCredential: DatasetWithId,
+): Record<string, unknown> {
+  const credentialObject = JSON.parse(JSON.stringify(accessCredential));
+  let consent: unknown;
+  if (isAccessGrant(credentialObject)) {
+    consent = (credentialObject as AccessGrant).credentialSubject
+      .providedConsent;
+  } else if (isAccessRequest(credentialObject)) {
+    consent = (credentialObject as AccessRequest).credentialSubject.hasConsent;
+  }
+  const customFields = JSON.parse(
+    JSON.stringify(consent, (k, v) =>
+      // Filter out all well-known keys
+      WELL_KNOWN_KEYS.includes(k) ? undefined : v,
+    ),
+  );
+  return customFields;
 }
 
 /**

--- a/src/common/index.test.ts
+++ b/src/common/index.test.ts
@@ -40,7 +40,7 @@ describe("Index exports", () => {
       "isValidAccessGrant",
       "getAccessModes",
       "getCustomBoolean",
-      "getCustomDouble",
+      "getCustomFloat",
       "getCustomFields",
       "getCustomInteger",
       "getCustomString",

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -26,7 +26,7 @@ export type { AccessGrantWrapper } from "./getters";
 export {
   getAccessModes,
   getCustomBoolean,
-  getCustomDouble,
+  getCustomFloat,
   getCustomFields,
   getCustomInteger,
   getCustomString,

--- a/src/gConsent/manage/approveAccessRequest.test.ts
+++ b/src/gConsent/manage/approveAccessRequest.test.ts
@@ -462,22 +462,6 @@ describe("approveAccessRequest", () => {
         key: new URL("https://example.org/ns/customFloat"),
         value: 1.1,
       },
-      {
-        key: new URL("https://example.org/ns/customStringArray"),
-        value: ["customValue", "otherCustomValue"],
-      },
-      {
-        key: new URL("https://example.org/ns/customBooleanArray"),
-        value: [true, false],
-      },
-      {
-        key: new URL("https://example.org/ns/customIntArray"),
-        value: [1, 2],
-      },
-      {
-        key: new URL("https://example.org/ns/customFloatArray"),
-        value: [1.1, 2.2],
-      },
     ];
     const customRequest = await mockAccessRequestVc({ custom: customFields });
     await approveAccessRequest(customRequest, undefined, {
@@ -827,22 +811,6 @@ describe("approveAccessRequest", () => {
         key: new URL("https://example.org/ns/customFloat"),
         value: 1.1,
       },
-      {
-        key: new URL("https://example.org/ns/customStringArray"),
-        value: ["customValue", "otherCustomValue"],
-      },
-      {
-        key: new URL("https://example.org/ns/customBooleanArray"),
-        value: [true, false],
-      },
-      {
-        key: new URL("https://example.org/ns/customIntArray"),
-        value: [1, 2],
-      },
-      {
-        key: new URL("https://example.org/ns/customFloatArray"),
-        value: [1.1, 2.2],
-      },
     ];
     const customRequest = await mockAccessRequestVc({ custom: customFields });
     await approveAccessRequest(
@@ -872,22 +840,6 @@ describe("approveAccessRequest", () => {
             key: new URL("https://example.org/ns/customFloat"),
             value: 2.2,
           },
-          {
-            key: new URL("https://example.org/ns/customStringArray"),
-            value: ["overriden customValue", "overriden otherCustomValue"],
-          },
-          {
-            key: new URL("https://example.org/ns/customBooleanArray"),
-            value: [false, false, false],
-          },
-          {
-            key: new URL("https://example.org/ns/customIntArray"),
-            value: [2, 3, 4],
-          },
-          {
-            key: new URL("https://example.org/ns/customFloatArray"),
-            value: [2.2, 3.3, 4.4],
-          },
         ]),
       },
       {
@@ -908,13 +860,6 @@ describe("approveAccessRequest", () => {
           "https://example.org/ns/customBoolean": false,
           "https://example.org/ns/customInt": 2,
           "https://example.org/ns/customFloat": 2.2,
-          "https://example.org/ns/customStringArray": [
-            "overriden customValue",
-            "overriden otherCustomValue",
-          ],
-          "https://example.org/ns/customBooleanArray": [false, false, false],
-          "https://example.org/ns/customIntArray": [2, 3, 4],
-          "https://example.org/ns/customFloatArray": [2.2, 3.3, 4.4],
         },
         inbox: "https://some-custom.inbox",
       }),
@@ -925,7 +870,7 @@ describe("approveAccessRequest", () => {
     );
   });
 
-  it("collapses overriden custom fields using the same key into a single array value", async () => {
+  it("throws if multiple overriden custom fields use the same key", async () => {
     mockAcpClient();
     mockAccessApiEndpoint();
     const mockedVcModule = jest.requireMock(
@@ -943,114 +888,33 @@ describe("approveAccessRequest", () => {
       },
     ];
     const customRequest = await mockAccessRequestVc({ custom: customFields });
-    await approveAccessRequest(
-      customRequest,
-      {
-        access: { append: true },
-        expirationDate: new Date(2021, 9, 14),
-        issuanceDate: new Date(2021, 9, 15),
-        purpose: ["https://some-custom.purpose"],
-        requestor: "https://some-custom.requestor",
-        resources: ["https://some-custom.resource"],
-        requestorInboxUrl: "https://some-custom.inbox",
-        customFields: new Set([
-          {
-            key: new URL("https://example.org/ns/customString"),
-            value: "overridden custom value",
-          },
-          {
-            key: new URL("https://example.org/ns/customString"),
-            value: "another custom value",
-          },
-          {
-            key: new URL("https://example.org/ns/customString"),
-            value: "yet another custom value",
-          },
-        ]),
-      },
-      {
-        fetch: jest.fn<typeof fetch>(),
-      },
-    );
-
-    expect(spiedIssueRequest).toHaveBeenCalledWith(
-      `${MOCKED_ACCESS_ISSUER}/issue`,
-      expect.objectContaining({
-        providedConsent: expect.objectContaining({
-          "https://example.org/ns/customString": [
-            "overridden custom value",
-            "another custom value",
-            "yet another custom value",
-          ],
-        }),
-      }),
-      expect.anything(),
-      expect.anything(),
-    );
-  });
-
-  it("supports overriden custom fields using the same key having different value types", async () => {
-    mockAcpClient();
-    mockAccessApiEndpoint();
-    const mockedVcModule = jest.requireMock(
-      "@inrupt/solid-client-vc",
-    ) as typeof VcClient;
-    const spiedIssueRequest = jest.spyOn(
-      mockedVcModule,
-      "issueVerifiableCredential",
-    );
-    spiedIssueRequest.mockResolvedValueOnce(accessGrantVc);
-    const customFields = [
-      {
-        key: new URL("https://example.org/ns/customField"),
-        value: "custom value",
-      },
-    ];
-    const customRequest = await mockAccessRequestVc({ custom: customFields });
-    await approveAccessRequest(
-      customRequest,
-      {
-        access: { append: true },
-        expirationDate: new Date(2021, 9, 14),
-        issuanceDate: new Date(2021, 9, 15),
-        purpose: ["https://some-custom.purpose"],
-        requestor: "https://some-custom.requestor",
-        resources: ["https://some-custom.resource"],
-        requestorInboxUrl: "https://some-custom.inbox",
-        customFields: new Set([
-          {
-            key: new URL("https://example.org/ns/customField"),
-            value: "overridden custom value",
-          },
-          {
-            key: new URL("https://example.org/ns/customField"),
-            value: true,
-          },
-          {
-            key: new URL("https://example.org/ns/customField"),
-            value: 1,
-          },
-        ]),
-      },
-      {
-        fetch: jest.fn<typeof fetch>(),
-      },
-    );
-
-    expect(spiedIssueRequest).toHaveBeenCalledWith(
-      `${MOCKED_ACCESS_ISSUER}/issue`,
-      expect.objectContaining({
-        providedConsent: expect.objectContaining({
-          "https://example.org/ns/customField": [
-            "overridden custom value",
-            true,
-            1,
-          ],
-        }),
-      }),
-      expect.anything(),
-      expect.anything(),
-    );
+    await expect(() =>
+      approveAccessRequest(
+        customRequest,
+        {
+          access: { append: true },
+          expirationDate: new Date(2021, 9, 14),
+          issuanceDate: new Date(2021, 9, 15),
+          purpose: ["https://some-custom.purpose"],
+          requestor: "https://some-custom.requestor",
+          resources: ["https://some-custom.resource"],
+          requestorInboxUrl: "https://some-custom.inbox",
+          customFields: new Set([
+            {
+              key: new URL("https://example.org/ns/customString"),
+              value: "overridden custom value",
+            },
+            {
+              key: new URL("https://example.org/ns/customString"),
+              value: "another custom value",
+            },
+          ]),
+        },
+        {
+          fetch: jest.fn<typeof fetch>(),
+        },
+      ),
+    ).rejects.toThrow();
   });
 
   it("only overrides specified custom fields", async () => {

--- a/src/gConsent/manage/approveAccessRequest.test.ts
+++ b/src/gConsent/manage/approveAccessRequest.test.ts
@@ -938,7 +938,7 @@ describe("approveAccessRequest", () => {
     spiedIssueRequest.mockResolvedValueOnce(accessGrantVc);
     const customFields = [
       {
-        key: new URL("https://example.org/ns/overridenCustomString"),
+        key: new URL("https://example.org/ns/overriddenCustomString"),
         value: "custom value",
       },
       {
@@ -952,8 +952,8 @@ describe("approveAccessRequest", () => {
       {
         customFields: new Set([
           {
-            key: new URL("https://example.org/ns/overridenCustomString"),
-            value: "overriden value",
+            key: new URL("https://example.org/ns/overriddenCustomString"),
+            value: "overridden value",
           },
         ]),
       },
@@ -965,8 +965,10 @@ describe("approveAccessRequest", () => {
     expect(spiedIssueRequest).toHaveBeenCalledWith(
       `${MOCKED_ACCESS_ISSUER}/issue`,
       expect.objectContaining({
-        "https://example.org/ns/overridenCustomString": "overriden value",
-        "https://example.org/ns/unchangedCustomString": "unchanged value",
+        providedConsent: expect.objectContaining({
+          "https://example.org/ns/overriddenCustomString": "overridden value",
+          "https://example.org/ns/unchangedCustomString": "unchanged value",
+        }),
       }),
       expect.anything(),
       expect.anything(),

--- a/src/gConsent/manage/approveAccessRequest.test.ts
+++ b/src/gConsent/manage/approveAccessRequest.test.ts
@@ -448,7 +448,7 @@ describe("approveAccessRequest", () => {
     const customFields = [
       {
         key: new URL("https://example.org/ns/customString"),
-        value: "customValue",
+        value: "custom value",
       },
       {
         key: new URL("https://example.org/ns/customBoolean"),
@@ -459,8 +459,24 @@ describe("approveAccessRequest", () => {
         value: 1,
       },
       {
-        key: new URL("https://example.org/ns/customDouble"),
+        key: new URL("https://example.org/ns/customFloat"),
         value: 1.1,
+      },
+      {
+        key: new URL("https://example.org/ns/customStringArray"),
+        value: ["customValue", "otherCustomValue"],
+      },
+      {
+        key: new URL("https://example.org/ns/customBooleanArray"),
+        value: [true, false],
+      },
+      {
+        key: new URL("https://example.org/ns/customIntArray"),
+        value: [1, 2],
+      },
+      {
+        key: new URL("https://example.org/ns/customFloatArray"),
+        value: [1.1, 2.2],
       },
     ];
     const customRequest = await mockAccessRequestVc({ custom: customFields });
@@ -478,10 +494,17 @@ describe("approveAccessRequest", () => {
             accessRequestVc.credentialSubject.hasConsent.forPersonalData,
           isProvidedTo: accessRequestVc.credentialSubject.id,
           forPurpose: [],
-          "https://example.org/ns/customString": "customValue",
+          "https://example.org/ns/customString": "custom value",
           "https://example.org/ns/customBoolean": true,
           "https://example.org/ns/customInt": 1,
-          "https://example.org/ns/customDouble": 1.1,
+          "https://example.org/ns/customFloat": 1.1,
+          "https://example.org/ns/customStringArray": [
+            "customValue",
+            "otherCustomValue",
+          ],
+          "https://example.org/ns/customBooleanArray": [true, false],
+          "https://example.org/ns/customIntArray": [1, 2],
+          "https://example.org/ns/customFloatArray": [1.1, 2.2],
         }),
         inbox: accessRequestVc.credentialSubject.inbox,
       }),
@@ -790,7 +813,7 @@ describe("approveAccessRequest", () => {
     const customFields = [
       {
         key: new URL("https://example.org/ns/customString"),
-        value: "customValue",
+        value: "custom value",
       },
       {
         key: new URL("https://example.org/ns/customBoolean"),
@@ -803,6 +826,22 @@ describe("approveAccessRequest", () => {
       {
         key: new URL("https://example.org/ns/customDouble"),
         value: 1.1,
+      },
+      {
+        key: new URL("https://example.org/ns/customStringArray"),
+        value: ["customValue", "otherCustomValue"],
+      },
+      {
+        key: new URL("https://example.org/ns/customBooleanArray"),
+        value: [true, false],
+      },
+      {
+        key: new URL("https://example.org/ns/customIntArray"),
+        value: [1, 2],
+      },
+      {
+        key: new URL("https://example.org/ns/customFloatArray"),
+        value: [1.1, 2.2],
       },
     ];
     const customRequest = await mockAccessRequestVc({ custom: customFields });
@@ -818,20 +857,36 @@ describe("approveAccessRequest", () => {
         requestorInboxUrl: "https://some-custom.inbox",
         customFields: new Set([
           {
-            key: new URL("https://example.org/ns/overriddenCustomString"),
+            key: new URL("https://example.org/ns/customString"),
             value: "overriddenCustomValue",
           },
           {
-            key: new URL("https://example.org/ns/overriddenCustomBoolean"),
+            key: new URL("https://example.org/ns/customBoolean"),
             value: false,
           },
           {
-            key: new URL("https://example.org/ns/overriddenCustomInt"),
+            key: new URL("https://example.org/ns/customInt"),
             value: 2,
           },
           {
-            key: new URL("https://example.org/ns/overriddenCustomDouble"),
+            key: new URL("https://example.org/ns/customDouble"),
             value: 2.2,
+          },
+          {
+            key: new URL("https://example.org/ns/customStringArray"),
+            value: ["overriden customValue", "overriden otherCustomValue"],
+          },
+          {
+            key: new URL("https://example.org/ns/customBooleanArray"),
+            value: [false, false, false],
+          },
+          {
+            key: new URL("https://example.org/ns/customIntArray"),
+            value: [2, 3, 4],
+          },
+          {
+            key: new URL("https://example.org/ns/customFloatArray"),
+            value: [2.2, 3.3, 4.4],
           },
         ]),
       },
@@ -849,17 +904,71 @@ describe("approveAccessRequest", () => {
           forPersonalData: ["https://some-custom.resource"],
           isProvidedTo: "https://some-custom.requestor",
           forPurpose: ["https://some-custom.purpose"],
-          "https://example.org/ns/overriddenCustomString":
-            "overriddenCustomValue",
-          "https://example.org/ns/overriddenCustomBoolean": false,
-          "https://example.org/ns/overriddenCustomInt": 2,
-          "https://example.org/ns/overriddenCustomDouble": 2.2,
+          "https://example.org/ns/customString": "overriddenCustomValue",
+          "https://example.org/ns/customBoolean": false,
+          "https://example.org/ns/customInt": 2,
+          "https://example.org/ns/customDouble": 2.2,
+          "https://example.org/ns/customStringArray": [
+            "overriden customValue",
+            "overriden otherCustomValue",
+          ],
+          "https://example.org/ns/customBooleanArray": [false, false, false],
+          "https://example.org/ns/customIntArray": [2, 3, 4],
+          "https://example.org/ns/customFloatArray": [2.2, 3.3, 4.4],
         },
         inbox: "https://some-custom.inbox",
       }),
       expect.objectContaining({
         type: ["SolidAccessGrant"],
       }),
+      expect.anything(),
+    );
+  });
+
+  it("only overrides specified custom fields", async () => {
+    mockAcpClient();
+    mockAccessApiEndpoint();
+    const mockedVcModule = jest.requireMock(
+      "@inrupt/solid-client-vc",
+    ) as typeof VcClient;
+    const spiedIssueRequest = jest.spyOn(
+      mockedVcModule,
+      "issueVerifiableCredential",
+    );
+    spiedIssueRequest.mockResolvedValueOnce(accessGrantVc);
+    const customFields = [
+      {
+        key: new URL("https://example.org/ns/overridenCustomString"),
+        value: "custom value",
+      },
+      {
+        key: new URL("https://example.org/ns/unchangedCustomString"),
+        value: "unchanged value",
+      },
+    ];
+    const customRequest = await mockAccessRequestVc({ custom: customFields });
+    await approveAccessRequest(
+      customRequest,
+      {
+        customFields: new Set([
+          {
+            key: new URL("https://example.org/ns/overridenCustomString"),
+            value: "overriden value",
+          },
+        ]),
+      },
+      {
+        fetch: jest.fn<typeof fetch>(),
+      },
+    );
+
+    expect(spiedIssueRequest).toHaveBeenCalledWith(
+      `${MOCKED_ACCESS_ISSUER}/issue`,
+      expect.objectContaining({
+        "https://example.org/ns/overridenCustomString": "overriden value",
+        "https://example.org/ns/unchangedCustomString": "unchanged value",
+      }),
+      expect.anything(),
       expect.anything(),
     );
   });

--- a/src/gConsent/manage/approveAccessRequest.test.ts
+++ b/src/gConsent/manage/approveAccessRequest.test.ts
@@ -824,7 +824,7 @@ describe("approveAccessRequest", () => {
         value: 1,
       },
       {
-        key: new URL("https://example.org/ns/customDouble"),
+        key: new URL("https://example.org/ns/customFloat"),
         value: 1.1,
       },
       {
@@ -869,7 +869,7 @@ describe("approveAccessRequest", () => {
             value: 2,
           },
           {
-            key: new URL("https://example.org/ns/customDouble"),
+            key: new URL("https://example.org/ns/customFloat"),
             value: 2.2,
           },
           {
@@ -907,7 +907,7 @@ describe("approveAccessRequest", () => {
           "https://example.org/ns/customString": "overriddenCustomValue",
           "https://example.org/ns/customBoolean": false,
           "https://example.org/ns/customInt": 2,
-          "https://example.org/ns/customDouble": 2.2,
+          "https://example.org/ns/customFloat": 2.2,
           "https://example.org/ns/customStringArray": [
             "overriden customValue",
             "overriden otherCustomValue",
@@ -1138,7 +1138,7 @@ describe("approveAccessRequest", () => {
             value: 1,
           },
           {
-            key: new URL("https://example.org/ns/customDouble"),
+            key: new URL("https://example.org/ns/customFloat"),
             value: 1.1,
           },
         ]),
@@ -1160,7 +1160,7 @@ describe("approveAccessRequest", () => {
           "https://example.org/ns/customString": "customValue",
           "https://example.org/ns/customBoolean": true,
           "https://example.org/ns/customInt": 1,
-          "https://example.org/ns/customDouble": 1.1,
+          "https://example.org/ns/customFloat": 1.1,
         },
         inbox: "https://some-custom.inbox",
       }),

--- a/src/gConsent/manage/approveAccessRequest.test.ts
+++ b/src/gConsent/manage/approveAccessRequest.test.ts
@@ -482,13 +482,6 @@ describe("approveAccessRequest", () => {
           "https://example.org/ns/customBoolean": true,
           "https://example.org/ns/customInt": 1,
           "https://example.org/ns/customFloat": 1.1,
-          "https://example.org/ns/customStringArray": [
-            "customValue",
-            "otherCustomValue",
-          ],
-          "https://example.org/ns/customBooleanArray": [true, false],
-          "https://example.org/ns/customIntArray": [1, 2],
-          "https://example.org/ns/customFloatArray": [1.1, 2.2],
         }),
         inbox: accessRequestVc.credentialSubject.inbox,
       }),

--- a/src/gConsent/request/issueAccessRequest.test.ts
+++ b/src/gConsent/request/issueAccessRequest.test.ts
@@ -576,8 +576,36 @@ describe.each([true, false, undefined])(
           returnLegacyJsonld,
           customFields: new Set([
             {
-              key: new URL("https://example.org/ns/customField"),
-              value: "customValue",
+              key: new URL("https://example.org/ns/customString"),
+              value: "custom value",
+            },
+            {
+              key: new URL("https://example.org/ns/customBoolean"),
+              value: true,
+            },
+            {
+              key: new URL("https://example.org/ns/customInt"),
+              value: 1,
+            },
+            {
+              key: new URL("https://example.org/ns/customFloat"),
+              value: 1.1,
+            },
+            {
+              key: new URL("https://example.org/ns/customStringArray"),
+              value: ["customValue", "otherCustomValue"],
+            },
+            {
+              key: new URL("https://example.org/ns/customBooleanArray"),
+              value: [true, false],
+            },
+            {
+              key: new URL("https://example.org/ns/customIntArray"),
+              value: [1, 2],
+            },
+            {
+              key: new URL("https://example.org/ns/customFloatArray"),
+              value: [1.1, 2.2],
             },
           ]),
         },
@@ -591,7 +619,17 @@ describe.each([true, false, undefined])(
             hasStatus: "https://w3id.org/GConsent#ConsentStatusRequested",
             forPersonalData: ["https://some.pod/resource"],
             isConsentForDataSubject: "https://some.pod/profile#you",
-            "https://example.org/ns/customField": "customValue",
+            "https://example.org/ns/customString": "custom value",
+            "https://example.org/ns/customBoolean": true,
+            "https://example.org/ns/customInt": 1,
+            "https://example.org/ns/customFloat": 1.1,
+            "https://example.org/ns/customStringArray": [
+              "customValue",
+              "otherCustomValue",
+            ],
+            "https://example.org/ns/customBooleanArray": [true, false],
+            "https://example.org/ns/customIntArray": [1, 2],
+            "https://example.org/ns/customFloatArray": [1.1, 2.2],
           },
         }),
         expect.objectContaining({

--- a/src/gConsent/request/issueAccessRequest.test.ts
+++ b/src/gConsent/request/issueAccessRequest.test.ts
@@ -618,13 +618,6 @@ describe.each([true, false, undefined])(
 
     it("throws if the same key is used for multiple custom fields", async () => {
       mockAccessApiEndpoint();
-      const mockedIssue = jest.spyOn(
-        jest.requireMock("@inrupt/solid-client-vc") as {
-          issueVerifiableCredential: typeof VcLibrary.issueVerifiableCredential;
-        },
-        "issueVerifiableCredential",
-      );
-      mockedIssue.mockResolvedValueOnce(mockAccessRequest);
 
       await expect(() =>
         issueAccessRequest(

--- a/src/gConsent/util/access.mock.ts
+++ b/src/gConsent/util/access.mock.ts
@@ -38,6 +38,8 @@ import type { AccessGrant } from "../type/AccessGrant";
 import type { AccessRequest } from "../type/AccessRequest";
 
 type RequestVcOptions = Partial<{
+  subjectId: string;
+  inbox: string;
   issuer: string;
   resources: UrlString[];
   modes: ResourceAccessMode[];
@@ -117,15 +119,7 @@ export const mockAccessRequestVc = async (
   )) as unknown as AccessRequest;
 };
 
-export const mockAccessGrantObject = (
-  options?: Partial<{
-    issuer: string;
-    subjectId: string;
-    inherit: boolean;
-    resources: string[];
-    inbox: string;
-  }>,
-) => ({
+export const mockAccessGrantObject = (options?: RequestVcOptions) => ({
   "@context": MOCK_CONTEXT,
   id: "https://some.credential",
   credentialSubject: {
@@ -136,6 +130,7 @@ export const mockAccessGrantObject = (
       mode: ["http://www.w3.org/ns/auth/acl#Read"],
       isProvidedTo: "https://some.requestor",
       inherit: options?.inherit ?? true,
+      ...toJson(new Set(options?.custom)),
     },
     inbox: options?.inbox,
   },
@@ -153,14 +148,7 @@ export const mockAccessGrantObject = (
 });
 
 export const mockAccessGrantVc = async (
-  options?: Partial<{
-    issuer: string;
-    subjectId: string;
-    inherit: boolean;
-    resources: string[];
-    purposes: string[];
-    inbox: string;
-  }>,
+  options?: RequestVcOptions,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   modify?: (asObject: Record<string, any>) => void,
 ): Promise<AccessGrant> => {

--- a/src/gConsent/util/access.mock.ts
+++ b/src/gConsent/util/access.mock.ts
@@ -32,7 +32,7 @@ import {
   MOCK_CONTEXT,
 } from "../constants";
 import { normalizeAccessGrant } from "../manage/approveAccessRequest";
-import type { CustomField } from "../../type/CustomField";
+import { toJson, type CustomField } from "../../type/CustomField";
 import { normalizeAccessRequest } from "../request/issueAccessRequest";
 import type { AccessGrant } from "../type/AccessGrant";
 import type { AccessRequest } from "../type/AccessRequest";
@@ -56,10 +56,9 @@ export const mockAccessRequestVcObject = (options?: RequestVcOptions) => {
       | string
       | undefined,
   };
-  options?.custom?.forEach((field) => {
-    Object.assign(hasConsent, { [`${field.key.href}`]: field.value });
-  });
-
+  if (options?.custom !== undefined) {
+    Object.assign(hasConsent, toJson(new Set(options?.custom)));
+  }
   if (options?.resourceOwner === null) {
     delete hasConsent.isConsentForDataSubject;
   } else if (options?.resourceOwner) {

--- a/src/gConsent/util/initializeGrantParameters.ts
+++ b/src/gConsent/util/initializeGrantParameters.ts
@@ -94,7 +94,10 @@ export function initializeGrantParameters(
           inherit: requestOverride?.inherit ?? getInherit(requestVc),
           customFields:
             requestOverride?.customFields !== undefined
-              ? toJson(requestOverride?.customFields)
+              ? {
+                  ...getCustomFields(requestVc),
+                  ...toJson(requestOverride?.customFields),
+                }
               : getCustomFields(requestVc),
         };
   if (requestOverride?.expirationDate === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export {
 export {
   getAccessModes,
   getCustomBoolean,
-  getCustomDouble,
+  getCustomFloat,
   getCustomFields,
   getCustomInteger,
   getCustomString,

--- a/src/type/CustomField.ts
+++ b/src/type/CustomField.ts
@@ -73,7 +73,33 @@ export const toJson = (
       })
       // Collapse all the JSON object entries into a single object.
       .reduce(
-        (acc, cur) => Object.assign(acc, cur),
+        (acc, cur) => {
+          // We know the current object has a single key.
+          const curKey = Object.keys(cur)[0];
+          // If the provided key already exists, the values need to
+          // be combined rather than overwritten.
+          if (acc[curKey] !== undefined) {
+            if (Array.isArray(acc[curKey])) {
+              return {
+                ...acc,
+                // Append the new value to the existing array.
+                [`${curKey}`]: [...acc[curKey], cur[curKey]],
+                // TS is rightfully upset here, because we're pretending
+                // all the values for a given key is of the same type,
+                // which is not enforced at write time. Typed helpers
+                // will throw at read time, but untyped reader will allow
+                // to read back whathever.
+              } as Record<string, CustomField["value"]>;
+            }
+            return {
+              ...acc,
+              // Create a new array with the new value and the existing one.
+              [`${curKey}`]: [acc[curKey], cur[curKey]],
+              // See type assertion comment above.
+            } as Record<string, CustomField["value"]>;
+          }
+          return Object.assign(acc, cur);
+        },
         {} as Record<string, CustomField["value"]>,
       )
   );

--- a/src/type/CustomField.ts
+++ b/src/type/CustomField.ts
@@ -21,11 +21,12 @@
 
 import { INHERIT, acl, gc } from "../common/constants";
 
+
 export type CustomField = {
   /* The custom field name (this must be a URL). */
   key: URL;
   /* The custom field value (this must be a literal). */
-  value: string | number | boolean;
+  value: string | number | boolean | string[] | number[] | boolean[];
 };
 
 const WELL_KNOWN_FIELDS = [

--- a/src/type/CustomField.ts
+++ b/src/type/CustomField.ts
@@ -21,7 +21,6 @@
 
 import { INHERIT, acl, gc } from "../common/constants";
 
-
 export type CustomField = {
   /* The custom field name (this must be a URL). */
   key: URL;

--- a/src/type/CustomField.ts
+++ b/src/type/CustomField.ts
@@ -84,10 +84,10 @@ export const toJson = (
                 // Append the new value to the existing array.
                 [`${curKey}`]: [...acc[curKey], cur[curKey]],
                 // TS is rightfully upset here, because we're pretending
-                // all the values for a given key is of the same type,
+                // all the values for a given key are of the same type,
                 // which is not enforced at write time. Typed helpers
-                // will throw at read time, but untyped reader will allow
-                // to read back whathever.
+                // will throw at read time, but untyped readers will allow
+                // anything to be read back.
               } as Record<string, CustomField["value"]>;
             }
             return {

--- a/src/type/CustomField.ts
+++ b/src/type/CustomField.ts
@@ -68,6 +68,12 @@ export const toJson = (
             `All custom fields keys must be URL objects, found ${field.key}`,
           );
         }
+        if (!["string", "number", "boolean"].includes(typeof field.value)) {
+          // FIXME use inrupt error library
+          throw new Error(
+            `All custom fields values must be literals, found ${field.value} (or type ${typeof field.value})`,
+          );
+        }
         return { [`${field.key.toString()}`]: field.value };
       })
       // Collapse all the JSON object entries into a single object.

--- a/src/type/CustomField.ts
+++ b/src/type/CustomField.ts
@@ -71,7 +71,7 @@ export const toJson = (
         if (!["string", "number", "boolean"].includes(typeof field.value)) {
           // FIXME use inrupt error library
           throw new Error(
-            `All custom fields values must be literals, found ${field.value} (or type ${typeof field.value})`,
+            `All custom fields values must be literals, found ${JSON.stringify(field.value)} (of type ${typeof field.value})`,
           );
         }
         return { [`${field.key.toString()}`]: field.value };

--- a/src/type/CustomField.ts
+++ b/src/type/CustomField.ts
@@ -25,7 +25,7 @@ export type CustomField = {
   /* The custom field name (this must be a URL). */
   key: URL;
   /* The custom field value (this must be a literal). */
-  value: string | number | boolean | string[] | number[] | boolean[];
+  value: string | number | boolean;
 };
 
 const WELL_KNOWN_FIELDS = [
@@ -74,28 +74,12 @@ export const toJson = (
       .reduce(
         (acc, cur) => {
           // We know the current object has a single key.
-          const curKey = Object.keys(cur)[0];
-          // If the provided key already exists, the values need to
-          // be combined rather than overwritten.
-          if (acc[curKey] !== undefined) {
-            if (Array.isArray(acc[curKey])) {
-              return {
-                ...acc,
-                // Append the new value to the existing array.
-                [`${curKey}`]: [...acc[curKey], cur[curKey]],
-                // TS is rightfully upset here, because we're pretending
-                // all the values for a given key are of the same type,
-                // which is not enforced at write time. Typed helpers
-                // will throw at read time, but untyped readers will allow
-                // anything to be read back.
-              } as Record<string, CustomField["value"]>;
-            }
-            return {
-              ...acc,
-              // Create a new array with the new value and the existing one.
-              [`${curKey}`]: [acc[curKey], cur[curKey]],
-              // See type assertion comment above.
-            } as Record<string, CustomField["value"]>;
+          if (acc[Object.keys(cur)[0]] !== undefined) {
+            // If the provided key already exists, the input is invalid.
+            // FIXME use inrupt error library
+            throw new Error(
+              `Each custom field key must be unique. Found multiple values for ${Object.keys(cur)[0]}`,
+            );
           }
           return Object.assign(acc, cur);
         },

--- a/src/type/CustomField.ts
+++ b/src/type/CustomField.ts
@@ -25,7 +25,7 @@ export type CustomField = {
   /* The custom field name (this must be a URL). */
   key: URL;
   /* The custom field value (this must be a literal). */
-  value: string | number | boolean;
+  value: string | number | boolean | undefined;
 };
 
 const WELL_KNOWN_FIELDS = [
@@ -68,7 +68,11 @@ export const toJson = (
             `All custom fields keys must be URL objects, found ${field.key}`,
           );
         }
-        if (!["string", "number", "boolean"].includes(typeof field.value)) {
+        if (
+          !["string", "number", "boolean", "undefined"].includes(
+            typeof field.value,
+          )
+        ) {
           // FIXME use inrupt error library
           throw new Error(
             `All custom fields values must be literals, found ${JSON.stringify(field.value)} (of type ${typeof field.value})`,


### PR DESCRIPTION
Refines getters to read custom fields.

This adds throwing on deserialization issues or unexpected number of values as well.

Supporting arrays is out of scope for this.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
