### PR TITLE
Link Access Denial to Access Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The following changes are pending, and will be applied on the next major release
 
 ## Unreleased
 
+### Patch changes
+
+- `denyAccessRequest` now links the Access Denial to the incoming Access Request the same way `approveAccessRequest`
+  does, so that the request status is updated at the `/query` endpoint.
+
 ## [3.3.0](https://github.com/inrupt/solid-client-access-grants-js/releases/tag/v3.3.0) - 2025-04-23
 
 ### New feature

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -680,6 +680,8 @@ describe(`End-to-end access grant tests for environment [${environment}] `, () =
             ]),
           });
 
+          expect(getRequest(denial)).toBe(request.id);
+
           // Check custom fields on request.
           expect(
             getCustomBoolean(

--- a/src/gConsent/manage/denyAccessRequest.test.ts
+++ b/src/gConsent/manage/denyAccessRequest.test.ts
@@ -309,6 +309,7 @@ describe("denyAccessRequest", () => {
             isProvidedTo: "https://some.requestor",
             forPurpose:
               accessRequestWithPurpose.credentialSubject.hasConsent.forPurpose,
+            request: accessRequestWithPurpose.id,
           },
           inbox: accessRequestWithPurpose.credentialSubject.inbox,
         }),
@@ -349,6 +350,7 @@ describe("denyAccessRequest", () => {
             hasStatus: "https://w3id.org/GConsent#ConsentStatusDenied",
             forPersonalData:
               accessRequestVc.credentialSubject.hasConsent.forPersonalData,
+            request: "https://some.credential",
           }),
           inbox: accessRequestVc.credentialSubject.inbox,
         }),
@@ -390,6 +392,7 @@ describe("denyAccessRequest", () => {
             hasStatus: "https://w3id.org/GConsent#ConsentStatusDenied",
             forPersonalData:
               accessRequestVc.credentialSubject.hasConsent.forPersonalData,
+            request: "https://some.credential",
           }),
           inbox: accessRequestVc.credentialSubject.inbox,
         }),

--- a/src/gConsent/manage/denyAccessRequest.ts
+++ b/src/gConsent/manage/denyAccessRequest.ts
@@ -122,6 +122,7 @@ export async function denyAccessRequest(
       // denyAccessRequest doesn't take an override, so the expiration date
       // cannot be null.
       expirationDate: internalOptions.expirationDate as Date | undefined,
+      request: validVc.id,
     },
     {
       customFields: {

--- a/src/gConsent/util/access.mock.ts
+++ b/src/gConsent/util/access.mock.ts
@@ -47,6 +47,7 @@ type RequestVcOptions = Partial<{
   inherit: boolean;
   purpose: UrlString[];
   custom: CustomField[];
+  request: UrlString;
 }>;
 
 export const mockAccessRequestVcObject = (options?: RequestVcOptions) => {


### PR DESCRIPTION
When denying an Access Request, the issued Access Denial now references the denied Access Request, so that the request status is updated at the /query endpoint.