### PR TITLE
Remove no longer used linting dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,14 +27,11 @@
         "@inrupt/solid-client-authn-node": "^2.0.0",
         "@playwright/test": "~1.52.0",
         "@rdfjs/types": "^2.0.1",
-        "@rushstack/eslint-patch": "^1.6.1",
         "@types/auth-header": "^1.0.6",
         "@types/jest": "^29.5.11",
         "@types/n3": "^1.16.4",
         "eslint": "^9.28.0",
         "eslint-config-next": "^15.1.1",
-        "eslint-config-prettier": "^10.1.5",
-        "eslint-plugin-prettier": "^5.4.1",
         "event-emitter-promisify": "^1.1.0",
         "globals": "^16.2.0",
         "jest": "^29.7.0",
@@ -47,8 +44,7 @@
         "ts-node": "^10.9.2",
         "typedoc": "^0.28.1",
         "typedoc-plugin-markdown": "^3.17.1",
-        "typescript": "^5.3.3",
-        "typescript-eslint": "^8.34.0"
+        "typescript": "^5.3.3"
       },
       "engines": {
         "node": "^20.0.0 || ^22.0.0"

--- a/package.json
+++ b/package.json
@@ -111,14 +111,11 @@
     "@inrupt/solid-client-authn-node": "^2.0.0",
     "@playwright/test": "~1.52.0",
     "@rdfjs/types": "^2.0.1",
-    "@rushstack/eslint-patch": "^1.6.1",
     "@types/auth-header": "^1.0.6",
     "@types/jest": "^29.5.11",
     "@types/n3": "^1.16.4",
     "eslint": "^9.28.0",
     "eslint-config-next": "^15.1.1",
-    "eslint-config-prettier": "^10.1.5",
-    "eslint-plugin-prettier": "^5.4.1",
     "event-emitter-promisify": "^1.1.0",
     "globals": "^16.2.0",
     "jest": "^29.7.0",
@@ -131,8 +128,7 @@
     "ts-node": "^10.9.2",
     "typedoc": "^0.28.1",
     "typedoc-plugin-markdown": "^3.17.1",
-    "typescript": "^5.3.3",
-    "typescript-eslint": "^8.34.0"
+    "typescript": "^5.3.3"
   },
   "dependencies": {
     "@inrupt/solid-client": "^2.0.0",


### PR DESCRIPTION
This is an oversight from the shared linting dependency upgrade.