### PR TITLE
SDK-3395: Link Access Grant to Access Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ The following changes are pending, and will be applied on the next major release
 
 ## Unreleased
 
+### Patch changes
+
+- When issuing an Access Grant from an Access Request using `approveAccessRequest`,
+  the resulting Access Request now references the source Access Request. A new
+  `getRequest` getter has been added to get this value from an Access Grant.
+  This will result in the `query` module no longer showing approved Access Requests
+  as "Pending".
+- The `query` function now supports the `type` filter not being set, which will result
+  in both Access Grants and Access Requests matching the provided filters being returned.
+
 ## [3.2.1](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v3.2.1) - 2025-01-13
 
 ### New feature

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -88,6 +88,8 @@ import {
   getPurposes,
 } from "../../src/common/getters";
 import { toBeEqual } from "../../src/gConsent/util/toBeEqual.mock";
+import { setGlobalDispatcher, ProxyAgent } from "undici";
+
 
 const { namedNode } = DataFactory;
 
@@ -231,7 +233,6 @@ describe(`End-to-end access grant tests for environment [${environment}] `, () =
       retryAsync(getRequestorSession),
       retryAsync(() => getAuthenticatedSession(env)),
     ];
-
     sessionInterval = setInterval(
       async () => {
         const nextSessions = [
@@ -1719,11 +1720,12 @@ describe(`End-to-end access grant tests for environment [${environment}] `, () =
   describeIf(environmentFeatures?.QUERY_ENDPOINT === "true")(
     "query endpoint",
     () => {
-      it.skip("can navigate the paginated results", async () => {
+      it("can navigate the paginated results", async () => {
         const allCredentialsPageOne = await query(
           {
-            pageSize: 15,
+            pageSize: 2,
             type: "SolidAccessGrant",
+            issuedWithin: "P1D"
           },
           {
             fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
@@ -1746,9 +1748,9 @@ describe(`End-to-end access grant tests for environment [${environment}] `, () =
         expect(allCredentialsPageTwo.items.length).toBeLessThanOrEqual(200);
       });
 
-      it.skip("can filter based on one or more criteria", async () => {
+      it("can filter based on one or more criteria", async () => {
         const onType = await query(
-          { type: "SolidAccessGrant" },
+          { type: "SolidAccessGrant", issuedWithin: "P1D" },
           {
             fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
             // FIXME add query endpoint discovery check.
@@ -1774,11 +1776,13 @@ describe(`End-to-end access grant tests for environment [${environment}] `, () =
         );
       });
 
-      it.skip("can iterate through pages", async () => {
+      it("can iterate through pages", async () => {
         const pages = paginatedQuery(
           {
-            pageSize: 20,
+            pageSize: 2,
             type: "SolidAccessRequest",
+            issuedWithin: "P1D"
+            
           },
           {
             fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
@@ -1786,17 +1790,70 @@ describe(`End-to-end access grant tests for environment [${environment}] `, () =
             queryEndpoint: new URL("query", vcProvider),
           },
         );
-        const maxPages = 2;
         let pageCount = 0;
         for await (const page of pages) {
           expect(page.items).not.toHaveLength(0);
           pageCount += 1;
           // Avoid iterating for too long when there are a lot of results.
-          if (pageCount === maxPages) {
+        }
+      }, 120_000);
+
+      it("shows updated status for an approved request", async () => {
+        // Issue an Access Request.
+        const request = await issueAccessRequest(
+          {
+            access: { read: true },
+            resourceOwner: resourceOwnerSession.info.webId as string,
+            resources: [sharedFileIri],
+            expirationDate: new Date(Date.now() + 60 * 60 * 1000),
+          },
+          {
+            fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
+            accessEndpoint: vcProvider,
+            updateAcr: false,
+            returnLegacyJsonld: false,
+          },
+        );
+        console.debug("Access request issued");
+        const pendingRequests = paginatedQuery(
+          { status: "Pending", issuedWithin: "P1D" },
+          {
+            fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
+            queryEndpoint: new URL("query", vcProvider),
+          },
+        );
+        let foundRequest = false;
+        let currentPage = 1;
+        for await (const page of pendingRequests) {
+          currentPage++;
+          if (page.items.map((item) => item.id).includes(request.id)) {
+            foundRequest = true;
             break;
           }
         }
-      }, 120_000);
+        expect(foundRequest).toBe(true);
+        await approveAccessRequest(
+          request,
+          {},
+          {
+            fetch: addUserAgent(resourceOwnerSession.fetch, TEST_USER_AGENT),
+            accessEndpoint: vcProvider,
+            updateAcr: false,
+            returnLegacyJsonld: false,
+          },
+        );
+        // Check the request status has been updated and is no longer "Pending"
+        foundRequest = false;
+        currentPage = 1;
+        for await (const page of pendingRequests) {
+          currentPage++;
+          if (page.items.map((item) => item.id).includes(request.id)) {
+            foundRequest = true;
+            break;
+          }
+        }
+        expect(foundRequest).toBe(false);
+      });
     },
   );
 });

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -1808,7 +1808,6 @@ describe(`End-to-end access grant tests for environment [${environment}] `, () =
             returnLegacyJsonld: false,
           },
         );
-        console.debug("Access request issued");
         const pendingRequests = paginatedQuery(
           { status: "Pending", issuedWithin: "P1D" },
           {

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -88,8 +88,6 @@ import {
   getPurposes,
 } from "../../src/common/getters";
 import { toBeEqual } from "../../src/gConsent/util/toBeEqual.mock";
-import { setGlobalDispatcher, ProxyAgent } from "undici";
-
 
 const { namedNode } = DataFactory;
 
@@ -1725,7 +1723,7 @@ describe(`End-to-end access grant tests for environment [${environment}] `, () =
           {
             pageSize: 2,
             type: "SolidAccessGrant",
-            issuedWithin: "P1D"
+            issuedWithin: "P1D",
           },
           {
             fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
@@ -1781,8 +1779,7 @@ describe(`End-to-end access grant tests for environment [${environment}] `, () =
           {
             pageSize: 2,
             type: "SolidAccessRequest",
-            issuedWithin: "P1D"
-            
+            issuedWithin: "P1D",
           },
           {
             fetch: addUserAgent(requestorSession.fetch, TEST_USER_AGENT),
@@ -1790,11 +1787,8 @@ describe(`End-to-end access grant tests for environment [${environment}] `, () =
             queryEndpoint: new URL("query", vcProvider),
           },
         );
-        let pageCount = 0;
         for await (const page of pages) {
           expect(page.items).not.toHaveLength(0);
-          pageCount += 1;
-          // Avoid iterating for too long when there are a lot of results.
         }
       }, 120_000);
 
@@ -1823,9 +1817,7 @@ describe(`End-to-end access grant tests for environment [${environment}] `, () =
           },
         );
         let foundRequest = false;
-        let currentPage = 1;
         for await (const page of pendingRequests) {
-          currentPage++;
           if (page.items.map((item) => item.id).includes(request.id)) {
             foundRequest = true;
             break;
@@ -1844,9 +1836,7 @@ describe(`End-to-end access grant tests for environment [${environment}] `, () =
         );
         // Check the request status has been updated and is no longer "Pending"
         foundRequest = false;
-        currentPage = 1;
         for await (const page of pendingRequests) {
-          currentPage++;
           if (page.items.map((item) => item.id).includes(request.id)) {
             foundRequest = true;
             break;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -35,6 +35,7 @@ export const solidVc = {
   SolidAccessRequest: namedNode(`${VC}SolidAccessRequest`),
   SolidAccessGrant: namedNode(`${VC}SolidAccessGrant`),
   SolidAccessDenial: namedNode(`${VC}SolidAccessDenial`),
+  request: namedNode(`${VC}request`),
 };
 
 export const gc = {

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -47,9 +47,10 @@ import {
   getResources,
   getCustomString,
   getTypes,
+getRequest,
 } from "./getters";
 import type { AccessGrant, AccessRequest } from "../gConsent";
-import { TYPE, gc } from "./constants";
+import { TYPE, gc, solidVc } from "./constants";
 
 const { quad, namedNode, literal, blankNode } = DataFactory;
 
@@ -910,6 +911,60 @@ describe("getters", () => {
     });
   });
 
+  describe("getRequest", () => {
+    it("gets the request from a gConsent access grant", async () => {
+      const requestId = "https://example.org/request/123";
+      const grantWithRequest = await mockGConsentGrant(undefined, (grant) => {
+        // eslint-disable-next-line no-param-reassign
+        grant.credentialSubject.providedConsent.request = requestId;
+      });
+
+      expect(getRequest(grantWithRequest)).toBe(requestId);
+    });
+
+    it("returns undefined if the request is not present in a gConsent access grant", async () => {
+      // Use the default mocked grant which doesn't have a request field
+      expect(getRequest(mockedGConsentGrant)).toBeUndefined();
+    });
+
+    it("ignores request if it is not a NamedNode", async () => {
+      const store = new Store([
+        ...mockedGConsentGrant,
+        quad(
+          getConsent(mockedGConsentGrant),
+          solidVc.request,
+          literal("hello world"),
+        ),
+      ]);
+
+      expect(
+        getRequest(Object.assign(store, { id: mockedGConsentGrant.id }))
+      ).totoBe    });
+
+    it("handles multiple request values by returning the first one", async () => {
+      const firstRequestId = "https://example.org/request/123";
+      const secondRequestId = "https://example.org/request/456";
+
+      const store = new Store([
+        ...mockedGConsentGrant,
+        quad(
+          getConsent(mockedGConsentGrant),
+          solidVc.request,
+          namedNode(firstRequestId),
+        ),
+        quad(
+          getConsent(mockedGConsentGrant),
+          solidVc.request,
+          namedNode(secondRequestId),
+        ),
+      ]);
+
+      expect(
+        getRequest(Object.assign(store, { id: mockedGConsentGrant.id })),
+      ).toBe(firstRequestId);
+    });
+  });
+
   describe("AccessGrant", () => {
     it("wraps calls to the underlying functions", async () => {
       const wrappedConsentRequest = new AccessGrantWrapper(
@@ -950,6 +1005,9 @@ describe("getters", () => {
       );
       expect(wrappedConsentRequest.getInbox()).toStrictEqual(
         getInbox(mockedGConsentRequest),
+      );
+      expect(wrappedConsentRequest.getRequest()).toStrictEqual(
+       getRequest(mockedGConsentRequest),
       );
     });
   });

--- a/src/common/getters.test.ts
+++ b/src/common/getters.test.ts
@@ -47,7 +47,7 @@ import {
   getResources,
   getCustomString,
   getTypes,
-getRequest,
+  getRequest,
 } from "./getters";
 import type { AccessGrant, AccessRequest } from "../gConsent";
 import { TYPE, gc, solidVc } from "./constants";
@@ -938,8 +938,9 @@ describe("getters", () => {
       ]);
 
       expect(
-        getRequest(Object.assign(store, { id: mockedGConsentGrant.id }))
-      ).totoBe    });
+        getRequest(Object.assign(store, { id: mockedGConsentGrant.id })),
+      ).toBeUndefined();
+    });
 
     it("handles multiple request values by returning the first one", async () => {
       const firstRequestId = "https://example.org/request/123";
@@ -1007,7 +1008,7 @@ describe("getters", () => {
         getInbox(mockedGConsentRequest),
       );
       expect(wrappedConsentRequest.getRequest()).toStrictEqual(
-       getRequest(mockedGConsentRequest),
+        getRequest(mockedGConsentRequest),
       );
     });
   });

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -386,13 +386,11 @@ export function getAccessModes(vc: DatasetWithId): AccessModes {
  */
 export function getRequest(grant: DatasetWithId): string | undefined {
   const consent = getConsent(grant);
-  const result = Array.from(grant.match(
-    consent,
-    solidVc.request,
-    null,
-    defaultGraph(),
-  )).filter(({ object }) => object.termType === "NamedNode")
-  .map(({ object }) => object.value);
+  const result = Array.from(
+    grant.match(consent, solidVc.request, null, defaultGraph()),
+  )
+    .filter(({ object }) => object.termType === "NamedNode")
+    .map(({ object }) => object.value);
   if (result.length === 0) {
     return undefined;
   }

--- a/src/common/getters.ts
+++ b/src/common/getters.ts
@@ -36,7 +36,7 @@ import type {
 import { DataFactory } from "n3";
 import type { AccessGrantGConsent } from "../gConsent/type/AccessGrant";
 import type { AccessModes } from "../type/AccessModes";
-import { INHERIT, TYPE, XSD_BOOLEAN, acl, gc, ldp } from "./constants";
+import { INHERIT, TYPE, XSD_BOOLEAN, acl, gc, ldp, solidVc } from "./constants";
 import { AccessGrantError } from "./errors/AccessGrantError";
 
 const { namedNode, defaultGraph, quad, literal } = DataFactory;
@@ -370,6 +370,33 @@ export function getAccessModes(vc: DatasetWithId): AccessModes {
     write: vc.has(quad(consent, acl.mode, acl.Write, defaultGraph())),
     append: vc.has(quad(consent, acl.mode, acl.Append, defaultGraph())),
   };
+}
+
+/**
+ * Get the request related to the provided Access Grant, if any.
+ *
+ * @example
+ *
+ * ```
+ * const requestUrl = getRequest(accessGrant);
+ * ```
+ *
+ * @param grant The Access Grant
+ * @returns The request IRI
+ */
+export function getRequest(grant: DatasetWithId): string | undefined {
+  const consent = getConsent(grant);
+  const result = Array.from(grant.match(
+    consent,
+    solidVc.request,
+    null,
+    defaultGraph(),
+  )).filter(({ object }) => object.termType === "NamedNode")
+  .map(({ object }) => object.value);
+  if (result.length === 0) {
+    return undefined;
+  }
+  return result[0];
 }
 
 const shorthand = {
@@ -816,5 +843,9 @@ export class AccessGrantWrapper {
 
   getInherit(): ReturnType<typeof getInherit> {
     return getInherit(this.vc);
+  }
+
+  getRequest(): ReturnType<typeof getRequest> {
+    return getRequest(this.vc);
   }
 }

--- a/src/gConsent/manage/approveAccessRequest.test.ts
+++ b/src/gConsent/manage/approveAccessRequest.test.ts
@@ -430,6 +430,7 @@ describe("approveAccessRequest", () => {
             accessRequestVc.credentialSubject.hasConsent.forPersonalData,
           isProvidedTo: accessRequestVc.credentialSubject.id,
           forPurpose: [],
+          request: customRequest.id,
         },
         inbox: accessRequestVc.credentialSubject.inbox,
       }),
@@ -485,6 +486,7 @@ describe("approveAccessRequest", () => {
             accessRequestVc.credentialSubject.hasConsent.forPersonalData,
           isProvidedTo: accessRequestVc.credentialSubject.id,
           forPurpose: [],
+          request: customRequest.id,
           "https://example.org/ns/customString": "custom value",
           "https://example.org/ns/customBoolean": true,
           "https://example.org/ns/customInt": 1,
@@ -529,6 +531,7 @@ describe("approveAccessRequest", () => {
             accessRequestVc.credentialSubject.hasConsent.forPersonalData,
           isProvidedTo: accessRequestVc.credentialSubject.id,
           forPurpose: [],
+          request: accessRequestVc.id,
         },
         inbox: accessRequestVc.credentialSubject.inbox,
       }),
@@ -566,47 +569,7 @@ describe("approveAccessRequest", () => {
           isProvidedTo: accessRequestVc.credentialSubject.id,
           forPurpose: accessRequestVc.credentialSubject.hasConsent
             .forPurpose ?? ["https://some.purpose"],
-        },
-        inbox: accessRequestVc.credentialSubject.inbox,
-      }),
-      expect.objectContaining({
-        type: ["SolidAccessGrant"],
-      }),
-      expect.anything(),
-    );
-  });
-
-  it("issues a proper access grant from a given plain JSON request VC IRI", async () => {
-    mockAcpClient();
-    mockAccessApiEndpoint();
-    const mockedIssue = jest.spyOn(
-      jest.requireMock("@inrupt/solid-client-vc") as typeof VcClient,
-      "issueVerifiableCredential",
-    );
-    mockedIssue.mockResolvedValueOnce(accessGrantVc);
-    const mockedFetch = jest.fn<typeof fetch>();
-    mockedFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify(consentRequestVc)),
-    );
-    await approveAccessRequest(
-      JSON.parse(JSON.stringify("https://some.credential")),
-      undefined,
-      {
-        fetch: mockedFetch,
-      },
-    );
-
-    expect(mockedIssue).toHaveBeenCalledWith(
-      `${MOCKED_ACCESS_ISSUER}/issue`,
-      expect.objectContaining({
-        providedConsent: {
-          mode: accessRequestVc.credentialSubject.hasConsent.mode,
-          hasStatus: "https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-          forPersonalData:
-            accessRequestVc.credentialSubject.hasConsent.forPersonalData,
-          isProvidedTo: accessRequestVc.credentialSubject.id,
-          forPurpose: accessRequestVc.credentialSubject.hasConsent
-            .forPurpose ?? ["https://some.purpose"],
+          request: "https://some.credential",
         },
         inbox: accessRequestVc.credentialSubject.inbox,
       }),
@@ -705,6 +668,7 @@ describe("approveAccessRequest", () => {
           isProvidedTo: consentRequestVc.credentialSubject.id,
           forPurpose:
             consentGrantVc.credentialSubject.providedConsent.forPurpose,
+          request: consentRequestVc.id,
         },
       }),
       expect.objectContaining({
@@ -746,6 +710,7 @@ describe("approveAccessRequest", () => {
           forPersonalData: ["https://some-custom.resource"],
           isProvidedTo: consentRequestVc.credentialSubject.id,
           forPurpose: ["https://some-custom.purpose"],
+          request: consentRequestVc.id,
         },
         inbox: consentRequestVc.credentialSubject.inbox,
       }),
@@ -856,6 +821,7 @@ describe("approveAccessRequest", () => {
           forPersonalData: ["https://some-custom.resource"],
           isProvidedTo: "https://some-custom.requestor",
           forPurpose: ["https://some-custom.purpose"],
+          request: customRequest.id,
           "https://example.org/ns/customString": "overriddenCustomValue",
           "https://example.org/ns/customBoolean": false,
           "https://example.org/ns/customInt": 2,
@@ -1067,6 +1033,7 @@ describe("approveAccessRequest", () => {
           isProvidedTo: consentRequestVc.credentialSubject.id,
           forPurpose:
             consentGrantVc.credentialSubject.providedConsent.forPurpose,
+          request: consentRequestVc.id,
         },
         inbox: consentRequestVc.credentialSubject.inbox,
       }),
@@ -1110,6 +1077,7 @@ describe("approveAccessRequest", () => {
             consentRequestVc.credentialSubject.hasConsent.forPersonalData,
           isProvidedTo: consentRequestVc.credentialSubject.id,
           forPurpose: consentRequestVc.credentialSubject.hasConsent.forPurpose,
+          request: consentRequestVc.id,
         },
         inbox: consentRequestVc.credentialSubject.inbox,
       }),
@@ -1153,6 +1121,7 @@ describe("approveAccessRequest", () => {
             consentRequestVc.credentialSubject.hasConsent.forPersonalData,
           isProvidedTo: consentRequestVc.credentialSubject.id,
           forPurpose: consentRequestVc.credentialSubject.hasConsent.forPurpose,
+          request: consentRequestVc.id,
         },
         inbox: consentRequestVc.credentialSubject.inbox,
       }),
@@ -1197,6 +1166,7 @@ describe("approveAccessRequest", () => {
             consentRequestVc.credentialSubject.hasConsent.forPersonalData,
           isProvidedTo: consentRequestVc.credentialSubject.id,
           forPurpose: consentRequestVc.credentialSubject.hasConsent.forPurpose,
+          request: consentRequestVc.id,
         },
         inbox: consentRequestVc.credentialSubject.inbox,
       }),
@@ -1242,6 +1212,7 @@ describe("approveAccessRequest", () => {
             consentRequestVc.credentialSubject.hasConsent.forPersonalData,
           isProvidedTo: consentRequestVc.credentialSubject.id,
           forPurpose: consentRequestVc.credentialSubject.hasConsent.forPurpose,
+          request: consentRequestVc.id,
         },
         inbox: consentRequestVc.credentialSubject.inbox,
       }),
@@ -1285,6 +1256,7 @@ describe("approveAccessRequest", () => {
             consentRequestVc.credentialSubject.hasConsent.forPersonalData,
           isProvidedTo: consentRequestVc.credentialSubject.id,
           forPurpose: consentRequestVc.credentialSubject.hasConsent.forPurpose,
+          request: consentRequestVc.id,
         },
         inbox: consentRequestVc.credentialSubject.inbox,
       }),

--- a/src/gConsent/manage/approveAccessRequest.ts
+++ b/src/gConsent/manage/approveAccessRequest.ts
@@ -315,6 +315,7 @@ export async function approveAccessRequest(
       expirationDate: internalGrantOptions.expirationDate ?? undefined,
       status: gc.ConsentStatusExplicitlyGiven.value,
       inherit: internalGrantOptions.inherit,
+      request: internalGrantOptions.request,
     },
     { customFields: internalGrantOptions.customFields },
   );

--- a/src/gConsent/query/query.ts
+++ b/src/gConsent/query/query.ts
@@ -103,7 +103,7 @@ export type CredentialFilter = {
 };
 
 export type AccessGrantFilter = CredentialFilter & {
-  type: "SolidAccessGrant";
+  type?: "SolidAccessGrant";
   /**
    * The Access Grant status (e.g. Active, Revoked...).
    */
@@ -111,7 +111,7 @@ export type AccessGrantFilter = CredentialFilter & {
 };
 
 export type AccessRequestFilter = CredentialFilter & {
-  type: "SolidAccessRequest";
+  type?: "SolidAccessRequest";
   /**
    * The Access Request status (e.g. Pending, Granted...).
    */

--- a/src/gConsent/type/AccessVerifiableCredential.ts
+++ b/src/gConsent/type/AccessVerifiableCredential.ts
@@ -41,6 +41,7 @@ export type GConsentAttributes = {
 
 export type GConsentGrantAttributes = GConsentAttributes & {
   isProvidedTo: UrlString;
+  request?: UrlString;
 };
 
 export type GConsentRequestAttributes = GConsentAttributes & {

--- a/src/gConsent/type/Parameter.ts
+++ b/src/gConsent/type/Parameter.ts
@@ -46,6 +46,7 @@ export interface AccessRequestParameters extends InputAccessRequestParameters {
 
 export interface InputAccessGrantParameters extends BaseRequestParameters {
   requestor: UrlString;
+  request?: UrlString;
 }
 
 export interface AccessGrantParameters extends InputAccessGrantParameters {

--- a/src/gConsent/util/initializeGrantParameters.ts
+++ b/src/gConsent/util/initializeGrantParameters.ts
@@ -99,6 +99,7 @@ export function initializeGrantParameters(
                   ...toJson(requestOverride?.customFields),
                 }
               : getCustomFields(requestVc),
+          request: requestVc.id,
         };
   if (requestOverride?.expirationDate === null) {
     resultGrant.expirationDate = undefined;

--- a/src/gConsent/util/issueAccessVc.ts
+++ b/src/gConsent/util/issueAccessVc.ts
@@ -88,6 +88,7 @@ function getGConsentAttributes(
     return {
       ...consentAttributes,
       isProvidedTo: (params as AccessGrantParameters).requestor,
+      request: (params as AccessGrantParameters).request,
     };
   }
   return {
@@ -121,6 +122,10 @@ function getBaseBody(
   };
   if (params.issuanceDate !== undefined) {
     (body as BaseAccessVcBody).issuanceDate = params.issuanceDate.toISOString();
+  }
+  if (params.expirationDate !== undefined) {
+    (body as BaseAccessVcBody).expirationDate =
+      params.expirationDate.toISOString();
   }
   if (params.expirationDate !== undefined) {
     (body as BaseAccessVcBody).expirationDate =


### PR DESCRIPTION
When issuing an Access Grant from an Access Request, there is now a formal link from the former to the latter now, which results in an improved behavior of the query endpoint.