### PR TITLE
Throw custom error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^2.0.0",
+        "@inrupt/solid-client-errors": "^0.0.2",
         "@inrupt/solid-client-vc": "^1.1.2",
         "@types/rdfjs__dataset": "^2.0.7",
         "auth-header": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
   },
   "dependencies": {
     "@inrupt/solid-client": "^2.0.0",
+    "@inrupt/solid-client-errors": "^0.0.2",
     "@inrupt/solid-client-vc": "^1.1.2",
     "@types/rdfjs__dataset": "^2.0.7",
     "auth-header": "^1.0.0",

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -1,0 +1,24 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { InruptClientError } from "@inrupt/solid-client-errors";
+
+export class AccessGrantError extends InruptClientError { };

--- a/src/common/errors/AccessGrantError.ts
+++ b/src/common/errors/AccessGrantError.ts
@@ -1,0 +1,27 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { InruptClientError } from "@inrupt/solid-client-errors";
+
+/**
+ * Superclass of errors thrown by the @inrupt/solid-client-access-grants library.
+ */
+export class AccessGrantError extends InruptClientError {}

--- a/src/common/errors/UmaError.ts
+++ b/src/common/errors/UmaError.ts
@@ -21,4 +21,7 @@
 
 import { InruptClientError } from "@inrupt/solid-client-errors";
 
-export class AccessGrantError extends InruptClientError { };
+/**
+ * Superclass of errors thrown in the context of using an Access Grant to get access to a resource.
+ */
+export class UmaError extends InruptClientError {}

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -327,7 +327,7 @@ export function getRequestor(vc: DatasetWithId): string {
     );
   }
 
