### PR TITLE
Custom fields for Access Denial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The following changes are pending, and will be applied on the next major release
 
 ## Unreleased
 
+### New feature
+
+- `denyAccessRequest` supports a new `customFields` option to add custom fields to the
+  resulting Access Denial. This option behaves the same as the `customFields` option
+  of `approveAccessRequest`.
+
 ### Patch changes
 
 - When issuing an Access Grant from an Access Request using `approveAccessRequest`,

--- a/src/gConsent/manage/denyAccessRequest.test.ts
+++ b/src/gConsent/manage/denyAccessRequest.test.ts
@@ -400,4 +400,91 @@ describe("denyAccessRequest", () => {
       );
     },
   );
+
+  it("passes custom fields to the VC issuer", async () => {
+    mockAccessApiEndpoint();
+    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
+      issueVerifiableCredential: () => Promise<AccessGrant>;
+    };
+    const spiedIssueRequest = jest
+      .spyOn(mockedVcModule, "issueVerifiableCredential")
+      .mockResolvedValueOnce(await mockAccessGrantVc());
+
+    const customFields = new Set([
+      {
+        key: new URL("https://example.org/testField1"),
+        value: "testValue1",
+      },
+      {
+        key: new URL("https://example.org/testField2"),
+        value: 42,
+      },
+    ]);
+
+    await denyAccessRequest(accessRequestVc, {
+      customFields,
+      fetch: jest.fn<typeof fetch>(),
+    });
+
+    expect(spiedIssueRequest).toHaveBeenCalledWith(
+      `${MOCKED_ACCESS_ISSUER}/issue`,
+      expect.objectContaining({
+        providedConsent: expect.objectContaining({
+          "https://example.org/testField1": "testValue1",
+          "https://example.org/testField2": 42,
+        }),
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("correctly merges multiple custom fields", async () => {
+    mockAccessApiEndpoint();
+    const mockedVcModule = jest.requireMock("@inrupt/solid-client-vc") as {
+      issueVerifiableCredential: () => Promise<AccessGrant>;
+    };
+    const spiedIssueRequest = jest
+      .spyOn(mockedVcModule, "issueVerifiableCredential")
+      .mockResolvedValueOnce(await mockAccessGrantVc());
+
+    const customFields = new Set([
+      {
+        key: new URL("https://example.org/field1"),
+        value: "value1",
+      },
+      {
+        key: new URL("https://example.org/field2"),
+        value: "value2",
+      },
+      {
+        key: new URL("https://example.org/field3"),
+        value: true,
+      },
+      {
+        key: new URL("https://example.org/field4"),
+        value: 123,
+      },
+    ]);
+
+    await denyAccessRequest(accessRequestVc, {
+      customFields,
+      fetch: jest.fn<typeof fetch>(),
+    });
+
+    // Verify all custom fields are included in the context and body
+    expect(spiedIssueRequest).toHaveBeenCalledWith(
+      `${MOCKED_ACCESS_ISSUER}/issue`,
+      expect.objectContaining({
+        providedConsent: expect.objectContaining({
+          "https://example.org/field1": "value1",
+          "https://example.org/field2": "value2",
+          "https://example.org/field3": true,
+          "https://example.org/field4": 123,
+        }),
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
 });

--- a/src/gConsent/manage/denyAccessRequest.ts
+++ b/src/gConsent/manage/denyAccessRequest.ts
@@ -34,6 +34,7 @@ import { normalizeAccessGrant } from "./approveAccessRequest";
 import { getBaseAccess } from "../util/getBaseAccessVerifiableCredential";
 import { toVcDataset } from "../../common/util/toVcDataset";
 import { AccessGrantError } from "../../common/errors/AccessGrantError";
+import { toJson, type CustomField } from "../../type/CustomField";
 
 /**
  * Deny an access request. The content of the denied access request is provided
@@ -49,6 +50,7 @@ export async function denyAccessRequest(
   vc: DatasetWithId | VerifiableCredential | URL | UrlString,
   options: AccessBaseOptions & {
     returnLegacyJsonld: false;
+    customFields?: Set<CustomField>;
   },
 ): Promise<DatasetWithId>;
 /**
@@ -78,19 +80,19 @@ export async function denyAccessRequest(
  * @param options Optional properties to customise the access denial behaviour.
  * @returns A Verifiable Credential representing the denied access.
  * @since 0.0.1
- * @deprecated Deprecated in favour of setting returnLegacyJsonld: false. This will be the default value in future
- * versions of this library.
  */
 export async function denyAccessRequest(
   vc: DatasetWithId | VerifiableCredential | URL | UrlString,
   options?: AccessBaseOptions & {
     returnLegacyJsonld?: boolean;
+    customFields?: Set<CustomField>;
   },
 ): Promise<DatasetWithId>;
 export async function denyAccessRequest(
   vc: DatasetWithId | VerifiableCredential | URL | UrlString,
   options?: AccessBaseOptions & {
     returnLegacyJsonld?: boolean;
+    customFields?: Set<CustomField>;
   },
 ): Promise<DatasetWithId> {
   const validVc = await toVcDataset(vc, options);
@@ -108,17 +110,22 @@ export async function denyAccessRequest(
   );
 
   const internalOptions = initializeGrantParameters(baseVc);
-  const denialBody = getGrantBody({
-    access: internalOptions.access,
-    requestor: internalOptions.requestor,
-    resources: internalOptions.resources,
-    requestorInboxUrl: internalOptions.requestorInboxUrl,
-    status: gc.ConsentStatusExplicitlyGiven.value,
-    purpose: internalOptions.purpose,
-    // denyAccessRequest doesn't take an override, so the expiration date
-    // cannot be null.
-    expirationDate: internalOptions.expirationDate as Date | undefined,
-  });
+  const denialBody = getGrantBody(
+    {
+      access: internalOptions.access,
+      requestor: internalOptions.requestor,
+      resources: internalOptions.resources,
+      requestorInboxUrl: internalOptions.requestorInboxUrl,
+      status: gc.ConsentStatusExplicitlyGiven.value,
+      purpose: internalOptions.purpose,
+      // denyAccessRequest doesn't take an override, so the expiration date
+      // cannot be null.
+      expirationDate: internalOptions.expirationDate as Date | undefined,
+    },
+    {
+      customFields: toJson(options?.customFields),
+    },
+  );
   denialBody.type = [CREDENTIAL_TYPE_ACCESS_DENIAL];
   denialBody.credentialSubject.providedConsent.hasStatus =
     gc.ConsentStatusDenied.value;

--- a/src/gConsent/manage/denyAccessRequest.ts
+++ b/src/gConsent/manage/denyAccessRequest.ts
@@ -35,6 +35,7 @@ import { getBaseAccess } from "../util/getBaseAccessVerifiableCredential";
 import { toVcDataset } from "../../common/util/toVcDataset";
 import { AccessGrantError } from "../../common/errors/AccessGrantError";
 import { toJson, type CustomField } from "../../type/CustomField";
+import { getCustomFields } from "../../common";
 
 /**
  * Deny an access request. The content of the denied access request is provided
@@ -123,7 +124,10 @@ export async function denyAccessRequest(
       expirationDate: internalOptions.expirationDate as Date | undefined,
     },
     {
-      customFields: toJson(options?.customFields),
+      customFields: {
+        ...getCustomFields(validVc),
+        ...toJson(options?.customFields),
+      },
     },
   );
   denialBody.type = [CREDENTIAL_TYPE_ACCESS_DENIAL];


### PR DESCRIPTION
# New feature description

It is now possible to pass custom fields as an option to
`denyAccessRequest`.

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).