### PR TITLE
Add support for linked Access Request validation

### DIFF
--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -1884,6 +1884,7 @@ describe(`End-to-end access grant tests for environment [${environment}] `, () =
             accessEndpoint: vcProvider,
             updateAcr: false,
             returnLegacyJsonld: false,
+            verifyLinkedRequest: true,
           },
         );
         // Check the request status has been updated and is no longer "Pending"

--- a/src/gConsent/manage/approveAccessRequest.ts
+++ b/src/gConsent/manage/approveAccessRequest.ts
@@ -165,6 +165,7 @@ export async function approveAccessRequest(
   requestOverride: Partial<ApproveAccessRequestOverrides>,
   options: AccessBaseOptions & {
     returnLegacyJsonld: false;
+    verifyLinkedRequest?: boolean;
   },
 ): Promise<DatasetWithId>;
 
@@ -221,6 +222,7 @@ export async function approveAccessRequest(
   requestOverride?: Partial<ApproveAccessRequestOverrides>,
   options?: AccessBaseOptions & {
     returnLegacyJsonld?: boolean;
+    verifyLinkedRequest?: boolean;
   },
 ): Promise<DatasetWithId>;
 
@@ -240,6 +242,7 @@ export async function approveAccessRequest(
   requestOverride: ApproveAccessRequestOverrides,
   options: AccessBaseOptions & {
     returnLegacyJsonld: false;
+    verifyLinkedRequest?: boolean;
   },
 ): Promise<DatasetWithId>;
 /**
@@ -281,7 +284,8 @@ export async function approveAccessRequest(
 export async function approveAccessRequest(
   requestVc: DatasetWithId | VerifiableCredential | URL | UrlString | undefined,
   requestOverride?: Partial<ApproveAccessRequestOverrides>,
-  options: AccessBaseOptions & WithLegacyJsonFlag = {},
+  options: AccessBaseOptions &
+    WithLegacyJsonFlag & { verifyLinkedRequest?: boolean } = {},
 ): Promise<DatasetWithId> {
   const internalOptions = {
     ...options,
@@ -302,21 +306,28 @@ export async function approveAccessRequest(
     requestOverride,
   );
 
-  const grantBody = getGrantBody(
-    {
-      access: internalGrantOptions.access,
-      requestor: internalGrantOptions.requestor,
-      resources: internalGrantOptions.resources,
-      requestorInboxUrl: internalGrantOptions.requestorInboxUrl,
-      purpose: internalGrantOptions.purpose,
-      issuanceDate: internalGrantOptions.issuanceDate,
-      expirationDate: internalGrantOptions.expirationDate ?? undefined,
-      status: gc.ConsentStatusExplicitlyGiven.value,
-      inherit: internalGrantOptions.inherit,
-      request: internalGrantOptions.request,
-    },
-    { customFields: internalGrantOptions.customFields },
-  );
+  const grantBodyParams: AccessGrantParameters = {
+    access: internalGrantOptions.access,
+    requestor: internalGrantOptions.requestor,
+    resources: internalGrantOptions.resources,
+    requestorInboxUrl: internalGrantOptions.requestorInboxUrl,
+    purpose: internalGrantOptions.purpose,
+    issuanceDate: internalGrantOptions.issuanceDate,
+    expirationDate: internalGrantOptions.expirationDate ?? undefined,
+    status: gc.ConsentStatusExplicitlyGiven.value,
+    inherit: internalGrantOptions.inherit,
+  };
+
+  // Default to unverified request for backwards compatibility.
+  if (options.verifyLinkedRequest === true) {
+    grantBodyParams.verifiedRequest = internalGrantOptions.request;
+  } else {
+    grantBodyParams.request = internalGrantOptions.request;
+  }
+
+  const grantBody = getGrantBody(grantBodyParams, {
+    customFields: internalGrantOptions.customFields,
+  });
 
   const grantedAccess = getAccessModesFromAccessGrant(grantBody);
 

--- a/src/gConsent/type/AccessVerifiableCredential.ts
+++ b/src/gConsent/type/AccessVerifiableCredential.ts
@@ -41,6 +41,7 @@ export type GConsentAttributes = {
 export type GConsentGrantAttributes = GConsentAttributes & {
   isProvidedTo: UrlString;
   request?: UrlString;
+  verifiedRequest?: UrlString;
 };
 
 export type GConsentRequestAttributes = GConsentAttributes & {

--- a/src/gConsent/type/Parameter.ts
+++ b/src/gConsent/type/Parameter.ts
@@ -46,6 +46,7 @@ export interface AccessRequestParameters extends InputAccessRequestParameters {
 export interface InputAccessGrantParameters extends BaseRequestParameters {
   requestor: UrlString;
   request?: UrlString;
+  verifiedRequest?: UrlString;
 }
 
 export interface AccessGrantParameters extends InputAccessGrantParameters {

--- a/src/gConsent/util/issueAccessVc.ts
+++ b/src/gConsent/util/issueAccessVc.ts
@@ -87,7 +87,9 @@ function getGConsentAttributes(
     return {
       ...consentAttributes,
       isProvidedTo: (params as AccessGrantParameters).requestor,
+      // Only one of the following two should be defined.
       request: (params as AccessGrantParameters).request,
+      verifiedRequest: (params as AccessGrantParameters).verifiedRequest,
     };
   }
   return {


### PR DESCRIPTION
When approving an Access Request, one can provide an Access Request so
that the Grant is linked to the Request. By default, this link isn't
verified, and the server doesn't enforce any validation on the linked
Request. The server now supports additional validation, and this flag
allows to opt-in for Access Request validation.

Validation includes:
- Non-revocation of the Request
- Non-expiration of the Request
- The Request must not have been Granted already