-  throw new Error(`No requestor found.`);
+  throw new AccessGrantError(`No requestor found.`);
 }
 
 /**

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -37,6 +37,7 @@ import { DataFactory } from "n3";
 import type { AccessGrantGConsent } from "../gConsent/type/AccessGrant";
 import type { AccessModes } from "../type/AccessModes";
 import { INHERIT, TYPE, XSD_BOOLEAN, acl, gc, ldp } from "./constants";
+import { AccessGrantError } from "./errors";
 
 const { namedNode, defaultGraph, quad, literal } = DataFactory;
 
@@ -463,8 +464,7 @@ function deserializeFields<T>(
     .map((object) => {
       const result = deserializer(object);
       if (result === undefined) {
-        // FIXME use inrupt error library
-        throw new Error(
+        throw new AccessGrantError(
           `Failed to deserialize value ${object.value} for predicate ${field.href} as type ${type}.`,
         );
       }
@@ -480,8 +480,7 @@ function deserializeField<T>(
 ): T | undefined {
   const result = deserializeFields(vc, field, deserializer, type);
   if (result.length > 1) {
-    // FIXME use inrupt error library
-    throw new Error(
+    throw new AccessGrantError(
       `Expected one value for predicate ${field.href}, found many: ${result}`,
     );
   }
@@ -740,8 +739,7 @@ export function getCustomFields(
         // There is a single key in the current object.
         const curKey = Object.keys(cur)[0];
         if (acc[curKey] !== undefined) {
-          // FIXME use inrupt error
-          throw new Error(
+          throw new AccessGrantError(
             `Expected single values for custom fields, found multiple for ${curKey}`,
           );
         }

--- a/src/common/verify/isValidAccessGrant.ts
+++ b/src/common/verify/isValidAccessGrant.ts
@@ -31,6 +31,7 @@ import {
 import { getBaseAccess } from "../../gConsent/util/getBaseAccessVerifiableCredential";
 import { getSessionFetch } from "../util/getSessionFetch";
 import { toVcDataset } from "../util/toVcDataset";
+import { AccessGrantError } from "../errors/AccessGrantError";
 
 /**
  * Makes a request to the access server to verify the validity of a given Verifiable Credential.
@@ -52,7 +53,7 @@ async function isValidAccessGrant(
   const validVc = await toVcDataset(vc, options);
 
   if (validVc === undefined) {
-    throw new Error(
+    throw new AccessGrantError(
       `Invalid argument: expected either a VC URL or a RDFJS DatasetCore, received ${vc}`,
     );
   }
@@ -66,7 +67,7 @@ async function isValidAccessGrant(
       .verifierService;
 
   if (verifierEndpoint === undefined) {
-    throw new Error(
+    throw new AccessGrantError(
       `The VC service provider ${getIssuer(
         vcObject,
       )} does not advertize for a verifier service in its .well-known/vc-configuration document`,

--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -30,6 +30,7 @@ import {
   CONTEXT_ESS_DEFAULT,
   PRESENTATION_TYPE_BASE,
 } from "../gConsent/constants";
+import { UmaError } from "../common/errors/UmaError";
 
 const WWW_AUTH_HEADER = "www-authenticate";
 const VC_CLAIM_TOKEN_TYPE = "https://www.w3.org/TR/vc-data-model/#json-ld";
@@ -75,7 +76,7 @@ export async function getUmaConfiguration(
   const configurationUrl = new URL(UMA_CONFIG_PATH, authIri).href;
   const response = await fetch(configurationUrl);
   return response.json().catch((e) => {
-    throw new Error(
+    throw new UmaError(
       `Parsing the UMA configuration found at ${configurationUrl} failed with the following error: ${e.toString()}`,
     );
   });
@@ -178,18 +179,18 @@ export async function fetchWithVc(
   const wwwAuthentication = headers.get(WWW_AUTH_HEADER);
 
   if (!wwwAuthentication) {
-    throw new Error(NO_WWW_AUTH_HEADER_ERROR);
+    throw new UmaError(NO_WWW_AUTH_HEADER_ERROR);
   }
 
   const authTicket = parseUMAAuthTicket(wwwAuthentication);
   const authIri = parseUMAAuthIri(wwwAuthentication);
 
   if (!authTicket) {
-    throw new Error(NO_WWW_AUTH_HEADER_UMA_TICKET_ERROR);
+    throw new UmaError(NO_WWW_AUTH_HEADER_UMA_TICKET_ERROR);
   }
 
   if (!authIri) {
-    throw new Error(NO_WWW_AUTH_HEADER_UMA_IRI_ERROR);
+    throw new UmaError(NO_WWW_AUTH_HEADER_UMA_IRI_ERROR);
   }
 
   const umaConfiguration = await getUmaConfiguration(authIri);
@@ -203,7 +204,7 @@ export async function fetchWithVc(
   );
 
   if (!accessToken) {
-    throw new Error(NO_ACCESS_TOKEN_RETURNED);
+    throw new UmaError(NO_ACCESS_TOKEN_RETURNED);
   }
 
   return boundFetch(accessToken);

--- a/src/gConsent/discover/getAccessApiEndpoint.ts
+++ b/src/gConsent/discover/getAccessApiEndpoint.ts
@@ -23,7 +23,6 @@ import type { UrlString } from "@inrupt/solid-client";
 import { parse } from "auth-header";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import { AccessGrantError } from "../../common/errors/AccessGrantError";
-import { UmaError } from "../../common/errors/UmaError";
 
 async function getAccessEndpointForResource(
   resource: UrlString,

--- a/src/gConsent/discover/getAccessApiEndpoint.ts
+++ b/src/gConsent/discover/getAccessApiEndpoint.ts
@@ -22,6 +22,8 @@
 import type { UrlString } from "@inrupt/solid-client";
 import { parse } from "auth-header";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
+import { UmaError } from "../../common/errors/UmaError";
 
 async function getAccessEndpointForResource(
   resource: UrlString,
@@ -30,14 +32,14 @@ async function getAccessEndpointForResource(
   // authorization server.
   const response = await fetch(resource);
   if (!response.headers.has("WWW-Authenticate")) {
-    throw new Error(
+    throw new AccessGrantError(
       `Expected a 401 error with a WWW-Authenticate header, got a [${response.status}: ${response.statusText}] response lacking the WWW-Authenticate header.`,
     );
   }
   const authHeader = response.headers.get("WWW-Authenticate") as string;
   const authHeaderToken = parse(authHeader);
   if (authHeaderToken.scheme !== "UMA") {
-    throw new Error(
+    throw new AccessGrantError(
       `Unsupported authorization scheme: [${authHeaderToken.scheme}]`,
     );
   }
@@ -49,7 +51,7 @@ async function getAccessEndpointForResource(
   const rawDiscoveryDocument = await fetch(wellKnownIri.href);
   const discoveryDocument = await rawDiscoveryDocument.json();
   if (typeof discoveryDocument.verifiable_credential_issuer !== "string") {
-    throw new Error(
+    throw new AccessGrantError(
       `No access issuer listed for property [verifiable_credential_issuer] in [${JSON.stringify(
         discoveryDocument,
       )}]`,
@@ -76,7 +78,7 @@ async function getAccessApiEndpoint(
   try {
     return await getAccessEndpointForResource(resource.toString());
   } catch (e: unknown) {
-    throw new Error(
+    throw new AccessGrantError(
       `Couldn't figure out the Access Grant issuer from the resources: ${e}`,
     );
   }

--- a/src/gConsent/discover/getAccessManagementUi.ts
+++ b/src/gConsent/discover/getAccessManagementUi.ts
@@ -30,6 +30,7 @@ import {
 import { getSessionFetch } from "../../common/util/getSessionFetch";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import { PIM_STORAGE, PREFERRED_CONSENT_MANAGEMENT_UI } from "../constants";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 interface AccessManagementUiFromProfile {
   accessEndpoint?: UrlString;
@@ -48,12 +49,14 @@ async function getAccessManagementUiFromProfile(
       fetch: options.fetch,
     });
   } catch (e) {
-    throw new Error(`Cannot get the Access Management UI for ${webId}: ${e}.`);
+    throw new AccessGrantError(
+      `Cannot get the Access Management UI for ${webId}: ${e}.`,
+    );
   }
 
   const profile = getThing(webIdDocument, webId);
   if (profile === null) {
-    throw new Error(
+    throw new AccessGrantError(
       `Cannot get the Access Management UI for ${webId}: the WebID cannot be dereferenced.`,
     );
   }

--- a/src/gConsent/discover/redirectToAccessManagementUi.ts
+++ b/src/gConsent/discover/redirectToAccessManagementUi.ts
@@ -35,6 +35,7 @@ import type { FetchOptions } from "../../type/FetchOptions";
 import type { RedirectOptions } from "../../type/RedirectOptions";
 import { getResources } from "../../common";
 import { toVcDataset } from "../../common/util/toVcDataset";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 export const REQUEST_VC_URL_PARAM_NAME = "requestVcUrl";
 export const REDIRECT_URL_PARAM_NAME = "redirectUrl";
@@ -104,7 +105,7 @@ export async function redirectToAccessManagementUi(
   const validVc = await toVcDataset(accessRequestVc, options);
 
   if (validVc === undefined) {
-    throw new Error(
+    throw new AccessGrantError(
       `Invalid argument: expected either a VC URL or a RDFJS DatasetCore, received ${accessRequestVc}`,
     );
   }
@@ -123,7 +124,7 @@ export async function redirectToAccessManagementUi(
   });
 
   if (accessManagementUi === undefined) {
-    throw new Error(
+    throw new AccessGrantError(
       `Cannot discover access management UI URL for [${resourceUrl}]${
         options.resourceOwner ? `, neither from [${options.resourceOwner}]` : ""
       }`,

--- a/src/gConsent/guard/isGConsentAttributes.ts
+++ b/src/gConsent/guard/isGConsentAttributes.ts
@@ -30,6 +30,7 @@ import { RESOURCE_ACCESS_MODE } from "../../type/ResourceAccessMode";
 import { isUnknownObject } from "./isUnknownObject";
 import type { GConsentStatus } from "../type/GConsentStatus";
 import { acl, gc } from "../../common/constants";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 const { defaultGraph } = DataFactory;
 
@@ -104,7 +105,7 @@ export function isRdfjsGConsentAttributes(
   );
 
   if (forPersonalData.size === 0) {
-    throw new Error("No Personal Data specified for Access Grant");
+    throw new AccessGrantError("No Personal Data specified for Access Grant");
   }
 
   for (const { object } of forPersonalData) {

--- a/src/gConsent/manage/approveAccessRequest.ts
+++ b/src/gConsent/manage/approveAccessRequest.ts
@@ -52,6 +52,7 @@ import { initializeGrantParameters } from "../util/initializeGrantParameters";
 import { getGrantBody, issueAccessVc } from "../util/issueAccessVc";
 import { toVcDataset } from "../../common/util/toVcDataset";
 import type { CustomField } from "../../type/CustomField";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 export type ApproveAccessRequestOverrides = Omit<
   Omit<AccessGrantParameters, "status">,
@@ -75,7 +76,7 @@ export function normalizeAccessGrant<T extends VerifiableCredentialBase>(
   // Proper type checking is performed after normalization, so casting here is fine.
   const normalized = { ...accessGrant } as unknown as AccessGrant;
   if (normalized.credentialSubject.providedConsent === undefined) {
-    throw new Error(
+    throw new AccessGrantError(
       `[${normalized.id}] is not an Access Grant: missing field "credentialSubject.providedConsent".`,
     );
   }
@@ -128,7 +129,7 @@ async function addVcMatcher(
       );
       // eslint-disable-next-line camelcase
       if (!acp_ess_2.hasAccessibleAcr(resourceInfo)) {
-        throw new Error(
+        throw new AccessGrantError(
           "The current user does not have access to the resource's Access Control Resource. Either they have insufficiant credentials, or the resource is not controlled using ACP. In either case, an Access Grant cannot be issued.",
         );
       }
@@ -340,7 +341,7 @@ export async function approveAccessRequest(
         !isAccessGrant(accessGrant)
       : !isRdfjsBaseAccessGrantVerifiableCredential(accessGrant)
   ) {
-    throw new Error(
+    throw new AccessGrantError(
       `Unexpected response when approving Access Request, the result is not an Access Grant: ${JSON.stringify(
         accessGrant,
       )}`,

--- a/src/gConsent/manage/denyAccessRequest.ts
+++ b/src/gConsent/manage/denyAccessRequest.ts
@@ -33,6 +33,7 @@ import { getGrantBody, issueAccessVc } from "../util/issueAccessVc";
 import { normalizeAccessGrant } from "./approveAccessRequest";
 import { getBaseAccess } from "../util/getBaseAccessVerifiableCredential";
 import { toVcDataset } from "../../common/util/toVcDataset";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 /**
  * Deny an access request. The content of the denied access request is provided
@@ -95,7 +96,7 @@ async function denyAccessRequest(
   const validVc = await toVcDataset(vc, options);
 
   if (validVc === undefined) {
-    throw new Error(
+    throw new AccessGrantError(
       `Invalid argument: expected either a VC URL or a RDFJS DatasetCore, received ${vc}`,
     );
   }

--- a/src/gConsent/manage/getAccessGrant.ts
+++ b/src/gConsent/manage/getAccessGrant.ts
@@ -31,6 +31,7 @@ import {
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import type { AccessGrant } from "../type/AccessGrant";
 import { normalizeAccessGrant } from "./approveAccessRequest";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 /**
  * Retrieve the Access Grant associated to the given URL.
@@ -105,7 +106,7 @@ export async function getAccessGrant(
       !isRdfjsBaseAccessGrantVerifiableCredential(data) ||
       !isGConsentAccessGrant(data)
     ) {
-      throw new Error(
+      throw new AccessGrantError(
         `Unexpected response when resolving [${vcUrl}], the result is not an Access Grant: ${JSON.stringify(
           data,
           null,
@@ -121,7 +122,7 @@ export async function getAccessGrant(
     normalize: normalizeAccessGrant,
   });
   if (!isBaseAccessGrantVerifiableCredential(data) || !isAccessGrant(data)) {
-    throw new Error(
+    throw new AccessGrantError(
       `Unexpected response when resolving [${vcUrl}], the result is not an Access Grant: ${JSON.stringify(
         data,
       )}`,

--- a/src/gConsent/manage/getAccessGrantAll.ts
+++ b/src/gConsent/manage/getAccessGrantAll.ts
@@ -47,6 +47,7 @@ import {
 import { getInherit, getResources } from "../../common/getters";
 import { normalizeAccessGrant } from "./approveAccessRequest";
 import { gc } from "../../common/constants";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 export type AccessParameters = Partial<
   Pick<IssueAccessRequestParameters, "access" | "purpose"> & {
@@ -157,7 +158,9 @@ async function getAccessGrantAll(
   } = {},
 ): Promise<Array<DatasetWithId>> {
   if (!params.resource && !options.accessEndpoint) {
-    throw new Error("resource and accessEndpoint cannot both be undefined");
+    throw new AccessGrantError(
+      "resource and accessEndpoint cannot both be undefined",
+    );
   }
   const sessionFetch = await getSessionFetch(options);
   // TODO: Fix access API endpoint retrieval (should include all the different API endpoints)

--- a/src/gConsent/manage/getAccessRequest.ts
+++ b/src/gConsent/manage/getAccessRequest.ts
@@ -28,6 +28,7 @@ import {
 import type { AccessRequest } from "../type/AccessRequest";
 import { getSessionFetch } from "../../common/util/getSessionFetch";
 import { normalizeAccessRequest } from "../request/issueAccessRequest";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 /**
  * Fetch the Access Request from the given URL.
@@ -94,7 +95,7 @@ export async function getAccessRequest(
     });
 
     if (!isRdfjsAccessRequest(accessRequest)) {
-      throw new Error(
+      throw new AccessGrantError(
         `${JSON.stringify(accessRequest)} is not an Access Request`,
       );
     }
@@ -107,7 +108,7 @@ export async function getAccessRequest(
   });
 
   if (!isAccessRequest(accessRequest)) {
-    throw new Error(
+    throw new AccessGrantError(
       `${JSON.stringify(accessRequest, null, 2)} is not an Access Request`,
     );
   }

--- a/src/gConsent/manage/getAccessRequestFromRedirectUrl.ts
+++ b/src/gConsent/manage/getAccessRequestFromRedirectUrl.ts
@@ -27,11 +27,12 @@ import {
 } from "../discover/redirectToAccessManagementUi";
 import type { AccessRequest } from "../type/AccessRequest";
 import getAccessRequest from "./getAccessRequest";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 function getSearchParam(url: URL, param: string) {
   const value = url.searchParams.get(param);
   if (value === null) {
-    throw new Error(
+    throw new AccessGrantError(
       `The provided redirect URL [${url.toString()}] is missing the expected [${param}] query parameter`,
     );
   }

--- a/src/gConsent/manage/revokeAccessGrant.ts
+++ b/src/gConsent/manage/revokeAccessGrant.ts
@@ -36,6 +36,7 @@ import { getSessionFetch } from "../../common/util/getSessionFetch";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import { getBaseAccess } from "../util/getBaseAccessVerifiableCredential";
 import { toVcDataset } from "../../common/util/toVcDataset";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 const { quad, namedNode } = DataFactory;
 
@@ -57,7 +58,7 @@ async function revokeAccessCredential(
   const validVc = await toVcDataset(vc, options);
 
   if (validVc === undefined) {
-    throw new Error(
+    throw new AccessGrantError(
       `Invalid argument: expected either a VC URL or a RDFJS DatasetCore, received ${vc}`,
     );
   }

--- a/src/gConsent/request/getAccessGrantFromRedirectUrl.ts
+++ b/src/gConsent/request/getAccessGrantFromRedirectUrl.ts
@@ -24,6 +24,7 @@ import type { DatasetWithId } from "@inrupt/solid-client-vc";
 import { getAccessGrant } from "../manage";
 import { GRANT_VC_URL_PARAM_NAME } from "../manage/redirectToRequestor";
 import type { AccessGrant } from "../type/AccessGrant";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 /**
  * Get the Access Grant out of the incoming redirect from the Access Management app.
@@ -83,7 +84,7 @@ export async function getAccessGrantFromRedirectUrl(
     GRANT_VC_URL_PARAM_NAME,
   );
   if (accessGrantIri === null) {
-    throw new Error(
+    throw new AccessGrantError(
       `The provided redirect URL [${redirectUrl}] is missing the expected [${GRANT_VC_URL_PARAM_NAME}] query parameter`,
     );
   }

--- a/src/gConsent/request/issueAccessRequest.ts
+++ b/src/gConsent/request/issueAccessRequest.ts
@@ -37,6 +37,7 @@ import {
   isRdfjsAccessRequest,
 } from "../guard/isAccessRequest";
 import { gc } from "../../common/constants";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 /**
  * Internal function. This is a stopgap until we have proper JSON-LD parsing.
@@ -152,7 +153,7 @@ async function issueAccessRequest(
       returnLegacyJsonld: false,
     });
     if (!isRdfjsAccessRequest(accessRequest)) {
-      throw new Error(
+      throw new AccessGrantError(
         `${JSON.stringify(accessRequest)} is not an Access Request`,
       );
     }

--- a/src/gConsent/util/getBaseAccessVerifiableCredential.ts
+++ b/src/gConsent/util/getBaseAccessVerifiableCredential.ts
@@ -26,6 +26,7 @@ import { DataFactory } from "n3";
 import { TYPE, gc } from "../../common/constants";
 import type { AccessBaseOptions } from "../type/AccessBaseOptions";
 import { getConsent } from "../../common/getters";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 const { quad, namedNode } = DataFactory;
 
@@ -36,12 +37,12 @@ export async function getBaseAccess(
   hasStatus?: NamedNode,
 ) {
   if (type && !vc.has(quad(namedNode(getId(vc)), TYPE, type))) {
-    throw new Error(
+    throw new AccessGrantError(
       `An error occurred when type checking the VC: Not of type [${type.value}].`,
     );
   }
   if (hasStatus && !vc.has(quad(getConsent(vc), gc.hasStatus, hasStatus))) {
-    throw new Error(
+    throw new AccessGrantError(
       `An error occurred when type checking the VC: status not [${hasStatus.value}].`,
     );
   }

--- a/src/gConsent/util/issueAccessVc.ts
+++ b/src/gConsent/util/issueAccessVc.ts
@@ -53,6 +53,7 @@ import { accessToResourceAccessModeArray } from "./accessToResourceAccessModeArr
 import { isBaseRequest } from "../guard/isBaseRequest";
 import type { AccessCredentialType } from "../type/AccessCredentialType";
 import type { CustomField } from "../../type/CustomField";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 function getGConsentAttributes(
   params: AccessRequestParameters,
@@ -210,13 +211,13 @@ export async function issueAccessVc(
     hasConsent &&
     vcBody.credentialSubject.hasConsent.forPersonalData.length <= 0
   ) {
-    throw new Error("There are no resources in the access request!");
+    throw new AccessGrantError("There are no resources in the access request!");
   } else if (
     !hasConsent &&
     (vcBody as BaseGrantBody).credentialSubject.providedConsent.forPersonalData
       .length <= 0
   ) {
-    throw new Error("There are no resources in the access grant!");
+    throw new AccessGrantError("There are no resources in the access grant");
   }
 
   const targetResourceIri = isBaseRequest(vcBody)

--- a/src/gConsent/util/issueAccessVc.ts
+++ b/src/gConsent/util/issueAccessVc.ts
@@ -211,7 +211,7 @@ export async function issueAccessVc(
     hasConsent &&
     vcBody.credentialSubject.hasConsent.forPersonalData.length <= 0
   ) {
-    throw new AccessGrantError("There are no resources in the access request!");
+    throw new AccessGrantError("There are no resources in the access request");
   } else if (
     !hasConsent &&
     (vcBody as BaseGrantBody).credentialSubject.providedConsent.forPersonalData

--- a/src/gConsent/util/redirect.ts
+++ b/src/gConsent/util/redirect.ts
@@ -21,6 +21,7 @@
 
 import type { UrlString } from "@inrupt/solid-client";
 import type { RedirectOptions } from "../../type/RedirectOptions";
+import { AccessGrantError } from "../../common/errors/AccessGrantError";
 
 /**
  * Internal function implementing redirection with some query parameters.
@@ -42,7 +43,7 @@ export async function redirectWithParameters(
     options.redirectCallback(targetUrl.href);
   } else {
     if (typeof window === "undefined") {
-      throw new Error(
+      throw new AccessGrantError(
         "In a non-browser environment, a redirectCallback must be provided by the user.",
       );
     }

--- a/src/type/CustomField.ts
+++ b/src/type/CustomField.ts
@@ -20,6 +20,7 @@
 //
 
 import { INHERIT, acl, gc } from "../common/constants";
+import { AccessGrantError } from "../common/errors";
 
 export type CustomField = {
   /* The custom field name (this must be a URL). */
