### PR TITLE
Update query from `/derive` to the new  `/query` endpoint

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        environment-name: ["ESS PodSpaces", "ESS Dev-2-2"]
+        environment-name: ["ESS PodSpaces"]
         experimental: [false]
         include:
           - environment-name: "ESS Dev-2-3"

--- a/src/gConsent/manage/getAccessGrantAll.test.ts
+++ b/src/gConsent/manage/getAccessGrantAll.test.ts
@@ -82,7 +82,7 @@ describe("getAccessGrantAll", () => {
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalled();
 
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
-      "https://some.api.endpoint/derive",
+      "https://some.api.endpoint/query",
       expect.objectContaining(expectedDefaultVcShape),
       expect.objectContaining({
         // Expecting fetch to match universal-fetch fails in node because the
@@ -106,13 +106,13 @@ describe("getAccessGrantAll", () => {
 
     await getAccessGrantAll(
       { requestor },
-      { accessEndpoint: "https://some.api.endpoint/derive" },
+      { accessEndpoint: "https://some.api.endpoint/query" },
     );
 
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalled();
 
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
-      "https://some.api.endpoint/derive",
+      "https://some.api.endpoint/query",
       expect.objectContaining(expectedDefaultVcShape),
       expect.objectContaining({
         // Expecting fetch to match universal-fetch fails in node because the
@@ -153,7 +153,7 @@ describe("getAccessGrantAll", () => {
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalled();
 
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
-      "https://some.api.endpoint/derive",
+      "https://some.api.endpoint/query",
       expect.objectContaining(expectedVcShape),
       {
         fetch: otherFetch,
@@ -188,7 +188,7 @@ describe("getAccessGrantAll", () => {
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalled();
 
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
-      "https://some.api.endpoint/derive",
+      "https://some.api.endpoint/query",
       expect.objectContaining(expectedVcShape),
       {
         fetch: otherFetch,
@@ -223,7 +223,7 @@ describe("getAccessGrantAll", () => {
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalled();
 
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
-      "https://some.api.endpoint/derive",
+      "https://some.api.endpoint/query",
       expect.objectContaining(expectedVcShape),
       {
         fetch: otherFetch,
@@ -258,7 +258,7 @@ describe("getAccessGrantAll", () => {
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledTimes(4);
 
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
-      "https://some.api.endpoint/derive",
+      "https://some.api.endpoint/query",
       expect.objectContaining(expectedVcShapeOpen),
       {
         fetch: otherFetch,
@@ -296,7 +296,7 @@ describe("getAccessGrantAll", () => {
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalled();
 
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
-      "https://some.api.endpoint/derive",
+      "https://some.api.endpoint/query",
       expect.objectContaining(expectedVcShape),
       {
         fetch: otherFetch,
@@ -334,7 +334,7 @@ describe("getAccessGrantAll", () => {
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalled();
 
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
-      "https://some.api.endpoint/derive",
+      "https://some.api.endpoint/query",
       expect.objectContaining(expectedVcShape),
       {
         fetch: otherFetch,
@@ -353,7 +353,7 @@ describe("getAccessGrantAll", () => {
       },
     );
     expect(getVerifiableCredentialAllFromShape).toHaveBeenCalledWith(
-      "https://some.api.endpoint/derive",
+      "https://some.api.endpoint/query",
       expect.anything(),
       expect.objectContaining({
         // FIXME: expecting fetch to match crossFetch fails in node.

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -162,9 +162,9 @@ async function getAccessGrantAll(
   const sessionFetch = await getSessionFetch(options);
   // TODO: Fix access API endpoint retrieval (should include all the different API endpoints)
   const queryEndpoint = options.accessEndpoint
-    ? new URL("derive", options.accessEndpoint)
+    ? new URL("query", options.accessEndpoint)
     : new URL(
-        "derive",
+        "query",
         await getAccessApiEndpoint(params.resource as string, options),
       );
 


### PR DESCRIPTION
# New feature description

Library support for the new `/query` endpoint instead of continuing to use the `/derive` endpoint

# Checklist

- [ ] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
