### PR TITLE
Add check rollup job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  check:
+    if: always()
+    needs:
+      - lint
+      - unit-tests
+      - sonar-scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        with:
+          allowed-skips: sonar-scan
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Adds a `check` rollup job that gates on all other CI jobs, enabling org-level required status checks.