@@ -57,14 +58,12 @@ export const toJson = (
       // and change the validated CustomField into a plain JSON object entry.
       .map((field) => {
         if (isWellKnown(field.key)) {
-          // FIXME use inrupt error library
-          throw new Error(
+          throw new AccessGrantError(
             `${field.key.href} is a reserved field, and cannot be used as a custom field`,
           );
         }
         if (typeof field.key !== "object") {
-          // FIXME use inrupt error library
-          throw new Error(
+          throw new AccessGrantError(
             `All custom fields keys must be URL objects, found ${field.key}`,
           );
         }
@@ -73,8 +72,7 @@ export const toJson = (
             typeof field.value,
           )
         ) {
-          // FIXME use inrupt error library
-          throw new Error(
+          throw new AccessGrantError(
             `All custom fields values must be literals, found ${JSON.stringify(field.value)} (of type ${typeof field.value})`,
           );
         }
@@ -86,8 +84,7 @@ export const toJson = (
           // We know the current object has a single key.
           if (acc[Object.keys(cur)[0]] !== undefined) {
             // If the provided key already exists, the input is invalid.
-            // FIXME use inrupt error library
-            throw new Error(
+            throw new AccessGrantError(
               `Each custom field key must be unique. Found multiple values for ${Object.keys(cur)[0]}`,
             );
           }

--- a/src/type/CustomField.ts
+++ b/src/type/CustomField.ts
@@ -20,7 +20,7 @@
 //
 
 import { INHERIT, acl, gc } from "../common/constants";
-import { AccessGrantError } from "../common/errors";
+import { AccessGrantError } from "../common/errors/AccessGrantError";
 
 export type CustomField = {
   /* The custom field name (this must be a URL). */


### PR DESCRIPTION
This makes it so that the library throws a custom `AccessGrantError` (or `UmaError`, extending the shared `InruptClientError` instead of a generic `Error`.